### PR TITLE
chore(ci): re-tag the tested image on release instead of rebuilding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,81 @@ on:
     branches:
       - main
 
+# Main/PR runs share a lane so a new commit cancels the in-flight run. Tag pushes
+# get their own lane — the retag/release path must never be cancelled by a
+# parallel main push.
+concurrency:
+  group: build-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+
+env:
+  DOCKER_IMAGE_URL: ghcr.io/shutterbase/shutterbase
+  WASM_BUILDER_IMAGE: ghcr.io/shutterbase/wasm-builder
+
+# Two paths:
+#
+#   main + PR : test-api + test-ui -> server (build & push ghcr :<sha8>)
+#   v* tag    : retag (stamp :vX.Y.Z onto the EXISTING :<sha8> manifest)
+#               -> release -> downloader-release
+#
+# A tag push deliberately skips the tests and the image build. The tagged commit
+# already lives on main, was already tested there, and already has a sha-tagged
+# image in the registry. Rebuilding it would not only waste ~6 minutes, it would
+# ship a DIFFERENT artifact than the one CI proved green (base images and
+# wasm-builder:latest drift between runs). Re-tagging publishes the exact digest
+# that passed.
 jobs:
+  retag:
+    name: Re-tag tested image as release (no rebuild)
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve the tagged commit's image tag
+        id: sha
+        # On a tag push github.sha is the tagged commit — the same commit the
+        # main-branch run built and pushed as :<first 8 chars>.
+        run: echo "short=$(echo ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
+
+      - name: Wait for the tested image to exist
+        # `/release` tags immediately after the squash-merge, so this run usually
+        # starts while the main-branch build is still going. Poll instead of
+        # failing; if the main build broke, or the tag points at a commit that
+        # never landed on main, this times out with a clear message.
+        run: |
+          src="$DOCKER_IMAGE_URL:${{ steps.sha.outputs.short }}"
+          for attempt in $(seq 1 80); do            # 80 x 15s = 20 min
+            if docker buildx imagetools inspect "$src" >/dev/null 2>&1; then
+              echo "Source image $src is available."
+              exit 0
+            fi
+            echo "Image $src not yet in the registry — attempt $attempt/80, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::$src never appeared. Did the main-branch build for this commit succeed?"
+          exit 1
+
+      - name: Stamp the release tag onto the existing manifest
+        # imagetools create copies tags by manifest reference: no layer pull, no
+        # rebuild. :vX.Y.Z resolves to the same digest as :<sha8>.
+        run: |
+          docker buildx imagetools create \
+            -t $DOCKER_IMAGE_URL:${{ github.ref_name }} \
+            $DOCKER_IMAGE_URL:${{ steps.sha.outputs.short }}
+
   release:
     name: Create release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: retag
     runs-on: ubuntu-latest
     steps:
       - name: Changelog
@@ -34,6 +105,7 @@ jobs:
 
   test-api:
     name: API tests
+    if: github.ref_type != 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +124,7 @@ jobs:
 
   test-ui:
     name: UI tests
+    if: github.ref_type != 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -73,6 +146,7 @@ jobs:
         run: cd ui && bun run build
 
   downloader-build:
+    if: github.ref_type != 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -83,9 +157,10 @@ jobs:
         run: cd api && go build -ldflags="-s -w" -o downloader cmd/downloader/main.go
 
   downloader-release:
+    # Binaries are release artifacts, not registry images — they are compiled
+    # here on the tag. Only downloader-build (the main/PR compile check) is skipped.
     needs:
       - release
-      - downloader-build
     strategy:
       fail-fast: false
       matrix:
@@ -118,14 +193,12 @@ jobs:
 
   server:
     name: Server Build
+    if: github.ref_type != 'tag'
     needs:
       - test-api
       - test-ui
     runs-on: ubuntu-latest
     permissions: write-all
-    env:
-      DOCKER_IMAGE_URL: ghcr.io/shutterbase/shutterbase
-      WASM_BUILDER_IMAGE: ghcr.io/shutterbase/wasm-builder
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -143,8 +216,3 @@ jobs:
           docker build --platform=linux/amd64 -t $DOCKER_IMAGE_URL:${GITHUB_SHA::8} .
           docker push $DOCKER_IMAGE_URL:${GITHUB_SHA::8}
 
-      - name: Push released image
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        run: |
-          docker tag $DOCKER_IMAGE_URL:${GITHUB_SHA::8} $DOCKER_IMAGE_URL:${{ github.ref_name }}
-          docker push $DOCKER_IMAGE_URL:${{ github.ref_name }}


### PR DESCRIPTION
## Problem

A `v*` tag push reran everything — `test-api`, `test-ui`, `downloader-build` and a **full `docker build`** — then tagged the freshly built image as the release.

The tagged commit already lives on `main`, was already tested there, and already has a `ghcr.io/shutterbase/shutterbase:<sha8>` image from that run. So the rebuild was:

- **~6 minutes of wasted CI** per release, and worse
- **a correctness gap** — the released image was a *different artifact* than the one CI proved green. The Dockerfile pulls `wasm-builder:latest` and the base images drift between runs, so nothing guaranteed the release image matched the tested one.

## Change

Adopts the shape the aso-nexus-hub pipeline already uses:

```
main + PR : test-api + test-ui -> server (build & push :<sha8>)
v* tag    : retag -> release -> downloader-release
```

- **New `retag` job** stamps `:vX.Y.Z` onto the existing `:<sha8>` manifest with `docker buildx imagetools create` — a metadata copy by manifest reference. No layer pull, no rebuild. The released image is the exact digest that passed CI.
- **Polls the registry for up to 20 min first.** `/release` pushes the tag immediately after the squash-merge, so the tag run normally starts while the main build is still going. A tag pointing at a commit that never landed on main (or whose build failed) now times out with a clear error instead of publishing nothing quietly.
- **Tag pushes get their own concurrency lane**, so a parallel main push cannot cancel a release.
- **`release` now `needs: retag`** — no GitHub release is created for an image that failed to publish.
- Tests, `downloader-build` and `server` are gated to `github.ref_type != 'tag'`.
- **`downloader-release` still compiles on the tag** — those binaries are release artifacts, not registry images, so there is nothing to re-tag. Only `downloader-build` (the main/PR compile check) is skipped.

## Verification

This PR run exercises the **main/PR path** (tests + `server` build/push). The `retag` path only runs on a tag, so it gets proven on the next release. If it ever fails, the blast radius is contained: the tag and the GitHub release exist, the `:vX.Y.Z` image does not, and re-running the job fixes it — no bad artifact is published.