### PR TITLE
feat: cross-project person search toggle in the person dialog

### DIFF
--- a/api/internal/server/ai_controller.go
+++ b/api/internal/server/ai_controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -275,6 +276,12 @@ func (s *Server) aiImageFaces(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"faces": resp.Faces})
 }
 
+// aiPersonImages pages through a person's appearances. With crossProject=true
+// it widens to every project the user may view: the AI server's person ids are
+// global, so the same personRef is valid in each project. Page N is then the
+// concatenation of page N of every project (per-project paging, no merged
+// offset math); total sums the per-project totals and hasMore flags any
+// project with a further page.
 func (s *Server) aiPersonImages(c *gin.Context) {
 	projectID, ok := getIdParam(c)
 	if !ok {
@@ -284,34 +291,77 @@ func (s *Server) aiPersonImages(c *gin.Context) {
 	if !ok {
 		return
 	}
-	if !allow(c, authorization.CanViewProject(authUser(c), projectID)) {
+	u := authUser(c)
+	if !allow(c, authorization.CanViewProject(u, projectID)) {
 		return
 	}
 	page, pageSize := aiPageParams(c)
-	resp, err := remote.PersonImages(c.Request.Context(), projectID, c.Param("personRef"), page, pageSize)
-	if abortAIError(c, err) {
-		return
+	ctx := c.Request.Context()
+
+	projectIDs := []string{projectID}
+	if c.Query("crossProject") == "true" {
+		projectIDs = append(projectIDs, s.otherViewableProjectIDs(ctx, u, projectID)...)
 	}
 
-	refs := make([]string, 0, len(resp.Items))
-	for _, item := range resp.Items {
-		refs = append(refs, item.ImageRef)
-	}
-	images := s.resolveImageRefs(c.Request.Context(), projectID, refs)
-	items := make([]gin.H, 0, len(resp.Items))
-	for _, item := range resp.Items {
-		img, ok := images[item.ImageRef]
-		if !ok {
-			continue // deleted in shutterbase but still known to the AI server
+	items := make([]gin.H, 0)
+	total := 0
+	hasMore := false
+	for i, pid := range projectIDs {
+		resp, err := remote.PersonImages(ctx, pid, c.Param("personRef"), page, pageSize)
+		if i == 0 && abortAIError(c, err) {
+			return // the requested project keeps its single-project error semantics
 		}
-		items = append(items, gin.H{
-			"image": ToImageResponse(c.Request.Context(), img, s.s3Client, s.thumbnailSizes),
-			"x":     item.X, "y": item.Y, "w": item.W, "h": item.H,
-		})
+		if err != nil {
+			continue // other projects are best-effort: person unknown there, or upstream hiccup
+		}
+		total += resp.Total
+		if (page+1)*pageSize < resp.Total {
+			hasMore = true
+		}
+		refs := make([]string, 0, len(resp.Items))
+		for _, item := range resp.Items {
+			refs = append(refs, item.ImageRef)
+		}
+		images := s.resolveImageRefs(ctx, pid, refs)
+		for _, item := range resp.Items {
+			img, ok := images[item.ImageRef]
+			if !ok {
+				continue // deleted in shutterbase but still known to the AI server
+			}
+			items = append(items, gin.H{
+				"image": ToImageResponse(ctx, img, s.s3Client, s.thumbnailSizes),
+				"x":     item.X, "y": item.Y, "w": item.W, "h": item.H,
+			})
+		}
 	}
 	c.JSON(http.StatusOK, gin.H{
-		"items": items, "total": resp.Total, "page": resp.Page, "pageSize": resp.PageSize,
+		"items": items, "total": total, "page": page, "pageSize": pageSize, "hasMore": hasMore,
 	})
+}
+
+// otherViewableProjectIDs lists the projects (minus exclude) the user may view:
+// all of them for admins, assigned ones otherwise. Sorted so cross-project
+// paging walks the projects in a stable order.
+func (s *Server) otherViewableProjectIDs(ctx context.Context, u *ent.User, exclude string) []string {
+	var ids []string
+	if authorization.IsAdminUser(u) {
+		var err error
+		ids, err = s.Repository.Client.Project.Query().IDs(ctx)
+		if err != nil {
+			log.Error().Err(err).Msg("AI: listing projects for cross-project person search failed")
+			return nil
+		}
+	} else {
+		ids = authorization.AssignedProjectIDs(u)
+	}
+	sort.Strings(ids)
+	out := ids[:0]
+	for _, id := range ids {
+		if id != exclude {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 func (s *Server) aiImageSimilar(c *gin.Context) {

--- a/api/internal/server/ai_controller_test.go
+++ b/api/internal/server/ai_controller_test.go
@@ -197,6 +197,10 @@ func TestAIRerunBatchScopesToProject(t *testing.T) {
 type fakeRemote struct {
 	faces    aiserver.FacesResponse
 	facesErr error
+	// personQueried records the project ids PersonImages was called with;
+	// personTotals (optional) serves a per-project Total, unknown ids -> 404.
+	personQueried []string
+	personTotals  map[string]int
 }
 
 func (f *fakeRemote) Prime(context.Context, string, aiserver.Project) error { return nil }
@@ -206,9 +210,17 @@ func (f *fakeRemote) Ingest(context.Context, string, aiserver.IngestRequest) (ai
 func (f *fakeRemote) Faces(context.Context, string, string) (aiserver.FacesResponse, error) {
 	return f.faces, f.facesErr
 }
-func (f *fakeRemote) PersonImages(_ context.Context, _ string, _ string, page, pageSize int) (aiserver.PersonImagesResponse, error) {
+func (f *fakeRemote) PersonImages(_ context.Context, projectID string, _ string, page, pageSize int) (aiserver.PersonImagesResponse, error) {
+	f.personQueried = append(f.personQueried, projectID)
+	total := 1
+	if f.personTotals != nil {
+		var ok bool
+		if total, ok = f.personTotals[projectID]; !ok {
+			return aiserver.PersonImagesResponse{}, aiserver.ErrNotFound
+		}
+	}
 	return aiserver.PersonImagesResponse{
-		Items: []aiserver.PersonImage{{ImageRef: "ghost"}}, Total: 1, Page: page, PageSize: pageSize,
+		Items: []aiserver.PersonImage{{ImageRef: "ghost"}}, Total: total, Page: page, PageSize: pageSize,
 	}, nil
 }
 func (f *fakeRemote) Similar(context.Context, string, string, int, int) (aiserver.SimilarResponse, error) {
@@ -271,4 +283,53 @@ func TestAIPersonImagesDropsUnknownRefs(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Empty(t, body.Items, "unresolvable refs must be dropped")
 	assert.Equal(t, 1, body.Total)
+}
+
+// crossProject=true fans out over the user's viewable projects (all of them
+// for admins, assigned ones otherwise) and sums the totals; without the flag
+// only the requested project is queried.
+func TestAIPersonImagesCrossProject(t *testing.T) {
+	s, m := newAITestServer(t)
+	ctx := context.Background()
+	other := s.Repository.Client.Project.Create().
+		SetName("Other Event").
+		SetDescription("second project").
+		SetCopyright("Test Team").
+		SetCopyrightReference("https://example.test").
+		SetLocationName("Elsewhere").
+		SetLocationCode("ELS").
+		SetLocationCity("Elsewhere").
+		SaveX(ctx)
+	fake := &fakeRemote{personTotals: map[string]int{m.Project: 3, other.ID: 2}}
+	s.aiRemote = fake
+
+	get := func(u *ent.User, query string) (int, map[string]any) {
+		t.Helper()
+		c, rec := aiCtx(t, u, http.MethodGet, "/api/v1/projects/"+m.Project+"/ai/persons/p1/images"+query, "")
+		c.Params = gin.Params{{Key: "id", Value: m.Project}, {Key: "personRef", Value: "p1"}}
+		s.aiPersonImages(c)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		return rec.Code, body
+	}
+
+	code, body := get(adminUser(), "?crossProject=true")
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{m.Project, other.ID}, fake.personQueried, "requested project first, then the others")
+	assert.EqualValues(t, 5, body["total"], "totals sum across projects")
+	assert.Equal(t, false, body["hasMore"])
+
+	fake.personQueried = nil
+	code, _ = get(adminUser(), "")
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{m.Project}, fake.personQueried, "no flag -> single project")
+
+	// non-admin: only assigned projects join the fan-out.
+	viewer, err := s.Repository.GetEffectiveUser(ctx, m.Users["projectViewer"])
+	require.NoError(t, err)
+	fake.personQueried = nil
+	code, body = get(viewer, "?crossProject=true")
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{m.Project}, fake.personQueried, "unassigned project must not be queried")
+	assert.EqualValues(t, 3, body["total"])
 }

--- a/ui/src/api/ai.ts
+++ b/ui/src/api/ai.ts
@@ -42,9 +42,10 @@ export interface AiPersonImage {
 
 export interface AiPersonImagesPage {
   items: AiPersonImage[];
-  total: number;
+  total: number; // crossProject: summed over all queried projects
   page: number;
   pageSize: number;
+  hasMore: boolean;
 }
 
 export interface AiSimilarImage {
@@ -93,8 +94,10 @@ export async function faces(imageId: string): Promise<AiFace[]> {
   return data.faces;
 }
 
-export async function personImages(projectId: string, personRef: string, page: number, pageSize = 20): Promise<AiPersonImagesPage> {
-  const { data } = await http.get<AiPersonImagesPage>(`/projects/${projectId}/ai/persons/${encodeURIComponent(personRef)}/images`, { params: { page, pageSize } });
+export async function personImages(projectId: string, personRef: string, page: number, pageSize = 20, crossProject = false): Promise<AiPersonImagesPage> {
+  const { data } = await http.get<AiPersonImagesPage>(`/projects/${projectId}/ai/persons/${encodeURIComponent(personRef)}/images`, {
+    params: { page, pageSize, ...(crossProject ? { crossProject: "true" } : {}) },
+  });
   return data;
 }
 

--- a/ui/src/components/image/AiImageListDialog.vue
+++ b/ui/src/components/image/AiImageListDialog.vue
@@ -11,7 +11,13 @@
             <h3 class="display text-lg text-primary-900 dark:text-white">{{ title }}</h3>
             <p class="label-mono-sm mt-0.5 text-primary-500 dark:text-primary-400">{{ subtitle }}</p>
           </div>
-          <XMarkIcon class="h-5 w-5 cursor-pointer text-primary-400 hover:text-primary-600 dark:hover:text-primary-200" @click="emit('close')" />
+          <div class="flex items-center gap-4">
+            <label v-if="mode === 'person'" class="flex cursor-pointer items-center gap-1.5 text-sm text-primary-600 dark:text-primary-300">
+              <input v-model="crossProject" type="checkbox" class="accent-accent-600" />
+              all my projects
+            </label>
+            <XMarkIcon class="h-5 w-5 cursor-pointer text-primary-400 hover:text-primary-600 dark:hover:text-primary-200" @click="emit('close')" />
+          </div>
         </div>
 
         <div class="max-h-[65vh] overflow-y-auto p-5">
@@ -22,6 +28,11 @@
                 v-if="mode === 'similar' && entry.similarity !== undefined"
                 class="label-mono-sm pointer-events-none absolute bottom-1 right-1 rounded bg-primary-950/70 px-1 text-accent-300"
                 >{{ Math.round(entry.similarity * 100) }}%</span
+              >
+              <span
+                v-if="entry.image.project.id !== projectId"
+                class="label-mono-sm pointer-events-none absolute bottom-1 right-1 max-w-full truncate rounded bg-primary-950/70 px-1 text-accent-300"
+                >{{ entry.image.project.name }}</span
               >
             </div>
           </div>
@@ -87,20 +98,23 @@ const total = ref(0);
 const hasMore = ref(false);
 const loading = ref(false);
 const notAnalyzed = ref(false);
+// person mode: also query the user's other projects (person ids are global)
+const crossProject = ref(false);
 
 const title = computed(() => (props.mode === "person" ? "Photos of this person" : "Similar images"));
 const subtitle = computed(() => {
-  if (props.mode === "person" && total.value > 0) return `${total.value} photo${total.value === 1 ? "" : "s"} in this project`;
+  if (props.mode === "person" && total.value > 0) return `${total.value} photo${total.value === 1 ? "" : "s"} ${crossProject.value ? "across your projects" : "in this project"}`;
   return "";
 });
-const hasNext = computed(() => (props.mode === "person" ? (page.value + 1) * PAGE_SIZE < total.value : hasMore.value));
+const hasNext = computed(() => (props.mode === "person" && !crossProject.value ? (page.value + 1) * PAGE_SIZE < total.value : hasMore.value));
 const pageLabel = computed(() => {
-  if (props.mode === "person" && total.value > 0) return `page ${page.value + 1} / ${Math.max(1, Math.ceil(total.value / PAGE_SIZE))}`;
+  // cross-project pages are per-project slices, so total/PAGE_SIZE math doesn't apply
+  if (props.mode === "person" && !crossProject.value && total.value > 0) return `page ${page.value + 1} / ${Math.max(1, Math.ceil(total.value / PAGE_SIZE))}`;
   return `page ${page.value + 1}`;
 });
 
 watch(
-  () => [props.shown, props.mode, props.personRef, props.imageId],
+  () => [props.shown, props.mode, props.personRef, props.imageId, crossProject.value],
   () => {
     if (!props.shown) return;
     page.value = 0;
@@ -116,9 +130,10 @@ async function load() {
   items.value = [];
   try {
     if (props.mode === "person" && props.personRef) {
-      const result = await api.ai.personImages(props.projectId, props.personRef, page.value, PAGE_SIZE);
+      const result = await api.ai.personImages(props.projectId, props.personRef, page.value, PAGE_SIZE, crossProject.value);
       items.value = result.items.map((i) => ({ image: i.image }));
       total.value = result.total;
+      hasMore.value = result.hasMore;
     } else if (props.mode === "similar" && props.imageId) {
       const result = await api.ai.similar(props.imageId, page.value, PAGE_SIZE);
       items.value = result.items.map((i) => ({ image: i.image, similarity: i.similarity }));


### PR DESCRIPTION
The AI server's person ids are global, so the same personRef is valid in
every project. With ?crossProject=true the person-images endpoint fans
out over the user's viewable projects (admins: all, others: assigned),
concatenates each project's page N, sums the totals, and flags hasMore.
The requested project keeps its single-project error semantics; the
others are best-effort. The person dialog gets an 'all my projects'
toggle and labels foreign-project tiles with the project name.
