### PR TITLE
fix(docker): ship pkg/aiserver into the Go builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ FROM golang:1.26.4-alpine AS builder
 WORKDIR /usr/src
 COPY api/go.mod /usr/src/go.mod
 COPY api/go.sum /usr/src/go.sum
+# The AI-server contract is a nested module resolved via `replace ../pkg/aiserver`
+# (relative to go.mod at /usr/src => /usr/pkg/aiserver).
+COPY pkg /usr/pkg
 RUN go mod download
 
 COPY api/cmd /usr/src/cmd


### PR DESCRIPTION
The api module resolves the AI-server contract via `replace ../pkg/aiserver`; the Go builder stage only copied `api/`, so `go mod download` failed (Server Build red on the #65 merge). One COPY line; the exact failing step verified locally against the fixed layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)