### PR TITLE
feat: source application secrets from vault (VAULT_ENV_KV_PATH env overlay)

### DIFF
--- a/api/cmd/server/main.go
+++ b/api/cmd/server/main.go
@@ -72,19 +72,21 @@ type vaultCredentials struct {
 }
 
 // resolveVaultCredentials honors DATABASE_CREDENTIALS_SOURCE and
-// S3_CREDENTIALS_SOURCE ("env" or "vault", independently) and only dials vault
-// when at least one resource asks for it. The vault client and its renewers
-// live for the process lifetime, hence context.Background().
+// S3_CREDENTIALS_SOURCE ("env" or "vault", independently) plus the
+// VAULT_ENV_KV_PATH app-secret overlay, and only dials vault when at least one
+// of them asks for it. The vault client and its renewers live for the process
+// lifetime, hence context.Background().
 func resolveVaultCredentials(ctx context.Context) *vaultCredentials {
 	databaseSource := config.Get().String("DATABASE_CREDENTIALS_SOURCE")
 	s3Source := config.Get().String("S3_CREDENTIALS_SOURCE")
+	envKVPath := config.Get().String("VAULT_ENV_KV_PATH")
 	for name, source := range map[string]string{"DATABASE_CREDENTIALS_SOURCE": databaseSource, "S3_CREDENTIALS_SOURCE": s3Source} {
 		if source != "env" && source != "vault" {
 			log.Panic().Str(name, source).Msg("invalid credentials source (supported: env, vault)")
 		}
 	}
 	credentials := &vaultCredentials{}
-	if databaseSource != "vault" && s3Source != "vault" {
+	if databaseSource != "vault" && s3Source != "vault" && envKVPath == "" {
 		return credentials
 	}
 
@@ -97,6 +99,19 @@ func resolveVaultCredentials(ctx context.Context) *vaultCredentials {
 	})
 	if err != nil {
 		log.Panic().Err(err).Msg("error connecting to vault")
+	}
+
+	if envKVPath != "" {
+		data, err := vaultClient.GetKV(ctx, envKVPath)
+		if err != nil {
+			log.Panic().Err(err).Msg("error fetching env secret from vault")
+		}
+		applied := vault.ApplyEnvOverlay(data)
+		// Re-resolve config so the overlaid variables are visible everywhere.
+		if err := util.InitConfig(); err != nil {
+			log.Panic().Err(err).Msg("error re-initializing config after vault env overlay")
+		}
+		log.Info().Int("applied", applied).Str("path", envKVPath).Msg("vault env overlay applied")
 	}
 
 	if databaseSource == "vault" {

--- a/api/internal/authentication/authentication.go
+++ b/api/internal/authentication/authentication.go
@@ -45,6 +45,12 @@ type handler struct {
 // Path gating: /api/v1/* is private except /health and /version; /auth/login and
 // /auth/register are public (register is then hard-blocked — self-signup is off).
 func Setup(options *Options) error {
+	// Guard here rather than NotEmpty in config: the secret may arrive via the
+	// vault env overlay after the first config load. Empty input would derive
+	// deterministic (publicly known) session keys.
+	if options.SessionSecretKey == "" {
+		return fmt.Errorf("SESSION_SECRET_KEY is empty — set it in the environment or the vault env secret (VAULT_ENV_KV_PATH)")
+	}
 	secretKey, encKey := deriveSessionKeys(options.SessionSecretKey)
 
 	storage := &repositoryStorage{repo: options.Repository}

--- a/api/internal/util/config.go
+++ b/api/internal/util/config.go
@@ -16,8 +16,10 @@ func InitConfig() error {
 		config.String("API_BASE_URL").Default("/api/v1"),
 		config.String("DOMAIN_NAME").Default("localhost"),
 
-		// basicauth / session
-		config.String("SESSION_SECRET_KEY").NotEmpty().Sensitive(),
+		// basicauth / session. May arrive via the vault env overlay
+		// (VAULT_ENV_KV_PATH) instead of the environment, so no NotEmpty here —
+		// authentication.Setup rejects an empty value after the overlay ran.
+		config.String("SESSION_SECRET_KEY").Sensitive().Default(""),
 		config.String("DEFAULT_ADMIN_USERNAME").NotEmpty().Default("admin"),
 		// No default: shipping a known admin credential is a security hole. When unset,
 		// ensureDefaultAdmin generates a random one-time bootstrap password and logs it.
@@ -95,6 +97,10 @@ func InitConfig() error {
 		config.String("VAULT_S3_KV_PATH").Default(""),
 		config.String("VAULT_S3_ACCESS_KEY_FIELD").Default("access_key"),
 		config.String("VAULT_S3_SECRET_KEY_FIELD").Default("secret_key"),
+		// KV path of the application env secret. Every string field is applied
+		// as a process env var at startup (explicit env wins), then config is
+		// re-initialized — app secrets like SESSION_SECRET_KEY live in vault.
+		config.String("VAULT_ENV_KV_PATH").Default(""),
 
 		// ai inference (S6). AI_PROVIDER selects the ImageInference impl:
 		// "stub" (deterministic echo, dev/test), "openai", "openrouter", "http".

--- a/api/internal/util/config_test.go
+++ b/api/internal/util/config_test.go
@@ -25,18 +25,15 @@ func TestConfigDefaults(t *testing.T) {
 	assert.False(t, config.Get().Bool("DEV"))
 }
 
-// S1 unit: a required key with no default fails when missing.
+// S1 unit: a NotEmpty key set to the empty string fails. (SESSION_SECRET_KEY
+// is no longer NotEmpty — it may arrive via the vault env overlay and is
+// enforced in authentication.Setup instead.)
 func TestConfigRequiredMissingFails(t *testing.T) {
-	orig, had := os.LookupEnv("SESSION_SECRET_KEY")
-	os.Unsetenv("SESSION_SECRET_KEY")
-	t.Cleanup(func() {
-		if had {
-			os.Setenv("SESSION_SECRET_KEY", orig)
-		}
-	})
+	t.Setenv("SESSION_SECRET_KEY", "test-secret")
+	t.Setenv("DEPLOYMENT_IMAGE_TAG", "")
 
-	// go-config panics (log.Panic) on a missing required key with no default.
-	assert.Panics(t, func() { _ = util.InitConfig() }, "SESSION_SECRET_KEY is required (NotEmpty, no default)")
+	// go-config panics (log.Panic) on a NotEmpty key explicitly set to "".
+	assert.Panics(t, func() { _ = util.InitConfig() }, "DEPLOYMENT_IMAGE_TAG is NotEmpty")
 }
 
 // S1 unit: a .Sensitive() value is masked in config.Print().

--- a/api/internal/vault/env.go
+++ b/api/internal/vault/env.go
@@ -1,0 +1,22 @@
+package vault
+
+import "os"
+
+// ApplyEnvOverlay sets every string field of a KV secret as a process env var,
+// skipping variables that are already set — explicit process env always wins
+// over vault. Non-string fields are ignored. Returns how many were applied.
+func ApplyEnvOverlay(data map[string]interface{}) int {
+	applied := 0
+	for key, value := range data {
+		s, ok := value.(string)
+		if !ok {
+			continue
+		}
+		if _, exists := os.LookupEnv(key); exists {
+			continue
+		}
+		os.Setenv(key, s)
+		applied++
+	}
+	return applied
+}

--- a/api/internal/vault/env_test.go
+++ b/api/internal/vault/env_test.go
@@ -1,0 +1,31 @@
+package vault
+
+import (
+	"os"
+	"testing"
+)
+
+func TestApplyEnvOverlay(t *testing.T) {
+	t.Setenv("OVERLAY_EXISTING", "from-env")
+	os.Unsetenv("OVERLAY_NEW")
+	t.Cleanup(func() { os.Unsetenv("OVERLAY_NEW") })
+
+	applied := ApplyEnvOverlay(map[string]interface{}{
+		"OVERLAY_EXISTING": "from-vault", // must not win over process env
+		"OVERLAY_NEW":      "from-vault",
+		"OVERLAY_NUMBER":   42, // non-string: ignored
+	})
+
+	if applied != 1 {
+		t.Errorf("applied = %d, want 1", applied)
+	}
+	if got := os.Getenv("OVERLAY_EXISTING"); got != "from-env" {
+		t.Errorf("OVERLAY_EXISTING = %q, want env value to win", got)
+	}
+	if got := os.Getenv("OVERLAY_NEW"); got != "from-vault" {
+		t.Errorf("OVERLAY_NEW = %q, want from-vault", got)
+	}
+	if _, exists := os.LookupEnv("OVERLAY_NUMBER"); exists {
+		t.Error("OVERLAY_NUMBER should not be set from a non-string field")
+	}
+}


### PR DESCRIPTION
## Summary

Moves the last non-vault secret out of k8s Secrets: `VAULT_ENV_KV_PATH` names a KV secret whose string fields are applied as process env vars at startup (explicit env always wins), followed by a config re-init. `SESSION_SECRET_KEY` loses `NotEmpty` (it may now arrive via the overlay); an empty value is instead rejected in `authentication.Setup`, where empty input would otherwise derive publicly-known session keys.

## Test plan

- [x] `go build && go vet && go test ./...` green
- [x] new `TestApplyEnvOverlay` (env precedence, non-string skip)
- [x] `TestConfigRequiredMissingFails` retargeted to a NotEmpty-empty case
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)