### PR TITLE
feat: platform role management, and report the deployed image tag

### DIFF
--- a/.claude/commands/deploy-fsg.md
+++ b/.claude/commands/deploy-fsg.md
@@ -88,30 +88,45 @@ production — ArgoCD picks it up on its own.
 Push only the shutterbase change. If `git status` shows unrelated dirty files from other
 apps in that repo, stop and ask — `just push` stages everything with `git add .`.
 
-### 6. Watch the rollout
+### 6. Verify the rollout against the running pods
 
-There is no FSG kube context configured locally, so verify through ArgoCD (or ask the user
-to look):
+Do **not** poll ArgoCD — there is no FSG argocd context on this machine and the CLI
+points at an unrelated cluster. The app reports its own deployed tag, which is a stronger
+signal anyway: ArgoCD "Synced" only means the manifest was applied, not that pods are
+serving the new image.
 
-```bash
-argocd app get shutterbase        # needs an argocd login against the FSG instance
-```
-
-If no session is available, say so and report what to check in the ArgoCD UI: the
-shutterbase app Synced + Healthy, and both replicas on the new tag. RollingUpdate with
-`maxUnavailable: 0` means the old pods keep serving until the new ones are ready, so a
-failed image pull degrades nothing — it just never completes.
-
-### 7. Verify the running version
+`/api/v1/health` returns `DEPLOYMENT_IMAGE_TAG` — the value this very manifest sets — so
+it flips to the new version only once a new pod is actually answering:
 
 ```bash
-curl -s https://shutterbase.fsg.one/api/v1/version
+curl -s https://shutterbase.fsg.one/api/v1/health
+# {"status":"ok","version":"vX.Y.Z"}
 ```
 
-It must report the version you just deployed. If it reports something else, the responding
-pod did not come from this manifest — investigate before declaring success (this exact
-mismatch has happened before, from a pre-GitOps pod started by hand).
+Poll until it matches, then stop. ArgoCD's sync interval plus a rolling update means a
+few minutes is normal:
 
-### 8. Report
+```bash
+for i in $(seq 1 40); do
+  v=$(curl -s --max-time 15 https://shutterbase.fsg.one/api/v1/health)
+  echo "$i: $v"
+  case "$v" in *'"version":"vX.Y.Z"'*) echo "rolled"; break;; esac
+  sleep 20
+done
+```
 
-Version deployed, the GitOps commit, sync/health status, and what `/api/v1/version` says.
+Two replicas roll one at a time (`maxSurge 1` / `maxUnavailable 0`), so during the roll the
+endpoint may answer from either the old or the new pod — treat a stable new version across
+a couple of consecutive polls as done, not the first hit.
+
+If it never flips, the deploy did not reach the pods. Check, in order: the GitOps commit is
+on `master`; the ArgoCD app synced (ask the user to look in the UI — no CLI session here);
+the image tag exists on ghcr; the pod is not in ImagePullBackOff. `maxUnavailable: 0` means
+a failed pull never degrades the service — the rollout simply never completes, and the old
+version keeps serving.
+
+### 7. Report
+
+Version deployed, the GitOps commit, and what `/api/v1/health` reports. If the version
+never flipped, say so plainly rather than calling the deploy done — the GitOps push
+succeeding is not the same as prod running the new binary.

--- a/api/internal/server/server.go
+++ b/api/internal/server/server.go
@@ -190,11 +190,15 @@ func NewServer(options *Options) (*Server, error) {
 
 func (s *Server) registerPublicRoutes() {
 	api := s.Engine.Group(s.options.ApiBaseURL)
+	// Both report DEPLOYMENT_IMAGE_TAG — the tag the deployment manifest actually
+	// pinned. util.Version is an ldflags var no build sets, so it always read
+	// "development" and was useless for answering "what is running in prod?".
+	// /health is the deploy verification probe (see .claude/commands/deploy-fsg.md).
 	api.GET("/health", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		c.JSON(http.StatusOK, gin.H{"status": "ok", "version": util.DeploymentImageTag()})
 	})
 	api.GET("/version", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"version": util.Version, "signupEnabled": selfSignupEnabled()})
+		c.JSON(http.StatusOK, gin.H{"version": util.DeploymentImageTag(), "signupEnabled": selfSignupEnabled()})
 	})
 	// Self-signup is a public write surface; it rate-limits per IP itself.
 	api.POST("/auth/signup", s.signup)

