### PR TITLE
fix(api): let projectAdmin edit project fields (lifecycle stays admin-only)

### DIFF
--- a/api/internal/authorization/authorization.go
+++ b/api/internal/authorization/authorization.go
@@ -204,8 +204,16 @@ func CanViewProject(u *ent.User, projectID string) bool {
 	return isAdmin(u) || IsAssigned(u, projectID)
 }
 
-// CanManageProject: admin only (project create/update/delete).
+// CanManageProject: global admin only — project lifecycle (CREATE and DELETE).
 func CanManageProject(u *ent.User) bool { return isAdmin(u) }
+
+// CanEditProject: global admin, or a projectAdmin OF THIS PROJECT — field edits
+// to an existing project (§4.6). A projectAdmin administers within a project
+// (properties, tags) but does not control its lifecycle; create/delete stay
+// global-admin-only via CanManageProject.
+func CanEditProject(u *ent.User, projectID string) bool {
+	return isAdmin(u) || HasRoleInProject(u, projectID, RoleProjectAdmin)
+}
 
 // --- Images (§4.3) ---
 

--- a/api/internal/authorization/authorization_test.go
+++ b/api/internal/authorization/authorization_test.go
@@ -209,6 +209,16 @@ func TestManageAndViewHelpers(t *testing.T) {
 	assert.True(t, CanManageProject(usr(user.RoleAdmin)))
 	assert.False(t, CanManageProject(editor))
 
+	// CanEditProject: global admin or a projectAdmin OF THIS project may edit
+	// fields; create/delete (CanManageProject) stay global-admin-only.
+	pAdmin := usr(user.RoleUser, pa(proj, RoleProjectAdmin))
+	assert.True(t, CanEditProject(usr(user.RoleAdmin), proj), "global admin edits any project")
+	assert.True(t, CanEditProject(pAdmin, proj), "projectAdmin edits own project")
+	assert.False(t, CanEditProject(pAdmin, "other"), "projectAdmin cannot edit a different project")
+	assert.False(t, CanEditProject(editor, proj), "projectEditor cannot edit project fields")
+	assert.False(t, CanEditProject(viewer, proj), "projectViewer cannot edit project fields")
+	assert.False(t, CanManageProject(pAdmin), "projectAdmin still cannot create/delete projects")
+
 	assert.True(t, HasAnyProjectAdmin(usr(user.RoleUser, pa(proj, RoleProjectAdmin))))
 	assert.False(t, HasAnyProjectAdmin(editor))
 }

--- a/api/internal/server/projects_controller.go
+++ b/api/internal/server/projects_controller.go
@@ -125,12 +125,13 @@ type updateProjectPayload struct {
 }
 
 func (s *Server) updateProject(c *gin.Context) {
-	// authz (S8): admin only.
-	if !allow(c, authorization.CanManageProject(authUser(c))) {
-		return
-	}
 	id, ok := getIdParam(c)
 	if !ok {
+		return
+	}
+	// A projectAdmin of this project (or a global admin) may edit project fields;
+	// project create/delete remain global-admin-only.
+	if !allow(c, authorization.CanEditProject(authUser(c), id)) {
 		return
 	}
 	var payload updateProjectPayload

--- a/api/test/e2e/security_review_e2e_test.go
+++ b/api/test/e2e/security_review_e2e_test.go
@@ -240,3 +240,31 @@ func TestSecurityReviewImpersonationCookieBinding(t *testing.T) {
 	_, hasBlock := me["impersonating"]
 	assert.False(t, hasBlock, "no impersonation block under a foreign-bound cookie")
 }
+
+// projectAdmin administers WITHIN a project: it may edit project fields, but the
+// project lifecycle (create/delete) stays global-admin-only, and a projectEditor
+// may not edit project fields.
+func TestProjectAdminEditsButCannotCreateProject(t *testing.T) {
+	m := stack.Manifest
+
+	padmin := roleClient(t, "projectAdmin")
+	resp := doJSON(t, padmin, http.MethodPut, "/api/v1/projects/"+m.Project,
+		map[string]any{"description": "edited by projectAdmin"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "projectAdmin edits its own project's fields")
+	resp.Body.Close()
+
+	resp = doJSON(t, padmin, http.MethodPost, "/api/v1/projects",
+		map[string]any{"name": "padmin-created", "description": "d", "copyright": "c"})
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode, "projectAdmin cannot create projects")
+	resp.Body.Close()
+
+	resp = doJSON(t, padmin, http.MethodDelete, "/api/v1/projects/"+m.Project, nil)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode, "projectAdmin cannot delete projects")
+	resp.Body.Close()
+
+	editor := roleClient(t, "projectEditor")
+	resp = doJSON(t, editor, http.MethodPut, "/api/v1/projects/"+m.Project,
+		map[string]any{"description": "nope"})
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode, "projectEditor cannot edit project fields")
+	resp.Body.Close()
+}


### PR DESCRIPTION
Resolves the UI↔backend mismatch flagged during the v3 merge: a projectAdmin saw the project-general Edit button but `updateProject` was global-admin-only, so saves 403'd.

Per the intended model — projectAdmin administers within a project (properties, tags); global admin owns project lifecycle (create/delete):
- New `CanEditProject(u, projectID)` = global admin **or** projectAdmin of that project.
- `updateProject` now uses it; `createProject`/`deleteProject` stay `CanManageProject` (global-admin-only).
- Members management untouched (ProjectMembers is a read-only view; list already allows projectAdmin).

Unit + e2e tests added; `go build/vet`, authorization unit, and full `-tags e2e` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)