### PR TITLE
fix(api): let project admins create $-prefixed template tags

### DIFF
--- a/api/internal/authorization/authorization.go
+++ b/api/internal/authorization/authorization.go
@@ -252,7 +252,11 @@ func CanDeleteImage(u *ent.User, img *ent.Image) bool {
 // any member. template (and unknown) -> never (not creatable via API).
 func CanCreateImageTag(u *ent.User, projectID, tagType string) bool {
 	switch tagType {
-	case "default", "manual":
+	// template tags ($DATE, $COPYRIGHT, …) drive automatic tagging for the whole
+	// project — the same blast radius as a default tag, so the same gate. They
+	// used to be uncreatable entirely, which left the UI offering a type the API
+	// refused and no way to add one outside the seed/import.
+	case "template", "default", "manual":
 		return isAdmin(u) || HasRoleInProject(u, projectID, RoleProjectAdmin)
 	case "custom":
 		return isAdmin(u) || IsAssigned(u, projectID)

--- a/api/internal/authorization/authorization_test.go
+++ b/api/internal/authorization/authorization_test.go
@@ -189,8 +189,14 @@ func TestCanCreateImageTag(t *testing.T) {
 	assert.True(t, CanCreateImageTag(editor, proj, "custom"), "custom editor allowed")
 	assert.False(t, CanCreateImageTag(none, proj, "custom"), "custom non-member denied")
 
-	// template + unknown -> never.
-	assert.False(t, CanCreateImageTag(admin, proj, "template"))
+	// template -> admin/projectAdmin only: it drives automatic tagging for the
+	// whole project, so it sits with default/manual, not with custom.
+	assert.True(t, CanCreateImageTag(admin, proj, "template"), "template admin allowed")
+	assert.True(t, CanCreateImageTag(pAdmin, proj, "template"), "template projectAdmin allowed")
+	assert.False(t, CanCreateImageTag(editor, proj, "template"), "template editor denied")
+	assert.False(t, CanCreateImageTag(none, proj, "template"), "template non-member denied")
+
+	// unknown -> never.
 	assert.False(t, CanCreateImageTag(admin, proj, "bogus"))
 }
 

--- a/api/internal/server/image_tags_controller.go
+++ b/api/internal/server/image_tags_controller.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -88,6 +89,15 @@ func (s *Server) getImageTag(c *gin.Context) {
 	c.JSON(http.StatusOK, s.imageTagResponse(c.Request.Context(), t))
 }
 
+// validTemplateName guards the one thing that makes a template tag work: the
+// "$" prefix. service.renderTemplate only substitutes names starting with it
+// ($PROJECT/$DATE/$WEEKDAY/$COPYRIGHT, anything else "$X" -> literal "X"), and
+// logs-and-ignores the rest — so a template tag without it is silently dead.
+// Non-template types may be named anything.
+func validTemplateName(t imagetag.Type, name string) bool {
+	return t != imagetag.TypeTemplate || strings.HasPrefix(name, "$")
+}
+
 type createImageTagPayload struct {
 	Name        string `json:"name" binding:"required"`
 	Description string `json:"description"`
@@ -108,8 +118,8 @@ func (s *Server) createImageTag(c *gin.Context) {
 		apiError(c, http.StatusBadRequest, "invalid_type", "invalid tag type")
 		return
 	}
-	if t == imagetag.TypeTemplate {
-		apiError(c, http.StatusBadRequest, "invalid_type", "template tags are not creatable via the API")
+	if !validTemplateName(t, payload.Name) {
+		apiError(c, http.StatusBadRequest, "invalid_template_name", `a template tag's name must start with "$" (e.g. $COPYRIGHT)`)
 		return
 	}
 	if !allow(c, authorization.CanCreateImageTag(authUser(c), payload.ProjectID, string(t))) {
@@ -158,12 +168,23 @@ func (s *Server) updateImageTag(c *gin.Context) {
 	resultingType := string(existing.Type)
 	if payload.Type != nil {
 		t := imagetag.Type(*payload.Type)
-		if err := imagetag.TypeValidator(t); err != nil || t == imagetag.TypeTemplate {
+		if err := imagetag.TypeValidator(t); err != nil {
 			apiError(c, http.StatusBadRequest, "invalid_type", "invalid tag type")
 			return
 		}
 		params.Type = &t
 		resultingType = string(t)
+	}
+	// The resulting name matters, not just the new one: renaming a template tag
+	// out of its "$" prefix would leave it rendering nothing, same as creating
+	// one without it.
+	resultingName := existing.Name
+	if payload.Name != nil {
+		resultingName = *payload.Name
+	}
+	if !validTemplateName(imagetag.Type(resultingType), resultingName) {
+		apiError(c, http.StatusBadRequest, "invalid_template_name", `a template tag's name must start with "$" (e.g. $COPYRIGHT)`)
+		return
 	}
 	// authz by the resulting type, scoped to the tag's project (§4.4).
 	if !allow(c, authorization.CanEditImageTag(authUser(c), existing.ProjectID, resultingType)) {

--- a/api/test/e2e/crud_e2e_test.go
+++ b/api/test/e2e/crud_e2e_test.go
@@ -155,11 +155,28 @@ func TestCRUDRoundTrips(t *testing.T) {
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 		assert.Equal(t, "custom", decodeBody(t, resp)["type"])
 
+		// Template tags are creatable (a project admin adds $COPYRIGHT/$WEEKDAY
+		// themselves) — the "$" prefix is what makes them render, so it is
+		// required and everything else is rejected.
+		resp = doJSON(t, client, http.MethodPost, "/api/v1/image-tags", map[string]any{
+			"name": "$COPYRIGHT", "description": "copyright template", "type": "template", "projectId": projectID,
+		})
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		created := decodeBody(t, resp)
+		assert.Equal(t, "template", created["type"])
+		assert.Equal(t, "$COPYRIGHT", created["name"])
+
 		resp = doJSON(t, client, http.MethodPost, "/api/v1/image-tags", map[string]any{
 			"name": "T", "description": "x", "type": "template", "projectId": projectID,
 		})
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-		assert.Equal(t, "invalid_type", decodeBody(t, resp)["code"])
+		assert.Equal(t, "invalid_template_name", decodeBody(t, resp)["code"])
+
+		// Renaming a template out of its prefix is the same defect, so it is
+		// refused on update too.
+		resp = doJSON(t, client, http.MethodPut, "/api/v1/image-tags/"+created["id"].(string), map[string]any{"name": "COPYRIGHT"})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, "invalid_template_name", decodeBody(t, resp)["code"])
 
 		resp = doJSON(t, client, http.MethodGet, "/api/v1/image-tags?projectId="+projectID, nil)
 		require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/ui/tests/e2e/project-tags.spec.ts
+++ b/ui/tests/e2e/project-tags.spec.ts
@@ -5,6 +5,9 @@ import { loginAs, collectJsErrors } from "./helpers";
 // the table, then delete it (deletion is immediate, no confirm). Self-cleaning.
 test.describe.serial("project tags CRUD", () => {
   const TAG = "E2E Smoke Tag";
+  // "$" prefixed: that is what makes a template tag render at image-create time.
+  // Deleted at the end of its test so it cannot default-tag images in later specs.
+  const TEMPLATE_TAG = "$E2ETEMPLATE";
 
   test("create a tag via the dialog, then delete it (admin)", async ({ page }) => {
     const errors = collectJsErrors(page);
@@ -37,6 +40,36 @@ test.describe.serial("project tags CRUD", () => {
     // fire-and-forget regression where optimistic removal hides a failed delete).
     await page.reload();
     await expect(page.getByRole("row").filter({ hasText: TAG }), "deleted tag must stay gone after reload").toHaveCount(0);
+
+    expect(errors, errors.join("\n")).toHaveLength(0);
+  });
+
+  // Regression: the dialog offered type=template while the API refused it
+  // outright ("template tags are not creatable via the API"), so a project admin
+  // could never add $COPYRIGHT/$WEEKDAY — the "$" prefix IS how a template tag is
+  // declared, and the seed/import was the only way one could exist.
+  test("create a $-prefixed template tag via the dialog, then delete it (admin)", async ({ page }) => {
+    const errors = collectJsErrors(page);
+    const project = await loginAs(page, "admin");
+    expect(project, "seed project should be active").not.toBeNull();
+
+    await page.goto(`/projects/${project!.id}/tags`);
+    await page.getByRole("button", { name: /Add Project Tag/i }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("Name", { exact: true }).fill(TEMPLATE_TAG);
+    await dialog.getByLabel("Description", { exact: true }).fill("template created by e2e");
+    await dialog.getByLabel("Type", { exact: true }).selectOption("template");
+    await dialog.getByRole("button", { name: "Save tag" }).click();
+    await expect(dialog, "the API must accept a template tag, not 400 the dialog open").toBeHidden();
+
+    await page.reload();
+    const row = page.getByRole("row").filter({ hasText: TEMPLATE_TAG });
+    await expect(row, "template tag must persist after reload").toBeVisible();
+    await expect(row, "and keep its type").toContainText("template");
+
+    await row.getByRole("button", { name: "Delete" }).click();
+    await page.reload();
+    await expect(page.getByRole("row").filter({ hasText: TEMPLATE_TAG })).toHaveCount(0);
 
     expect(errors, errors.join("\n")).toHaveLength(0);
   });


### PR DESCRIPTION
The tag dialog offered type=template while the API refused it outright
("template tags are not creatable via the API"), and CanCreateImageTag
returned false for it as well. So $COPYRIGHT, $WEEKDAY and friends could
only ever come from the seed or the PocketBase import — a project admin had
no way to add one, even though "$" is how a template tag is declared. The
"$" was never the problem; the type was.

template now sits with default/manual in CanCreateImageTag (admin or
projectAdmin): it drives automatic tagging for the whole project, the same
blast radius as a default tag. CanEditImageTag delegates there, so the edit
path opens up with it.

The inverse guard comes with it: a template tag's name must start with "$".
service.renderTemplate only substitutes $-prefixed names and logs-and-ignores
the rest, so a template named COPYRIGHT would be a silently dead tag. That is
now a 400 on create and on rename — renaming a template out of its prefix is
the same defect.

Covered on both ends: the API e2e asserted the old refusal and now asserts
creation, the prefix requirement and the rename guard; the Playwright tag spec
drives the dialog itself, since the dialog offering a type the API rejected is
exactly what made this reachable.