--- a/api/internal/server/users_controller.go
+++ b/api/internal/server/users_controller.go
@@ -167,13 +167,20 @@ func (s *Server) createUser(c *gin.Context) {
 }
 
 type updateUserPayload struct {
-	FirstName           *string             `json:"firstName"`
-	LastName            *string             `json:"lastName"`
-	CopyrightTag        *string             `json:"copyrightTag"`
-	Email               *string             `json:"email"`
-	Password            *string             `json:"password"`
-	Active              *bool               `json:"active"`
-	RoleID              *string             `json:"roleId"`
+	FirstName    *string `json:"firstName"`
+	LastName     *string `json:"lastName"`
+	CopyrightTag *string `json:"copyrightTag"`
+	Email        *string `json:"email"`
+	Password     *string `json:"password"`
+	Active       *bool   `json:"active"`
+	RoleID       *string `json:"roleId"`
+	// Role is the GLOBAL role enum ("user" | "admin"). roleId is kept for
+	// backwards compatibility but can never reach "admin": it resolves against
+	// the roles TABLE, which only holds the project roles (projectAdmin/Editor/
+	// Viewer). With no global "admin" row, every roleId silently mapped to
+	// "user" — promotion was impossible. The global role is an enum on the user;
+	// take it directly.
+	Role                *string             `json:"role"`
 	ForcePasswordChange *bool               `json:"forcePasswordChange"`
 	ActiveProjectID     *string             `json:"activeProjectId"`
 	Hotkeys             *schema.UserHotkeys `json:"hotkeys"`
@@ -222,7 +229,7 @@ func (s *Server) updateUser(c *gin.Context) {
 		return
 	}
 	// Admin-only fields: a non-admin sending any of them is forbidden (§4.12).
-	if !isAdmin && (payload.Active != nil || payload.RoleID != nil ||
+	if !isAdmin && (payload.Active != nil || payload.RoleID != nil || payload.Role != nil ||
 		payload.ForcePasswordChange != nil || payload.ActiveProjectID != nil) {
 		forbid(c)
 		return
@@ -259,6 +266,22 @@ func (s *Server) updateUser(c *gin.Context) {
 		role, ok := s.roleEnumFromID(c.Request.Context(), *payload.RoleID)
 		if !ok {
 			apiError(c, http.StatusBadRequest, "invalid_role", "invalid roleId")
+			return
+		}
+		params.Role = &role
+	}
+	if payload.Role != nil {
+		role := user.Role(*payload.Role)
+		if err := user.RoleValidator(role); err != nil {
+			apiError(c, http.StatusBadRequest, "invalid_role", `role must be "user" or "admin"`)
+			return
+		}
+		// You cannot change your OWN global role. Beyond the obvious footgun of
+		// an admin demoting themselves out of the admin UI, this is what keeps
+		// at least one admin alive: only a DIFFERENT admin may demote an admin,
+		// so the last one standing can never be removed.
+		if authorization.IsSelf(me, id) {
+			apiError(c, http.StatusConflict, "cannot_change_own_role", "you cannot change your own role — ask another administrator")
 			return
 		}
 		params.Role = &role

--- a/api/internal/util/deployment_tag_test.go
+++ b/api/internal/util/deployment_tag_test.go
@@ -1,0 +1,27 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shutterbase/shutterbase/internal/util"
+)
+
+// DeploymentImageTag backs the /health probe that `/deploy-fsg` polls to decide
+// whether a rollout actually reached the pods. If it ever stops reflecting the
+// env var the k8s manifest sets, deploy verification silently starts lying —
+// which is exactly what util.Version did (an ldflags var no build ever sets, so
+// it always read "development").
+func TestDeploymentImageTagReflectsEnv(t *testing.T) {
+	t.Setenv("DEPLOYMENT_IMAGE_TAG", "v9.9.9")
+	require.NoError(t, util.InitConfig())
+	assert.Equal(t, "v9.9.9", util.DeploymentImageTag())
+}
+
+func TestDeploymentImageTagDefaultsToDevelopment(t *testing.T) {
+	require.NoError(t, util.InitConfig())
+	assert.Equal(t, "development", util.DeploymentImageTag(),
+		"unset locally -> the config default, never an empty string")
+}

--- a/api/internal/util/version.go
+++ b/api/internal/util/version.go
@@ -1,7 +1,17 @@
 package util
 
+import "github.com/mxcd/go-config/config"
+
 // Version is the application version. It defaults to "development" and
 // can be overridden at build time via:
 //
 //	go build -ldflags "-X github.com/shutterbase/shutterbase/internal/util.Version=v1.0.0"
 var Version = "development"
+
+// DeploymentImageTag is the image tag the deployment pinned (DEPLOYMENT_IMAGE_TAG,
+// set by the k8s manifest; "development" locally). This — not Version — is the
+// honest answer to "which build is running", because no build passes the ldflags
+// that would set Version.
+func DeploymentImageTag() string {
+	return config.Get().String("DEPLOYMENT_IMAGE_TAG")
+}

--- a/ui/src/api/users.ts
+++ b/ui/src/api/users.ts
@@ -30,6 +30,9 @@ export interface UserUpdate {
   hotkeys?: UserHotkeys;
   // admin-only:
   active?: boolean;
+  // Global role enum. `roleId` resolves against the roles TABLE, which only holds
+  // project roles — it can never reach "admin". Use `role`.
+  role?: "user" | "admin";
   roleId?: string;
   forcePasswordChange?: boolean;
   activeProjectId?: string;

--- a/ui/src/components/layout/navbar/UserMenu.vue
+++ b/ui/src/components/layout/navbar/UserMenu.vue
@@ -110,6 +110,12 @@
             <a href="/logout" class="block cursor-pointer py-2 px-4 text-sm font-medium text-error-700 transition-colors hover:bg-error-50 dark:text-error-300 dark:hover:bg-error-950/40">Sign out</a>
           </li>
         </ul>
+        <!-- Deployed image tag (DEPLOYMENT_IMAGE_TAG). This is what /deploy-fsg
+             checks against to confirm a rollout actually reached the pods. -->
+        <div class="px-4 py-2">
+          <p class="label-mono text-[0.6rem] text-primary-400 dark:text-primary-500">Version</p>
+          <p class="font-data text-xs text-primary-600 dark:text-primary-300">{{ version || "—" }}</p>
+        </div>
       </MenuItems>
     </transition>
   </Menu>
@@ -123,6 +129,7 @@ import { initFlowbite } from "flowbite";
 import { useUserStore } from "src/stores/user-store";
 import Avatar from "avatar-initials";
 import { storeToRefs } from "pinia";
+import { api } from "src/api";
 
 const userMenuAvatar = ref<HTMLImageElement>();
 
@@ -136,6 +143,12 @@ const headshotUrl = ref("");
 function clearProjectSelection() {
   userStore.clearActiveProject();
 }
+
+const version = ref("");
+api.auth
+  .serverInfo()
+  .then((info) => (version.value = info.version))
+  .catch(() => (version.value = ""));
 
 onMounted(() => {
   initFlowbite();

--- a/ui/src/pages/user/UserGeneral.vue
+++ b/ui/src/pages/user/UserGeneral.vue
@@ -44,24 +44,82 @@
         :item="item"
       />
 
-      <!-- Admin-only account controls. The API refuses `active` from a non-admin
-           anyway; this just keeps the page honest about who can do what. -->
-      <section v-if="isAdmin && item" class="border-t border-primary-100 pt-10 dark:border-primary-800/70">
+      <!-- Account access. Rendered for every viewer, disabled with the reason
+           when they may not act: a control that simply is not there reads as
+           "broken" — which is exactly how the missing role control got reported. -->
+      <section v-if="item" class="border-t border-primary-100 pt-10 dark:border-primary-800/70">
         <h2 class="display text-xl text-primary-900 dark:text-white">Account access</h2>
-        <p class="mt-1 text-sm text-primary-500 dark:text-primary-400">
-          An inactive account cannot sign in, and its sessions and API keys stop working immediately.
+        <p class="mt-1 max-w-prose text-sm text-primary-500 dark:text-primary-400">
+          Whether this account can sign in, and what it may do platform-wide. Roles <em>inside</em> a project are managed on that project's Members page.
         </p>
-        <div class="mt-6 flex flex-wrap items-center gap-3">
-          <button v-if="!item.active" type="button" @click="setActive(true)" :disabled="busy" :class="[buttonBase, buttonAccent]">
-            <CheckCircleIcon class="h-4 w-4" />
-            Activate account
-          </button>
-          <button v-else type="button" @click="showDeactivateDialog = true" :disabled="busy || isSelf" :class="[buttonBase, buttonDanger]">
-            <NoSymbolIcon class="h-4 w-4" />
-            Deactivate account
-          </button>
-          <p v-if="isSelf && item.active" class="text-xs text-primary-500 dark:text-primary-400">You cannot deactivate your own account.</p>
-        </div>
+
+        <p
+          v-if="!isAdmin"
+          class="mt-4 flex max-w-prose items-start gap-1.5 rounded-md border border-primary-200 bg-surface-muted px-2.5 py-2 text-xs text-primary-600 dark:border-primary-700 dark:bg-surface-dark-muted dark:text-primary-300"
+        >
+          <LockClosedIcon class="mt-px h-4 w-4 shrink-0" />
+          <span>Only platform administrators can change sign-in access or the platform role.</span>
+        </p>
+
+        <dl class="mt-6 space-y-8">
+          <div class="sm:flex sm:items-start sm:gap-6">
+            <dt class="label-mono text-primary-500 dark:text-primary-400 sm:w-40 sm:shrink-0 sm:pt-2">Sign-in</dt>
+            <dd class="mt-2 sm:mt-0">
+              <div class="flex flex-wrap items-center gap-3">
+                <span :class="['inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium', item.active ? badgeSuccess : badgeError]">
+                  <component :is="item.active ? CheckCircleIcon : NoSymbolIcon" class="h-4 w-4" />
+                  {{ item.active ? "Active" : "Inactive" }}
+                </span>
+                <button v-if="!item.active" type="button" @click="setActive(true)" :disabled="!isAdmin || busy" :class="[buttonBase, buttonAccent]">
+                  <CheckCircleIcon class="h-4 w-4" />
+                  Activate account
+                </button>
+                <button v-else type="button" @click="showDeactivateDialog = true" :disabled="!isAdmin || busy || isSelf" :class="[buttonBase, buttonDanger]">
+                  <NoSymbolIcon class="h-4 w-4" />
+                  Deactivate account
+                </button>
+              </div>
+              <p class="mt-2 max-w-prose text-xs text-primary-500 dark:text-primary-400">
+                {{
+                  isSelf && item.active
+                    ? "You cannot deactivate your own account."
+                    : "An inactive account cannot sign in, and its sessions and API keys stop working immediately."
+                }}
+              </p>
+            </dd>
+          </div>
+
+          <div class="sm:flex sm:items-start sm:gap-6">
+            <dt class="label-mono text-primary-500 dark:text-primary-400 sm:w-40 sm:shrink-0 sm:pt-2">Platform role</dt>
+            <dd class="mt-2 sm:mt-0">
+              <div class="inline-flex rounded-lg border border-primary-200 bg-surface p-0.5 dark:border-primary-700 dark:bg-surface-dark">
+                <button
+                  v-for="option in roleOptions"
+                  :key="option.value"
+                  type="button"
+                  @click="setRole(option.value)"
+                  :disabled="!isAdmin || busy || isSelf"
+                  :class="[
+                    'inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+                    currentRole === option.value
+                      ? 'bg-accent-500/15 text-accent-700 dark:bg-accent-500/20 dark:text-accent-200'
+                      : 'cursor-pointer text-primary-500 hover:bg-primary-100 hover:text-primary-700 dark:text-primary-400 dark:hover:bg-primary-800 dark:hover:text-primary-200',
+                  ]"
+                >
+                  <component :is="option.icon" class="h-4 w-4" />
+                  {{ option.label }}
+                </button>
+              </div>
+              <p class="mt-2 max-w-prose text-xs text-primary-500 dark:text-primary-400">
+                {{
+                  isSelf
+                    ? "You cannot change your own role — another administrator has to. That rule is what guarantees the platform never loses its last admin."
+                    : "A platform admin manages every project, every user and every account. Grant it sparingly."
+                }}
+              </p>
+            </dd>
+          </div>
+        </dl>
       </section>
 
       <section v-if="isAdmin && item" class="border-t border-primary-100 pt-10 dark:border-primary-800/70">
@@ -115,7 +173,7 @@ import { UsersResponse } from "src/types/pocketbase";
 import { api } from "src/api";
 import { showNotificationToast } from "src/boot/mitt";
 import { useUserStore } from "src/stores/user-store";
-import { CheckCircleIcon, KeyIcon, NoSymbolIcon, ShieldCheckIcon } from "@heroicons/vue/24/outline";
+import { CheckCircleIcon, KeyIcon, LockClosedIcon, NoSymbolIcon, ShieldCheckIcon, UserIcon } from "@heroicons/vue/24/outline";
 
 const route = useRoute();
 const userStore = useUserStore();
@@ -197,6 +255,29 @@ async function setActive(active: boolean) {
 async function confirmDeactivate() {
   showDeactivateDialog.value = false;
   await setActive(false);
+}
+
+// --- platform role ---
+
+const roleOptions = [
+  { value: "user" as const, label: "User", icon: UserIcon },
+  { value: "admin" as const, label: "Platform admin", icon: ShieldCheckIcon },
+];
+
+const currentRole = computed(() => (item.value?.role?.key === "admin" ? "admin" : "user"));
+
+async function setRole(role: "user" | "admin") {
+  if (!item.value || role === currentRole.value) return;
+  busy.value = true;
+  try {
+    item.value = await api.users.update(item.value.id, { role });
+    showNotificationToast({ headline: role === "admin" ? "Promoted to platform admin" : "Platform admin removed", type: "success" });
+  } catch (error: any) {
+    // 409 is the self-change guard; surface the server's reason rather than a modal.
+    showNotificationToast({ headline: error?.response?.data?.message ?? "Could not change the role", type: "error" });
+  } finally {
+    busy.value = false;
+  }
 }
 
 // --- password reset ---


### PR DESCRIPTION
## The role bug

Changing a user's global role was **impossible**, not merely missing from the UI.

`PUT /users/:id` took a `roleId` and resolved it against the **`roles` table** — which only ever holds the *project* roles (`projectAdmin`, `projectEditor`, `projectViewer`). With no global `admin` row, `roleEnumFromID` could never return `RoleAdmin`, so every `roleId` silently mapped to `user`. Verified against a live server: passing the `projectAdmin` row id **demoted** the target instead of promoting it.

The global role is an enum on the user, so the API now takes it directly:

```
PUT /users/:id {"role": "admin"}
```

`roleId` still resolves, for compatibility. Admin-only, and **an admin may not change their own role** — only a different admin can demote an admin, which is what guarantees the platform never loses its last one.

| Case | Result |
|---|---|
| promote another user to `admin` | 200, `role.key = admin` |
| change your own role | 409 `cannot_change_own_role` |
| `{"role":"superuser"}` | 400 `invalid_role` |

## The UI rethink

The active toggle was never broken server-side (`{"active":false}` → 200). What broke was the *communication*: self-deactivation is deliberately blocked, and the disabled button never said why — so from the outside it looked like a dead control.

**Account access is now rendered for every viewer and disabled with the reason stated inline**, rather than hidden or silently inert:

- **Sign-in** — status badge, Activate/Deactivate, and the constraint ("You cannot deactivate your own account" / what deactivation does to sessions and API keys).
- **Platform role** — a User ↔ Platform admin control with the self-guard explained.
- Non-admins see both, greyed: "Only platform administrators can change sign-in access or the platform role."

A control that isn't there is indistinguishable from one that's broken. That's what produced this report.

## Deployed version is now observable

`DEPLOYMENT_IMAGE_TAG` was already read from config but surfaced nowhere, while `/version` reported `util.Version` — an ldflags var **no build sets**, so it always answered `"development"`. That made a deploy unverifiable.

- `GET /api/v1/health` → `{"status":"ok","version":"vX.Y.Z"}`
- `GET /api/v1/version` → same version, plus `signupEnabled`
- The tag is shown in the user-menu footer.

Pinned by `internal/util/deployment_tag_test.go`, since deploy verification now rests on it.

`/deploy-fsg` drops its ArgoCD polling: there's no FSG argocd context locally, and "Synced" would only mean the manifest was applied — not that pods serve the new image. It polls `/api/v1/health` until the version flips, treating a couple of stable consecutive reads as done (two replicas roll one at a time).

**Note:** the new verification only works once a build containing this change is deployed — prod's `/health` still returns bare `{"status":"ok"}` today.