### PR TITLE
fix(api): multi-replica-safe AI queue claim

### DIFF
--- a/api/internal/repository/repository.go
+++ b/api/internal/repository/repository.go
@@ -48,6 +48,10 @@ func (r *Repository) isPostgres() bool {
 	return r.Options.DatabaseConnection.Options.DatabaseType == "psql"
 }
 
+// IsPostgres reports whether the backing database is Postgres — callers gate
+// Postgres-only SQL (row locking) on it; SQLite (tests) takes the plain path.
+func (r *Repository) IsPostgres() bool { return r.isPostgres() }
+
 // ErrInvalidSort is returned when a requested sort key is not on a resource's
 // allowlist. Controllers map it to 400 {"code":"invalid_sort"}.
 var ErrInvalidSort = errors.New("invalid_sort")

--- a/api/internal/service/ai_service.go
+++ b/api/internal/service/ai_service.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	entsql "entgo.io/ent/dialect/sql"
 	"github.com/mxcd/go-config/config"
 	"github.com/rs/zerolog/log"
 
@@ -109,8 +110,12 @@ func (s *AIService) Enqueue(imageID string) {
 // processing (crash mid-inference) back to pending. It returns immediately;
 // the goroutine runs until ctx is cancelled.
 func (s *AIService) Start(ctx context.Context) {
+	// Only rows untouched for a while count as orphaned: during a rolling
+	// deploy the OTHER replica's in-flight images are also "processing", and
+	// re-queuing those would double-process them (claiming bumps updatedAt).
 	if n, err := s.repo.Client.Image.Update().
-		Where(entimage.AiStatusEQ(entimage.AiStatusProcessing)).
+		Where(entimage.AiStatusEQ(entimage.AiStatusProcessing),
+			entimage.UpdatedAtLT(time.Now().Add(-10*time.Minute))).
 		SetAiStatus(entimage.AiStatusPending).
 		Save(ctx); err != nil {
 		log.Error().Err(err).Msg("AI: boot recovery failed")
@@ -177,7 +182,10 @@ func (s *AIService) step(ctx context.Context) bool {
 }
 
 // claimNext moves the oldest pending image to processing and returns it; nil
-// when the queue is empty or the global backoff is armed.
+// when the queue is empty or the global backoff is armed. On Postgres the row
+// is claimed under FOR UPDATE SKIP LOCKED so concurrent replicas (FSG prod
+// runs 2) never double-claim an image; SQLite (single-process tests) takes the
+// plain read-then-update path.
 func (s *AIService) claimNext(ctx context.Context) *ent.Image {
 	s.lock.Lock()
 	backoff := s.backoffUntil
@@ -186,11 +194,20 @@ func (s *AIService) claimNext(ctx context.Context) *ent.Image {
 		return nil
 	}
 
-	img, err := s.repo.Client.Image.Query().
-		Where(entimage.AiStatusEQ(entimage.AiStatusPending)).
-		Order(ent.Asc(entimage.FieldAiQueuedAt)).
-		First(ctx)
+	tx, err := s.repo.Client.Tx(ctx)
 	if err != nil {
+		log.Error().Err(err).Msg("AI: claim tx failed")
+		return nil
+	}
+	q := tx.Image.Query().
+		Where(entimage.AiStatusEQ(entimage.AiStatusPending)).
+		Order(ent.Asc(entimage.FieldAiQueuedAt))
+	if s.repo.IsPostgres() {
+		q = q.ForUpdate(entsql.WithLockAction(entsql.SkipLocked))
+	}
+	img, err := q.First(ctx)
+	if err != nil {
+		_ = tx.Rollback()
 		if !ent.IsNotFound(err) {
 			log.Error().Err(err).Msg("AI: claim query failed")
 		}
@@ -198,7 +215,12 @@ func (s *AIService) claimNext(ctx context.Context) *ent.Image {
 	}
 	img, err = img.Update().SetAiStatus(entimage.AiStatusProcessing).Save(ctx)
 	if err != nil {
-		log.Error().Err(err).Str("image", img.ID).Msg("AI: claim update failed")
+		_ = tx.Rollback()
+		log.Error().Err(err).Msg("AI: claim update failed")
+		return nil
+	}
+	if err := tx.Commit(); err != nil {
+		log.Error().Err(err).Msg("AI: claim commit failed")
 		return nil
 	}
 	s.publish(ctx, img)

--- a/api/internal/service/ai_service_test.go
+++ b/api/internal/service/ai_service_test.go
@@ -248,17 +248,24 @@ func TestBackoffAndDeadLetter(t *testing.T) {
 	assert.Equal(t, 0, svc.repo.Client.Image.GetX(ctx, img).AiAttempts)
 }
 
-// Boot recovery: rows orphaned in processing are re-queued by Start.
+// Boot recovery: STALE processing rows are re-queued by Start; fresh ones are
+// left alone (they belong to another replica mid-flight during a rolling deploy).
 func TestBootRecovery(t *testing.T) {
 	svc, m := newSvc(t, &StubInference{Tags: []string{"none"}})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	img := m.Images[0]
+	stale, fresh := m.Images[0], m.Images[1]
 
-	svc.repo.Client.Image.UpdateOneID(img).
+	svc.repo.Client.Image.UpdateOneID(stale).
+		SetAiStatus(entimage.AiStatusProcessing).SetAiQueuedAt(time.Now()).SaveX(ctx)
+	// age the row past the orphan threshold (updatedAt is bumped by the save above)
+	svc.repo.Client.Image.UpdateOneID(stale).
+		SetUpdatedAt(time.Now().Add(-15 * time.Minute)).SaveX(ctx)
+	svc.repo.Client.Image.UpdateOneID(fresh).
 		SetAiStatus(entimage.AiStatusProcessing).SetAiQueuedAt(time.Now()).SaveX(ctx)
 
 	svc.Start(ctx)
 	cancel() // dispatcher exits; recovery already ran synchronously
-	assert.Equal(t, "pending", aiStatus(t, svc, img))
+	assert.Equal(t, "pending", aiStatus(t, svc, stale), "stale processing row must be re-queued")
+	assert.Equal(t, "processing", aiStatus(t, svc, fresh), "fresh processing row must be left to its replica")
 }


### PR DESCRIPTION
FSG prod runs 2 replicas; two dispatchers could double-claim the same pending image (benign but wasteful — duplicate fsai ingests). The claim now runs under `FOR UPDATE SKIP LOCKED` on Postgres (SQLite tests keep the plain path), and boot recovery only re-queues processing rows untouched for 10+ minutes, so a rolling deploy doesn't re-queue the other replica's in-flight images.

Unit + repository suites green on SQLite; `just test-e2e` green against testcontainers Postgres (exercises the locked claim path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)