### PR TITLE
feat: schedule shifts, implicit person grid filter, AI timeout retry

### DIFF
--- a/api/ent/client.go
+++ b/api/ent/client.go
@@ -2045,6 +2045,38 @@ func (c *ScheduleItemClient) QueryTags(_m *ScheduleItem) *ImageTagQuery {
 	return query
 }
 
+// QueryParent queries the parent edge of a ScheduleItem.
+func (c *ScheduleItemClient) QueryParent(_m *ScheduleItem) *ScheduleItemQuery {
+	query := (&ScheduleItemClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(scheduleitem.Table, scheduleitem.FieldID, id),
+			sqlgraph.To(scheduleitem.Table, scheduleitem.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, scheduleitem.ParentTable, scheduleitem.ParentColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryShifts queries the shifts edge of a ScheduleItem.
+func (c *ScheduleItemClient) QueryShifts(_m *ScheduleItem) *ScheduleItemQuery {
+	query := (&ScheduleItemClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(scheduleitem.Table, scheduleitem.FieldID, id),
+			sqlgraph.To(scheduleitem.Table, scheduleitem.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, scheduleitem.ShiftsTable, scheduleitem.ShiftsColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // Hooks returns the client hooks.
 func (c *ScheduleItemClient) Hooks() []Hook {
 	return c.hooks.ScheduleItem

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -423,7 +423,9 @@ var (
 		{Name: "start", Type: field.TypeTime},
 		{Name: "end", Type: field.TypeTime},
 		{Name: "cardinality", Type: field.TypeInt, Default: 1},
+		{Name: "kind", Type: field.TypeEnum, Enums: []string{"item", "break"}, Default: "item"},
 		{Name: "project_id", Type: field.TypeString, Size: 15},
+		{Name: "parent_id", Type: field.TypeString, Nullable: true, Size: 15},
 	}
 	// ScheduleItemsTable holds the schema information for the "schedule_items" table.
 	ScheduleItemsTable = &schema.Table{
@@ -433,8 +435,14 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "schedule_items_projects_scheduleItems",
-				Columns:    []*schema.Column{ScheduleItemsColumns[10]},
+				Columns:    []*schema.Column{ScheduleItemsColumns[11]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "schedule_items_schedule_items_shifts",
+				Columns:    []*schema.Column{ScheduleItemsColumns[12]},
+				RefColumns: []*schema.Column{ScheduleItemsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 		},
@@ -442,12 +450,17 @@ var (
 			{
 				Name:    "scheduleitem_project_id",
 				Unique:  false,
-				Columns: []*schema.Column{ScheduleItemsColumns[10]},
+				Columns: []*schema.Column{ScheduleItemsColumns[11]},
 			},
 			{
 				Name:    "scheduleitem_project_id_start",
 				Unique:  false,
-				Columns: []*schema.Column{ScheduleItemsColumns[10], ScheduleItemsColumns[7]},
+				Columns: []*schema.Column{ScheduleItemsColumns[11], ScheduleItemsColumns[7]},
+			},
+			{
+				Name:    "scheduleitem_parent_id",
+				Unique:  false,
+				Columns: []*schema.Column{ScheduleItemsColumns[12]},
 			},
 		},
 	}
@@ -659,6 +672,7 @@ func init() {
 	ProjectAssignmentsTable.ForeignKeys[1].RefTable = RolesTable
 	ProjectAssignmentsTable.ForeignKeys[2].RefTable = UsersTable
 	ScheduleItemsTable.ForeignKeys[0].RefTable = ProjectsTable
+	ScheduleItemsTable.ForeignKeys[1].RefTable = ScheduleItemsTable
 	TimeOffsetsTable.ForeignKeys[0].RefTable = CamerasTable
 	UploadsTable.ForeignKeys[0].RefTable = CamerasTable
 	UploadsTable.ForeignKeys[1].RefTable = ProjectsTable

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -10118,6 +10118,7 @@ type ScheduleItemMutation struct {
 	end              *time.Time
 	cardinality      *int
 	addcardinality   *int
+	kind             *scheduleitem.Kind
 	clearedFields    map[string]struct{}
 	project          *string
 	clearedproject   bool
@@ -10127,6 +10128,11 @@ type ScheduleItemMutation struct {
 	tags             map[string]struct{}
 	removedtags      map[string]struct{}
 	clearedtags      bool
+	parent           *string
+	clearedparent    bool
+	shifts           map[string]struct{}
+	removedshifts    map[string]struct{}
+	clearedshifts    bool
 	done             bool
 	oldValue         func(context.Context) (*ScheduleItem, error)
 	predicates       []predicate.ScheduleItem
@@ -10655,6 +10661,91 @@ func (m *ScheduleItemMutation) ResetProjectID() {
 	m.project = nil
 }
 
+// SetParentID sets the "parent_id" field.
+func (m *ScheduleItemMutation) SetParentID(s string) {
+	m.parent = &s
+}
+
+// ParentID returns the value of the "parent_id" field in the mutation.
+func (m *ScheduleItemMutation) ParentID() (r string, exists bool) {
+	v := m.parent
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldParentID returns the old "parent_id" field's value of the ScheduleItem entity.
+// If the ScheduleItem object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ScheduleItemMutation) OldParentID(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldParentID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldParentID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldParentID: %w", err)
+	}
+	return oldValue.ParentID, nil
+}
+
+// ClearParentID clears the value of the "parent_id" field.
+func (m *ScheduleItemMutation) ClearParentID() {
+	m.parent = nil
+	m.clearedFields[scheduleitem.FieldParentID] = struct{}{}
+}
+
+// ParentIDCleared returns if the "parent_id" field was cleared in this mutation.
+func (m *ScheduleItemMutation) ParentIDCleared() bool {
+	_, ok := m.clearedFields[scheduleitem.FieldParentID]
+	return ok
+}
+
+// ResetParentID resets all changes to the "parent_id" field.
+func (m *ScheduleItemMutation) ResetParentID() {
+	m.parent = nil
+	delete(m.clearedFields, scheduleitem.FieldParentID)
+}
+
+// SetKind sets the "kind" field.
+func (m *ScheduleItemMutation) SetKind(s scheduleitem.Kind) {
+	m.kind = &s
+}
+
+// Kind returns the value of the "kind" field in the mutation.
+func (m *ScheduleItemMutation) Kind() (r scheduleitem.Kind, exists bool) {
+	v := m.kind
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldKind returns the old "kind" field's value of the ScheduleItem entity.
+// If the ScheduleItem object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ScheduleItemMutation) OldKind(ctx context.Context) (v scheduleitem.Kind, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldKind is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldKind requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldKind: %w", err)
+	}
+	return oldValue.Kind, nil
+}
+
+// ResetKind resets all changes to the "kind" field.
+func (m *ScheduleItemMutation) ResetKind() {
+	m.kind = nil
+}
+
 // ClearProject clears the "project" edge to the Project entity.
 func (m *ScheduleItemMutation) ClearProject() {
 	m.clearedproject = true
@@ -10790,6 +10881,87 @@ func (m *ScheduleItemMutation) ResetTags() {
 	m.removedtags = nil
 }
 
+// ClearParent clears the "parent" edge to the ScheduleItem entity.
+func (m *ScheduleItemMutation) ClearParent() {
+	m.clearedparent = true
+	m.clearedFields[scheduleitem.FieldParentID] = struct{}{}
+}
+
+// ParentCleared reports if the "parent" edge to the ScheduleItem entity was cleared.
+func (m *ScheduleItemMutation) ParentCleared() bool {
+	return m.ParentIDCleared() || m.clearedparent
+}
+
+// ParentIDs returns the "parent" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// ParentID instead. It exists only for internal usage by the builders.
+func (m *ScheduleItemMutation) ParentIDs() (ids []string) {
+	if id := m.parent; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetParent resets all changes to the "parent" edge.
+func (m *ScheduleItemMutation) ResetParent() {
+	m.parent = nil
+	m.clearedparent = false
+}
+
+// AddShiftIDs adds the "shifts" edge to the ScheduleItem entity by ids.
+func (m *ScheduleItemMutation) AddShiftIDs(ids ...string) {
+	if m.shifts == nil {
+		m.shifts = make(map[string]struct{})
+	}
+	for i := range ids {
+		m.shifts[ids[i]] = struct{}{}
+	}
+}
+
+// ClearShifts clears the "shifts" edge to the ScheduleItem entity.
+func (m *ScheduleItemMutation) ClearShifts() {
+	m.clearedshifts = true
+}
+
+// ShiftsCleared reports if the "shifts" edge to the ScheduleItem entity was cleared.
+func (m *ScheduleItemMutation) ShiftsCleared() bool {
+	return m.clearedshifts
+}
+
+// RemoveShiftIDs removes the "shifts" edge to the ScheduleItem entity by IDs.
+func (m *ScheduleItemMutation) RemoveShiftIDs(ids ...string) {
+	if m.removedshifts == nil {
+		m.removedshifts = make(map[string]struct{})
+	}
+	for i := range ids {
+		delete(m.shifts, ids[i])
+		m.removedshifts[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedShifts returns the removed IDs of the "shifts" edge to the ScheduleItem entity.
+func (m *ScheduleItemMutation) RemovedShiftsIDs() (ids []string) {
+	for id := range m.removedshifts {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ShiftsIDs returns the "shifts" edge IDs in the mutation.
+func (m *ScheduleItemMutation) ShiftsIDs() (ids []string) {
+	for id := range m.shifts {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetShifts resets all changes to the "shifts" edge.
+func (m *ScheduleItemMutation) ResetShifts() {
+	m.shifts = nil
+	m.clearedshifts = false
+	m.removedshifts = nil
+}
+
 // Where appends a list predicates to the ScheduleItemMutation builder.
 func (m *ScheduleItemMutation) Where(ps ...predicate.ScheduleItem) {
 	m.predicates = append(m.predicates, ps...)
@@ -10824,7 +10996,7 @@ func (m *ScheduleItemMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ScheduleItemMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 12)
 	if m.createdAt != nil {
 		fields = append(fields, scheduleitem.FieldCreatedAt)
 	}
@@ -10855,6 +11027,12 @@ func (m *ScheduleItemMutation) Fields() []string {
 	if m.project != nil {
 		fields = append(fields, scheduleitem.FieldProjectID)
 	}
+	if m.parent != nil {
+		fields = append(fields, scheduleitem.FieldParentID)
+	}
+	if m.kind != nil {
+		fields = append(fields, scheduleitem.FieldKind)
+	}
 	return fields
 }
 
@@ -10883,6 +11061,10 @@ func (m *ScheduleItemMutation) Field(name string) (ent.Value, bool) {
 		return m.Cardinality()
 	case scheduleitem.FieldProjectID:
 		return m.ProjectID()
+	case scheduleitem.FieldParentID:
+		return m.ParentID()
+	case scheduleitem.FieldKind:
+		return m.Kind()
 	}
 	return nil, false
 }
@@ -10912,6 +11094,10 @@ func (m *ScheduleItemMutation) OldField(ctx context.Context, name string) (ent.V
 		return m.OldCardinality(ctx)
 	case scheduleitem.FieldProjectID:
 		return m.OldProjectID(ctx)
+	case scheduleitem.FieldParentID:
+		return m.OldParentID(ctx)
+	case scheduleitem.FieldKind:
+		return m.OldKind(ctx)
 	}
 	return nil, fmt.Errorf("unknown ScheduleItem field %s", name)
 }
@@ -10991,6 +11177,20 @@ func (m *ScheduleItemMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetProjectID(v)
 		return nil
+	case scheduleitem.FieldParentID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetParentID(v)
+		return nil
+	case scheduleitem.FieldKind:
+		v, ok := value.(scheduleitem.Kind)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetKind(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ScheduleItem field %s", name)
 }
@@ -11045,6 +11245,9 @@ func (m *ScheduleItemMutation) ClearedFields() []string {
 	if m.FieldCleared(scheduleitem.FieldDescription) {
 		fields = append(fields, scheduleitem.FieldDescription)
 	}
+	if m.FieldCleared(scheduleitem.FieldParentID) {
+		fields = append(fields, scheduleitem.FieldParentID)
+	}
 	return fields
 }
 
@@ -11067,6 +11270,9 @@ func (m *ScheduleItemMutation) ClearField(name string) error {
 		return nil
 	case scheduleitem.FieldDescription:
 		m.ClearDescription()
+		return nil
+	case scheduleitem.FieldParentID:
+		m.ClearParentID()
 		return nil
 	}
 	return fmt.Errorf("unknown ScheduleItem nullable field %s", name)
@@ -11106,13 +11312,19 @@ func (m *ScheduleItemMutation) ResetField(name string) error {
 	case scheduleitem.FieldProjectID:
 		m.ResetProjectID()
 		return nil
+	case scheduleitem.FieldParentID:
+		m.ResetParentID()
+		return nil
+	case scheduleitem.FieldKind:
+		m.ResetKind()
+		return nil
 	}
 	return fmt.Errorf("unknown ScheduleItem field %s", name)
 }
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ScheduleItemMutation) AddedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 5)
 	if m.project != nil {
 		edges = append(edges, scheduleitem.EdgeProject)
 	}
@@ -11121,6 +11333,12 @@ func (m *ScheduleItemMutation) AddedEdges() []string {
 	}
 	if m.tags != nil {
 		edges = append(edges, scheduleitem.EdgeTags)
+	}
+	if m.parent != nil {
+		edges = append(edges, scheduleitem.EdgeParent)
+	}
+	if m.shifts != nil {
+		edges = append(edges, scheduleitem.EdgeShifts)
 	}
 	return edges
 }
@@ -11145,18 +11363,31 @@ func (m *ScheduleItemMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case scheduleitem.EdgeParent:
+		if id := m.parent; id != nil {
+			return []ent.Value{*id}
+		}
+	case scheduleitem.EdgeShifts:
+		ids := make([]ent.Value, 0, len(m.shifts))
+		for id := range m.shifts {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *ScheduleItemMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 5)
 	if m.removedassignees != nil {
 		edges = append(edges, scheduleitem.EdgeAssignees)
 	}
 	if m.removedtags != nil {
 		edges = append(edges, scheduleitem.EdgeTags)
+	}
+	if m.removedshifts != nil {
+		edges = append(edges, scheduleitem.EdgeShifts)
 	}
 	return edges
 }
@@ -11177,13 +11408,19 @@ func (m *ScheduleItemMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case scheduleitem.EdgeShifts:
+		ids := make([]ent.Value, 0, len(m.removedshifts))
+		for id := range m.removedshifts {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ScheduleItemMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 5)
 	if m.clearedproject {
 		edges = append(edges, scheduleitem.EdgeProject)
 	}
@@ -11192,6 +11429,12 @@ func (m *ScheduleItemMutation) ClearedEdges() []string {
 	}
 	if m.clearedtags {
 		edges = append(edges, scheduleitem.EdgeTags)
+	}
+	if m.clearedparent {
+		edges = append(edges, scheduleitem.EdgeParent)
+	}
+	if m.clearedshifts {
+		edges = append(edges, scheduleitem.EdgeShifts)
 	}
 	return edges
 }
@@ -11206,6 +11449,10 @@ func (m *ScheduleItemMutation) EdgeCleared(name string) bool {
 		return m.clearedassignees
 	case scheduleitem.EdgeTags:
 		return m.clearedtags
+	case scheduleitem.EdgeParent:
+		return m.clearedparent
+	case scheduleitem.EdgeShifts:
+		return m.clearedshifts
 	}
 	return false
 }
@@ -11216,6 +11463,9 @@ func (m *ScheduleItemMutation) ClearEdge(name string) error {
 	switch name {
 	case scheduleitem.EdgeProject:
 		m.ClearProject()
+		return nil
+	case scheduleitem.EdgeParent:
+		m.ClearParent()
 		return nil
 	}
 	return fmt.Errorf("unknown ScheduleItem unique edge %s", name)
@@ -11233,6 +11483,12 @@ func (m *ScheduleItemMutation) ResetEdge(name string) error {
 		return nil
 	case scheduleitem.EdgeTags:
 		m.ResetTags()
+		return nil
+	case scheduleitem.EdgeParent:
+		m.ResetParent()
+		return nil
+	case scheduleitem.EdgeShifts:
+		m.ResetShifts()
 		return nil
 	}
 	return fmt.Errorf("unknown ScheduleItem edge %s", name)

--- a/api/ent/scheduleitem.go
+++ b/api/ent/scheduleitem.go
@@ -39,6 +39,10 @@ type ScheduleItem struct {
 	Cardinality int `json:"cardinality"`
 	// ProjectID holds the value of the "project_id" field.
 	ProjectID string `json:"-"`
+	// ParentID holds the value of the "parent_id" field.
+	ParentID string `json:"-"`
+	// Kind holds the value of the "kind" field.
+	Kind scheduleitem.Kind `json:"kind"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ScheduleItemQuery when eager-loading is set.
 	Edges        ScheduleItemEdges `json:"edges"`
@@ -53,9 +57,13 @@ type ScheduleItemEdges struct {
 	Assignees []*User `json:"assignees,omitempty"`
 	// Tags holds the value of the tags edge.
 	Tags []*ImageTag `json:"tags,omitempty"`
+	// Parent holds the value of the parent edge.
+	Parent *ScheduleItem `json:"parent,omitempty"`
+	// Shifts holds the value of the shifts edge.
+	Shifts []*ScheduleItem `json:"shifts,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [3]bool
+	loadedTypes [5]bool
 }
 
 // ProjectOrErr returns the Project value or an error if the edge
@@ -87,6 +95,26 @@ func (e ScheduleItemEdges) TagsOrErr() ([]*ImageTag, error) {
 	return nil, &NotLoadedError{edge: "tags"}
 }
 
+// ParentOrErr returns the Parent value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e ScheduleItemEdges) ParentOrErr() (*ScheduleItem, error) {
+	if e.Parent != nil {
+		return e.Parent, nil
+	} else if e.loadedTypes[3] {
+		return nil, &NotFoundError{label: scheduleitem.Label}
+	}
+	return nil, &NotLoadedError{edge: "parent"}
+}
+
+// ShiftsOrErr returns the Shifts value or an error if the edge
+// was not loaded in eager-loading.
+func (e ScheduleItemEdges) ShiftsOrErr() ([]*ScheduleItem, error) {
+	if e.loadedTypes[4] {
+		return e.Shifts, nil
+	}
+	return nil, &NotLoadedError{edge: "shifts"}
+}
+
 // scanValues returns the types for scanning values from sql.Rows.
 func (*ScheduleItem) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
@@ -96,7 +124,7 @@ func (*ScheduleItem) scanValues(columns []string) ([]any, error) {
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		case scheduleitem.FieldCardinality:
 			values[i] = new(sql.NullInt64)
-		case scheduleitem.FieldID, scheduleitem.FieldTitle, scheduleitem.FieldDescription, scheduleitem.FieldProjectID:
+		case scheduleitem.FieldID, scheduleitem.FieldTitle, scheduleitem.FieldDescription, scheduleitem.FieldProjectID, scheduleitem.FieldParentID, scheduleitem.FieldKind:
 			values[i] = new(sql.NullString)
 		case scheduleitem.FieldCreatedAt, scheduleitem.FieldUpdatedAt, scheduleitem.FieldStart, scheduleitem.FieldEnd:
 			values[i] = new(sql.NullTime)
@@ -183,6 +211,18 @@ func (_m *ScheduleItem) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.ProjectID = value.String
 			}
+		case scheduleitem.FieldParentID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field parent_id", values[i])
+			} else if value.Valid {
+				_m.ParentID = value.String
+			}
+		case scheduleitem.FieldKind:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field kind", values[i])
+			} else if value.Valid {
+				_m.Kind = scheduleitem.Kind(value.String)
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -209,6 +249,16 @@ func (_m *ScheduleItem) QueryAssignees() *UserQuery {
 // QueryTags queries the "tags" edge of the ScheduleItem entity.
 func (_m *ScheduleItem) QueryTags() *ImageTagQuery {
 	return NewScheduleItemClient(_m.config).QueryTags(_m)
+}
+
+// QueryParent queries the "parent" edge of the ScheduleItem entity.
+func (_m *ScheduleItem) QueryParent() *ScheduleItemQuery {
+	return NewScheduleItemClient(_m.config).QueryParent(_m)
+}
+
+// QueryShifts queries the "shifts" edge of the ScheduleItem entity.
+func (_m *ScheduleItem) QueryShifts() *ScheduleItemQuery {
+	return NewScheduleItemClient(_m.config).QueryShifts(_m)
 }
 
 // Update returns a builder for updating this ScheduleItem.
@@ -267,6 +317,12 @@ func (_m *ScheduleItem) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("project_id=")
 	builder.WriteString(_m.ProjectID)
+	builder.WriteString(", ")
+	builder.WriteString("parent_id=")
+	builder.WriteString(_m.ParentID)
+	builder.WriteString(", ")
+	builder.WriteString("kind=")
+	builder.WriteString(fmt.Sprintf("%v", _m.Kind))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/api/ent/scheduleitem/scheduleitem.go
+++ b/api/ent/scheduleitem/scheduleitem.go
@@ -3,6 +3,7 @@
 package scheduleitem
 
 import (
+	"fmt"
 	"time"
 
 	"entgo.io/ent/dialect/sql"
@@ -34,12 +35,20 @@ const (
 	FieldCardinality = "cardinality"
 	// FieldProjectID holds the string denoting the project_id field in the database.
 	FieldProjectID = "project_id"
+	// FieldParentID holds the string denoting the parent_id field in the database.
+	FieldParentID = "parent_id"
+	// FieldKind holds the string denoting the kind field in the database.
+	FieldKind = "kind"
 	// EdgeProject holds the string denoting the project edge name in mutations.
 	EdgeProject = "project"
 	// EdgeAssignees holds the string denoting the assignees edge name in mutations.
 	EdgeAssignees = "assignees"
 	// EdgeTags holds the string denoting the tags edge name in mutations.
 	EdgeTags = "tags"
+	// EdgeParent holds the string denoting the parent edge name in mutations.
+	EdgeParent = "parent"
+	// EdgeShifts holds the string denoting the shifts edge name in mutations.
+	EdgeShifts = "shifts"
 	// Table holds the table name of the scheduleitem in the database.
 	Table = "schedule_items"
 	// ProjectTable is the table that holds the project relation/edge.
@@ -61,6 +70,14 @@ const (
 	TagsInverseTable = "image_tags"
 	// TagsColumn is the table column denoting the tags relation/edge.
 	TagsColumn = "schedule_item_tags"
+	// ParentTable is the table that holds the parent relation/edge.
+	ParentTable = "schedule_items"
+	// ParentColumn is the table column denoting the parent relation/edge.
+	ParentColumn = "parent_id"
+	// ShiftsTable is the table that holds the shifts relation/edge.
+	ShiftsTable = "schedule_items"
+	// ShiftsColumn is the table column denoting the shifts relation/edge.
+	ShiftsColumn = "parent_id"
 )
 
 // Columns holds all SQL columns for scheduleitem fields.
@@ -76,6 +93,8 @@ var Columns = []string{
 	FieldEnd,
 	FieldCardinality,
 	FieldProjectID,
+	FieldParentID,
+	FieldKind,
 }
 
 var (
@@ -112,6 +131,32 @@ var (
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
 	IDValidator func(string) error
 )
+
+// Kind defines the type for the "kind" enum field.
+type Kind string
+
+// KindItem is the default value of the Kind enum.
+const DefaultKind = KindItem
+
+// Kind values.
+const (
+	KindItem  Kind = "item"
+	KindBreak Kind = "break"
+)
+
+func (k Kind) String() string {
+	return string(k)
+}
+
+// KindValidator is a validator for the "kind" field enum values. It is called by the builders before save.
+func KindValidator(k Kind) error {
+	switch k {
+	case KindItem, KindBreak:
+		return nil
+	default:
+		return fmt.Errorf("scheduleitem: invalid enum value for kind field: %q", k)
+	}
+}
 
 // OrderOption defines the ordering options for the ScheduleItem queries.
 type OrderOption func(*sql.Selector)
@@ -171,6 +216,16 @@ func ByProjectID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldProjectID, opts...).ToFunc()
 }
 
+// ByParentID orders the results by the parent_id field.
+func ByParentID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldParentID, opts...).ToFunc()
+}
+
+// ByKind orders the results by the kind field.
+func ByKind(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldKind, opts...).ToFunc()
+}
+
 // ByProjectField orders the results by project field.
 func ByProjectField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -205,6 +260,27 @@ func ByTags(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newTagsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
+
+// ByParentField orders the results by parent field.
+func ByParentField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newParentStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByShiftsCount orders the results by shifts count.
+func ByShiftsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newShiftsStep(), opts...)
+	}
+}
+
+// ByShifts orders the results by shifts terms.
+func ByShifts(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newShiftsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
 func newProjectStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -224,5 +300,19 @@ func newTagsStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(TagsInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.O2M, false, TagsTable, TagsColumn),
+	)
+}
+func newParentStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
+	)
+}
+func newShiftsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(Table, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ShiftsTable, ShiftsColumn),
 	)
 }

--- a/api/ent/scheduleitem/where.go
+++ b/api/ent/scheduleitem/where.go
@@ -116,6 +116,11 @@ func ProjectID(v string) predicate.ScheduleItem {
 	return predicate.ScheduleItem(sql.FieldEQ(FieldProjectID, v))
 }
 
+// ParentID applies equality check predicate on the "parent_id" field. It's identical to ParentIDEQ.
+func ParentID(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldEQ(FieldParentID, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "createdAt" field.
 func CreatedAtEQ(v time.Time) predicate.ScheduleItem {
 	return predicate.ScheduleItem(sql.FieldEQ(FieldCreatedAt, v))
@@ -621,6 +626,101 @@ func ProjectIDContainsFold(v string) predicate.ScheduleItem {
 	return predicate.ScheduleItem(sql.FieldContainsFold(FieldProjectID, v))
 }
 
+// ParentIDEQ applies the EQ predicate on the "parent_id" field.
+func ParentIDEQ(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldEQ(FieldParentID, v))
+}
+
+// ParentIDNEQ applies the NEQ predicate on the "parent_id" field.
+func ParentIDNEQ(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldNEQ(FieldParentID, v))
+}
+
+// ParentIDIn applies the In predicate on the "parent_id" field.
+func ParentIDIn(vs ...string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldIn(FieldParentID, vs...))
+}
+
+// ParentIDNotIn applies the NotIn predicate on the "parent_id" field.
+func ParentIDNotIn(vs ...string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldNotIn(FieldParentID, vs...))
+}
+
+// ParentIDGT applies the GT predicate on the "parent_id" field.
+func ParentIDGT(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldGT(FieldParentID, v))
+}
+
+// ParentIDGTE applies the GTE predicate on the "parent_id" field.
+func ParentIDGTE(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldGTE(FieldParentID, v))
+}
+
+// ParentIDLT applies the LT predicate on the "parent_id" field.
+func ParentIDLT(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldLT(FieldParentID, v))
+}
+
+// ParentIDLTE applies the LTE predicate on the "parent_id" field.
+func ParentIDLTE(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldLTE(FieldParentID, v))
+}
+
+// ParentIDContains applies the Contains predicate on the "parent_id" field.
+func ParentIDContains(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldContains(FieldParentID, v))
+}
+
+// ParentIDHasPrefix applies the HasPrefix predicate on the "parent_id" field.
+func ParentIDHasPrefix(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldHasPrefix(FieldParentID, v))
+}
+
+// ParentIDHasSuffix applies the HasSuffix predicate on the "parent_id" field.
+func ParentIDHasSuffix(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldHasSuffix(FieldParentID, v))
+}
+
+// ParentIDIsNil applies the IsNil predicate on the "parent_id" field.
+func ParentIDIsNil() predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldIsNull(FieldParentID))
+}
+
+// ParentIDNotNil applies the NotNil predicate on the "parent_id" field.
+func ParentIDNotNil() predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldNotNull(FieldParentID))
+}
+
+// ParentIDEqualFold applies the EqualFold predicate on the "parent_id" field.
+func ParentIDEqualFold(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldEqualFold(FieldParentID, v))
+}
+
+// ParentIDContainsFold applies the ContainsFold predicate on the "parent_id" field.
+func ParentIDContainsFold(v string) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldContainsFold(FieldParentID, v))
+}
+
+// KindEQ applies the EQ predicate on the "kind" field.
+func KindEQ(v Kind) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldEQ(FieldKind, v))
+}
+
+// KindNEQ applies the NEQ predicate on the "kind" field.
+func KindNEQ(v Kind) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldNEQ(FieldKind, v))
+}
+
+// KindIn applies the In predicate on the "kind" field.
+func KindIn(vs ...Kind) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldIn(FieldKind, vs...))
+}
+
+// KindNotIn applies the NotIn predicate on the "kind" field.
+func KindNotIn(vs ...Kind) predicate.ScheduleItem {
+	return predicate.ScheduleItem(sql.FieldNotIn(FieldKind, vs...))
+}
+
 // HasProject applies the HasEdge predicate on the "project" edge.
 func HasProject() predicate.ScheduleItem {
 	return predicate.ScheduleItem(func(s *sql.Selector) {
@@ -682,6 +782,52 @@ func HasTags() predicate.ScheduleItem {
 func HasTagsWith(preds ...predicate.ImageTag) predicate.ScheduleItem {
 	return predicate.ScheduleItem(func(s *sql.Selector) {
 		step := newTagsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasParent applies the HasEdge predicate on the "parent" edge.
+func HasParent() predicate.ScheduleItem {
+	return predicate.ScheduleItem(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, ParentTable, ParentColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasParentWith applies the HasEdge predicate on the "parent" edge with a given conditions (other predicates).
+func HasParentWith(preds ...predicate.ScheduleItem) predicate.ScheduleItem {
+	return predicate.ScheduleItem(func(s *sql.Selector) {
+		step := newParentStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasShifts applies the HasEdge predicate on the "shifts" edge.
+func HasShifts() predicate.ScheduleItem {
+	return predicate.ScheduleItem(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, ShiftsTable, ShiftsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasShiftsWith applies the HasEdge predicate on the "shifts" edge with a given conditions (other predicates).
+func HasShiftsWith(preds ...predicate.ScheduleItem) predicate.ScheduleItem {
+	return predicate.ScheduleItem(func(s *sql.Selector) {
+		step := newShiftsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/api/ent/scheduleitem_create.go
+++ b/api/ent/scheduleitem_create.go
@@ -132,6 +132,34 @@ func (_c *ScheduleItemCreate) SetProjectID(v string) *ScheduleItemCreate {
 	return _c
 }
 
+// SetParentID sets the "parent_id" field.
+func (_c *ScheduleItemCreate) SetParentID(v string) *ScheduleItemCreate {
+	_c.mutation.SetParentID(v)
+	return _c
+}
+
+// SetNillableParentID sets the "parent_id" field if the given value is not nil.
+func (_c *ScheduleItemCreate) SetNillableParentID(v *string) *ScheduleItemCreate {
+	if v != nil {
+		_c.SetParentID(*v)
+	}
+	return _c
+}
+
+// SetKind sets the "kind" field.
+func (_c *ScheduleItemCreate) SetKind(v scheduleitem.Kind) *ScheduleItemCreate {
+	_c.mutation.SetKind(v)
+	return _c
+}
+
+// SetNillableKind sets the "kind" field if the given value is not nil.
+func (_c *ScheduleItemCreate) SetNillableKind(v *scheduleitem.Kind) *ScheduleItemCreate {
+	if v != nil {
+		_c.SetKind(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ScheduleItemCreate) SetID(v string) *ScheduleItemCreate {
 	_c.mutation.SetID(v)
@@ -181,6 +209,26 @@ func (_c *ScheduleItemCreate) AddTags(v ...*ImageTag) *ScheduleItemCreate {
 	return _c.AddTagIDs(ids...)
 }
 
+// SetParent sets the "parent" edge to the ScheduleItem entity.
+func (_c *ScheduleItemCreate) SetParent(v *ScheduleItem) *ScheduleItemCreate {
+	return _c.SetParentID(v.ID)
+}
+
+// AddShiftIDs adds the "shifts" edge to the ScheduleItem entity by IDs.
+func (_c *ScheduleItemCreate) AddShiftIDs(ids ...string) *ScheduleItemCreate {
+	_c.mutation.AddShiftIDs(ids...)
+	return _c
+}
+
+// AddShifts adds the "shifts" edges to the ScheduleItem entity.
+func (_c *ScheduleItemCreate) AddShifts(v ...*ScheduleItem) *ScheduleItemCreate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddShiftIDs(ids...)
+}
+
 // Mutation returns the ScheduleItemMutation object of the builder.
 func (_c *ScheduleItemCreate) Mutation() *ScheduleItemMutation {
 	return _c.mutation
@@ -228,6 +276,10 @@ func (_c *ScheduleItemCreate) defaults() {
 		v := scheduleitem.DefaultCardinality
 		_c.mutation.SetCardinality(v)
 	}
+	if _, ok := _c.mutation.Kind(); !ok {
+		v := scheduleitem.DefaultKind
+		_c.mutation.SetKind(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := scheduleitem.DefaultID()
 		_c.mutation.SetID(v)
@@ -266,6 +318,14 @@ func (_c *ScheduleItemCreate) check() error {
 	}
 	if _, ok := _c.mutation.ProjectID(); !ok {
 		return &ValidationError{Name: "project_id", err: errors.New(`ent: missing required field "ScheduleItem.project_id"`)}
+	}
+	if _, ok := _c.mutation.Kind(); !ok {
+		return &ValidationError{Name: "kind", err: errors.New(`ent: missing required field "ScheduleItem.kind"`)}
+	}
+	if v, ok := _c.mutation.Kind(); ok {
+		if err := scheduleitem.KindValidator(v); err != nil {
+			return &ValidationError{Name: "kind", err: fmt.Errorf(`ent: validator failed for field "ScheduleItem.kind": %w`, err)}
+		}
 	}
 	if v, ok := _c.mutation.ID(); ok {
 		if err := scheduleitem.IDValidator(v); err != nil {
@@ -346,6 +406,10 @@ func (_c *ScheduleItemCreate) createSpec() (*ScheduleItem, *sqlgraph.CreateSpec)
 		_spec.SetField(scheduleitem.FieldCardinality, field.TypeInt, value)
 		_node.Cardinality = value
 	}
+	if value, ok := _c.mutation.Kind(); ok {
+		_spec.SetField(scheduleitem.FieldKind, field.TypeEnum, value)
+		_node.Kind = value
+	}
 	if nodes := _c.mutation.ProjectIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -388,6 +452,39 @@ func (_c *ScheduleItemCreate) createSpec() (*ScheduleItem, *sqlgraph.CreateSpec)
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.ParentIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   scheduleitem.ParentTable,
+			Columns: []string{scheduleitem.ParentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.ParentID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.ShiftsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   scheduleitem.ShiftsTable,
+			Columns: []string{scheduleitem.ShiftsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/api/ent/scheduleitem_query.go
+++ b/api/ent/scheduleitem_query.go
@@ -31,6 +31,8 @@ type ScheduleItemQuery struct {
 	withProject   *ProjectQuery
 	withAssignees *UserQuery
 	withTags      *ImageTagQuery
+	withParent    *ScheduleItemQuery
+	withShifts    *ScheduleItemQuery
 	modifiers     []func(*sql.Selector)
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
@@ -127,6 +129,50 @@ func (_q *ScheduleItemQuery) QueryTags() *ImageTagQuery {
 			sqlgraph.From(scheduleitem.Table, scheduleitem.FieldID, selector),
 			sqlgraph.To(imagetag.Table, imagetag.FieldID),
 			sqlgraph.Edge(sqlgraph.O2M, false, scheduleitem.TagsTable, scheduleitem.TagsColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryParent chains the current query on the "parent" edge.
+func (_q *ScheduleItemQuery) QueryParent() *ScheduleItemQuery {
+	query := (&ScheduleItemClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(scheduleitem.Table, scheduleitem.FieldID, selector),
+			sqlgraph.To(scheduleitem.Table, scheduleitem.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, scheduleitem.ParentTable, scheduleitem.ParentColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryShifts chains the current query on the "shifts" edge.
+func (_q *ScheduleItemQuery) QueryShifts() *ScheduleItemQuery {
+	query := (&ScheduleItemClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(scheduleitem.Table, scheduleitem.FieldID, selector),
+			sqlgraph.To(scheduleitem.Table, scheduleitem.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, scheduleitem.ShiftsTable, scheduleitem.ShiftsColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -329,6 +375,8 @@ func (_q *ScheduleItemQuery) Clone() *ScheduleItemQuery {
 		withProject:   _q.withProject.Clone(),
 		withAssignees: _q.withAssignees.Clone(),
 		withTags:      _q.withTags.Clone(),
+		withParent:    _q.withParent.Clone(),
+		withShifts:    _q.withShifts.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
 		path: _q.path,
@@ -365,6 +413,28 @@ func (_q *ScheduleItemQuery) WithTags(opts ...func(*ImageTagQuery)) *ScheduleIte
 		opt(query)
 	}
 	_q.withTags = query
+	return _q
+}
+
+// WithParent tells the query-builder to eager-load the nodes that are connected to
+// the "parent" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ScheduleItemQuery) WithParent(opts ...func(*ScheduleItemQuery)) *ScheduleItemQuery {
+	query := (&ScheduleItemClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withParent = query
+	return _q
+}
+
+// WithShifts tells the query-builder to eager-load the nodes that are connected to
+// the "shifts" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ScheduleItemQuery) WithShifts(opts ...func(*ScheduleItemQuery)) *ScheduleItemQuery {
+	query := (&ScheduleItemClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withShifts = query
 	return _q
 }
 
@@ -446,10 +516,12 @@ func (_q *ScheduleItemQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]
 	var (
 		nodes       = []*ScheduleItem{}
 		_spec       = _q.querySpec()
-		loadedTypes = [3]bool{
+		loadedTypes = [5]bool{
 			_q.withProject != nil,
 			_q.withAssignees != nil,
 			_q.withTags != nil,
+			_q.withParent != nil,
+			_q.withShifts != nil,
 		}
 	)
 	_spec.ScanValues = func(columns []string) ([]any, error) {
@@ -490,6 +562,19 @@ func (_q *ScheduleItemQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]
 		if err := _q.loadTags(ctx, query, nodes,
 			func(n *ScheduleItem) { n.Edges.Tags = []*ImageTag{} },
 			func(n *ScheduleItem, e *ImageTag) { n.Edges.Tags = append(n.Edges.Tags, e) }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withParent; query != nil {
+		if err := _q.loadParent(ctx, query, nodes, nil,
+			func(n *ScheduleItem, e *ScheduleItem) { n.Edges.Parent = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withShifts; query != nil {
+		if err := _q.loadShifts(ctx, query, nodes,
+			func(n *ScheduleItem) { n.Edges.Shifts = []*ScheduleItem{} },
+			func(n *ScheduleItem, e *ScheduleItem) { n.Edges.Shifts = append(n.Edges.Shifts, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -617,6 +702,65 @@ func (_q *ScheduleItemQuery) loadTags(ctx context.Context, query *ImageTagQuery,
 	}
 	return nil
 }
+func (_q *ScheduleItemQuery) loadParent(ctx context.Context, query *ScheduleItemQuery, nodes []*ScheduleItem, init func(*ScheduleItem), assign func(*ScheduleItem, *ScheduleItem)) error {
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*ScheduleItem)
+	for i := range nodes {
+		fk := nodes[i].ParentID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(scheduleitem.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "parent_id" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (_q *ScheduleItemQuery) loadShifts(ctx context.Context, query *ScheduleItemQuery, nodes []*ScheduleItem, init func(*ScheduleItem), assign func(*ScheduleItem, *ScheduleItem)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[string]*ScheduleItem)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(scheduleitem.FieldParentID)
+	}
+	query.Where(predicate.ScheduleItem(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(scheduleitem.ShiftsColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.ParentID
+		node, ok := nodeids[fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "parent_id" returned %v for node %v`, fk, n.ID)
+		}
+		assign(node, n)
+	}
+	return nil
+}
 
 func (_q *ScheduleItemQuery) sqlCount(ctx context.Context) (int, error) {
 	_spec := _q.querySpec()
@@ -648,6 +792,9 @@ func (_q *ScheduleItemQuery) querySpec() *sqlgraph.QuerySpec {
 		}
 		if _q.withProject != nil {
 			_spec.Node.AddColumnOnce(scheduleitem.FieldProjectID)
+		}
+		if _q.withParent != nil {
+			_spec.Node.AddColumnOnce(scheduleitem.FieldParentID)
 		}
 	}
 	if ps := _q.predicates; len(ps) > 0 {

--- a/api/ent/scheduleitem_update.go
+++ b/api/ent/scheduleitem_update.go
@@ -155,6 +155,40 @@ func (_u *ScheduleItemUpdate) SetNillableProjectID(v *string) *ScheduleItemUpdat
 	return _u
 }
 
+// SetParentID sets the "parent_id" field.
+func (_u *ScheduleItemUpdate) SetParentID(v string) *ScheduleItemUpdate {
+	_u.mutation.SetParentID(v)
+	return _u
+}
+
+// SetNillableParentID sets the "parent_id" field if the given value is not nil.
+func (_u *ScheduleItemUpdate) SetNillableParentID(v *string) *ScheduleItemUpdate {
+	if v != nil {
+		_u.SetParentID(*v)
+	}
+	return _u
+}
+
+// ClearParentID clears the value of the "parent_id" field.
+func (_u *ScheduleItemUpdate) ClearParentID() *ScheduleItemUpdate {
+	_u.mutation.ClearParentID()
+	return _u
+}
+
+// SetKind sets the "kind" field.
+func (_u *ScheduleItemUpdate) SetKind(v scheduleitem.Kind) *ScheduleItemUpdate {
+	_u.mutation.SetKind(v)
+	return _u
+}
+
+// SetNillableKind sets the "kind" field if the given value is not nil.
+func (_u *ScheduleItemUpdate) SetNillableKind(v *scheduleitem.Kind) *ScheduleItemUpdate {
+	if v != nil {
+		_u.SetKind(*v)
+	}
+	return _u
+}
+
 // SetProject sets the "project" edge to the Project entity.
 func (_u *ScheduleItemUpdate) SetProject(v *Project) *ScheduleItemUpdate {
 	return _u.SetProjectID(v.ID)
@@ -188,6 +222,26 @@ func (_u *ScheduleItemUpdate) AddTags(v ...*ImageTag) *ScheduleItemUpdate {
 		ids[i] = v[i].ID
 	}
 	return _u.AddTagIDs(ids...)
+}
+
+// SetParent sets the "parent" edge to the ScheduleItem entity.
+func (_u *ScheduleItemUpdate) SetParent(v *ScheduleItem) *ScheduleItemUpdate {
+	return _u.SetParentID(v.ID)
+}
+
+// AddShiftIDs adds the "shifts" edge to the ScheduleItem entity by IDs.
+func (_u *ScheduleItemUpdate) AddShiftIDs(ids ...string) *ScheduleItemUpdate {
+	_u.mutation.AddShiftIDs(ids...)
+	return _u
+}
+
+// AddShifts adds the "shifts" edges to the ScheduleItem entity.
+func (_u *ScheduleItemUpdate) AddShifts(v ...*ScheduleItem) *ScheduleItemUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddShiftIDs(ids...)
 }
 
 // Mutation returns the ScheduleItemMutation object of the builder.
@@ -243,6 +297,33 @@ func (_u *ScheduleItemUpdate) RemoveTags(v ...*ImageTag) *ScheduleItemUpdate {
 	return _u.RemoveTagIDs(ids...)
 }
 
+// ClearParent clears the "parent" edge to the ScheduleItem entity.
+func (_u *ScheduleItemUpdate) ClearParent() *ScheduleItemUpdate {
+	_u.mutation.ClearParent()
+	return _u
+}
+
+// ClearShifts clears all "shifts" edges to the ScheduleItem entity.
+func (_u *ScheduleItemUpdate) ClearShifts() *ScheduleItemUpdate {
+	_u.mutation.ClearShifts()
+	return _u
+}
+
+// RemoveShiftIDs removes the "shifts" edge to ScheduleItem entities by IDs.
+func (_u *ScheduleItemUpdate) RemoveShiftIDs(ids ...string) *ScheduleItemUpdate {
+	_u.mutation.RemoveShiftIDs(ids...)
+	return _u
+}
+
+// RemoveShifts removes "shifts" edges to ScheduleItem entities.
+func (_u *ScheduleItemUpdate) RemoveShifts(v ...*ScheduleItem) *ScheduleItemUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveShiftIDs(ids...)
+}
+
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (_u *ScheduleItemUpdate) Save(ctx context.Context) (int, error) {
 	_u.defaults()
@@ -289,6 +370,11 @@ func (_u *ScheduleItemUpdate) check() error {
 	if v, ok := _u.mutation.Cardinality(); ok {
 		if err := scheduleitem.CardinalityValidator(v); err != nil {
 			return &ValidationError{Name: "cardinality", err: fmt.Errorf(`ent: validator failed for field "ScheduleItem.cardinality": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.Kind(); ok {
+		if err := scheduleitem.KindValidator(v); err != nil {
+			return &ValidationError{Name: "kind", err: fmt.Errorf(`ent: validator failed for field "ScheduleItem.kind": %w`, err)}
 		}
 	}
 	if _u.mutation.ProjectCleared() && len(_u.mutation.ProjectIDs()) > 0 {
@@ -341,6 +427,9 @@ func (_u *ScheduleItemUpdate) sqlSave(ctx context.Context) (_node int, err error
 	}
 	if value, ok := _u.mutation.AddedCardinality(); ok {
 		_spec.AddField(scheduleitem.FieldCardinality, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.Kind(); ok {
+		_spec.SetField(scheduleitem.FieldKind, field.TypeEnum, value)
 	}
 	if _u.mutation.ProjectCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -454,6 +543,80 @@ func (_u *ScheduleItemUpdate) sqlSave(ctx context.Context) (_node int, err error
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ParentCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   scheduleitem.ParentTable,
+			Columns: []string{scheduleitem.ParentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ParentIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   scheduleitem.ParentTable,
+			Columns: []string{scheduleitem.ParentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ShiftsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   scheduleitem.ShiftsTable,
+			Columns: []string{scheduleitem.ShiftsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedShiftsIDs(); len(nodes) > 0 && !_u.mutation.ShiftsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   scheduleitem.ShiftsTable,
+			Columns: []string{scheduleitem.ShiftsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ShiftsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   scheduleitem.ShiftsTable,
+			Columns: []string{scheduleitem.ShiftsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -604,6 +767,40 @@ func (_u *ScheduleItemUpdateOne) SetNillableProjectID(v *string) *ScheduleItemUp
 	return _u
 }
 
+// SetParentID sets the "parent_id" field.
+func (_u *ScheduleItemUpdateOne) SetParentID(v string) *ScheduleItemUpdateOne {
+	_u.mutation.SetParentID(v)
+	return _u
+}
+
+// SetNillableParentID sets the "parent_id" field if the given value is not nil.
+func (_u *ScheduleItemUpdateOne) SetNillableParentID(v *string) *ScheduleItemUpdateOne {
+	if v != nil {
+		_u.SetParentID(*v)
+	}
+	return _u
+}
+
+// ClearParentID clears the value of the "parent_id" field.
+func (_u *ScheduleItemUpdateOne) ClearParentID() *ScheduleItemUpdateOne {
+	_u.mutation.ClearParentID()
+	return _u
+}
+
+// SetKind sets the "kind" field.
+func (_u *ScheduleItemUpdateOne) SetKind(v scheduleitem.Kind) *ScheduleItemUpdateOne {
+	_u.mutation.SetKind(v)
+	return _u
+}
+
+// SetNillableKind sets the "kind" field if the given value is not nil.
+func (_u *ScheduleItemUpdateOne) SetNillableKind(v *scheduleitem.Kind) *ScheduleItemUpdateOne {
+	if v != nil {
+		_u.SetKind(*v)
+	}
+	return _u
+}
+
 // SetProject sets the "project" edge to the Project entity.
 func (_u *ScheduleItemUpdateOne) SetProject(v *Project) *ScheduleItemUpdateOne {
 	return _u.SetProjectID(v.ID)
@@ -637,6 +834,26 @@ func (_u *ScheduleItemUpdateOne) AddTags(v ...*ImageTag) *ScheduleItemUpdateOne 
 		ids[i] = v[i].ID
 	}
 	return _u.AddTagIDs(ids...)
+}
+
+// SetParent sets the "parent" edge to the ScheduleItem entity.
+func (_u *ScheduleItemUpdateOne) SetParent(v *ScheduleItem) *ScheduleItemUpdateOne {
+	return _u.SetParentID(v.ID)
+}
+
+// AddShiftIDs adds the "shifts" edge to the ScheduleItem entity by IDs.
+func (_u *ScheduleItemUpdateOne) AddShiftIDs(ids ...string) *ScheduleItemUpdateOne {
+	_u.mutation.AddShiftIDs(ids...)
+	return _u
+}
+
+// AddShifts adds the "shifts" edges to the ScheduleItem entity.
+func (_u *ScheduleItemUpdateOne) AddShifts(v ...*ScheduleItem) *ScheduleItemUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddShiftIDs(ids...)
 }
 
 // Mutation returns the ScheduleItemMutation object of the builder.
@@ -690,6 +907,33 @@ func (_u *ScheduleItemUpdateOne) RemoveTags(v ...*ImageTag) *ScheduleItemUpdateO
 		ids[i] = v[i].ID
 	}
 	return _u.RemoveTagIDs(ids...)
+}
+
+// ClearParent clears the "parent" edge to the ScheduleItem entity.
+func (_u *ScheduleItemUpdateOne) ClearParent() *ScheduleItemUpdateOne {
+	_u.mutation.ClearParent()
+	return _u
+}
+
+// ClearShifts clears all "shifts" edges to the ScheduleItem entity.
+func (_u *ScheduleItemUpdateOne) ClearShifts() *ScheduleItemUpdateOne {
+	_u.mutation.ClearShifts()
+	return _u
+}
+
+// RemoveShiftIDs removes the "shifts" edge to ScheduleItem entities by IDs.
+func (_u *ScheduleItemUpdateOne) RemoveShiftIDs(ids ...string) *ScheduleItemUpdateOne {
+	_u.mutation.RemoveShiftIDs(ids...)
+	return _u
+}
+
+// RemoveShifts removes "shifts" edges to ScheduleItem entities.
+func (_u *ScheduleItemUpdateOne) RemoveShifts(v ...*ScheduleItem) *ScheduleItemUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveShiftIDs(ids...)
 }
 
 // Where appends a list predicates to the ScheduleItemUpdate builder.
@@ -751,6 +995,11 @@ func (_u *ScheduleItemUpdateOne) check() error {
 	if v, ok := _u.mutation.Cardinality(); ok {
 		if err := scheduleitem.CardinalityValidator(v); err != nil {
 			return &ValidationError{Name: "cardinality", err: fmt.Errorf(`ent: validator failed for field "ScheduleItem.cardinality": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.Kind(); ok {
+		if err := scheduleitem.KindValidator(v); err != nil {
+			return &ValidationError{Name: "kind", err: fmt.Errorf(`ent: validator failed for field "ScheduleItem.kind": %w`, err)}
 		}
 	}
 	if _u.mutation.ProjectCleared() && len(_u.mutation.ProjectIDs()) > 0 {
@@ -820,6 +1069,9 @@ func (_u *ScheduleItemUpdateOne) sqlSave(ctx context.Context) (_node *ScheduleIt
 	}
 	if value, ok := _u.mutation.AddedCardinality(); ok {
 		_spec.AddField(scheduleitem.FieldCardinality, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.Kind(); ok {
+		_spec.SetField(scheduleitem.FieldKind, field.TypeEnum, value)
 	}
 	if _u.mutation.ProjectCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -933,6 +1185,80 @@ func (_u *ScheduleItemUpdateOne) sqlSave(ctx context.Context) (_node *ScheduleIt
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ParentCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   scheduleitem.ParentTable,
+			Columns: []string{scheduleitem.ParentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ParentIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   scheduleitem.ParentTable,
+			Columns: []string{scheduleitem.ParentColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ShiftsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   scheduleitem.ShiftsTable,
+			Columns: []string{scheduleitem.ShiftsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedShiftsIDs(); len(nodes) > 0 && !_u.mutation.ShiftsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   scheduleitem.ShiftsTable,
+			Columns: []string{scheduleitem.ShiftsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ShiftsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   scheduleitem.ShiftsTable,
+			Columns: []string{scheduleitem.ShiftsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/api/ent/schema/schedule_item.go
+++ b/api/ent/schema/schedule_item.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
@@ -12,6 +13,12 @@ import (
 // via the M2M assignees edge. Cardinality is the TARGET headcount, not a cap —
 // overbooking is allowed by design (violett in the calendar). The M2M tags edge
 // carries the tag suggestions applied by the upload timeline editor.
+//
+// A block can be subdivided into shifts: child ScheduleItems (parent edge, one
+// level deep) whose windows lie inside the parent's. Claiming then happens on
+// the shifts, not the block. kind=break marks an unclaimable pause tile inside
+// a block. Top-level items without shifts keep the original claim-the-item
+// behavior; the upload timeline only ever consumes top-level items.
 type ScheduleItem struct{ ent.Schema }
 
 func (ScheduleItem) Mixin() []ent.Mixin {
@@ -26,6 +33,8 @@ func (ScheduleItem) Fields() []ent.Field {
 		field.Time("end").StructTag(`json:"end"`),
 		field.Int("cardinality").Positive().Default(1).StructTag(`json:"cardinality"`),
 		field.String("project_id").StructTag(`json:"-"`),
+		field.String("parent_id").Optional().StructTag(`json:"-"`),
+		field.Enum("kind").Values("item", "break").Default("item").StructTag(`json:"kind"`),
 	}
 }
 
@@ -34,6 +43,8 @@ func (ScheduleItem) Edges() []ent.Edge {
 		edge.From("project", Project.Type).Ref("scheduleItems").Field("project_id").Unique().Required(),
 		edge.To("assignees", User.Type),
 		edge.To("tags", ImageTag.Type),
+		edge.To("shifts", ScheduleItem.Type).Annotations(entsql.OnDelete(entsql.Cascade)).
+			From("parent").Field("parent_id").Unique(),
 	}
 }
 
@@ -41,5 +52,6 @@ func (ScheduleItem) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("project_id"),
 		index.Fields("project_id", "start"),
+		index.Fields("parent_id"),
 	}
 }

--- a/api/internal/repository/image.go
+++ b/api/internal/repository/image.go
@@ -53,6 +53,7 @@ type GetImageParameters struct {
 	UserID               *uuid.UUID
 	Search               *string
 	TagIDs               []string // repeated -> AND-match via a single jsonb @> containment
+	IDs                  []string // restrict to these ids (person filter); nil = no restriction
 	Orientation          *string  // "portrait" (w<h) | "landscape" (w>h); null w/h excluded
 	PaginationParameters *PaginationParameters
 }
@@ -80,6 +81,9 @@ func (r *Repository) GetImages(ctx context.Context, parameters *GetImageParamete
 			image.ComputedFileNameContainsFold(*parameters.Search),
 			image.FileNameContainsFold(*parameters.Search),
 		))
+	}
+	if parameters.IDs != nil {
+		predicates = append(predicates, image.IDIn(parameters.IDs...))
 	}
 	if len(parameters.TagIDs) > 0 {
 		// imageTags @> '["t1","t2",...]' — array containment => contains ALL ids (AND).

--- a/api/internal/repository/repository_test.go
+++ b/api/internal/repository/repository_test.go
@@ -164,6 +164,20 @@ func TestPaginationLimitOffset(t *testing.T) {
 	assert.Len(t, items, 2)
 }
 
+// IDs restricts the gallery query to the given ids (person filter).
+func TestGetImagesIDsFilter(t *testing.T) {
+	ctx := context.Background()
+	repo, m := seededRepo(t)
+	items, total, err := repo.GetImages(ctx, &repository.GetImageParameters{
+		ProjectID:            m.Project,
+		IDs:                  []string{m.Images[0], m.Images[1]},
+		PaginationParameters: &repository.PaginationParameters{Limit: 10},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, items, 2)
+}
+
 // SetImageTags rebuilds the denormalized list; idempotent assignment.
 func TestAssignmentIdempotentAndDenormalization(t *testing.T) {
 	ctx := context.Background()

--- a/api/internal/repository/schedule_item.go
+++ b/api/internal/repository/schedule_item.go
@@ -29,9 +29,13 @@ var scheduleItemSortFields = map[string]string{
 }
 
 // scheduleItemQuery eager-loads what every serialization needs: assignees (for
-// the avatar bubbles) and the suggestion tags.
+// the avatar bubbles), the suggestion tags, and the shifts of a block (with
+// their assignees), ordered by start.
 func (r *Repository) scheduleItemQuery() *ent.ScheduleItemQuery {
-	return r.Client.ScheduleItem.Query().WithAssignees().WithTags()
+	return r.Client.ScheduleItem.Query().WithAssignees().WithTags().
+		WithShifts(func(q *ent.ScheduleItemQuery) {
+			q.WithAssignees().Order(ent.Asc(scheduleitem.FieldStart))
+		})
 }
 
 func (r *Repository) GetScheduleItem(ctx context.Context, id string) (*ent.ScheduleItem, error) {
@@ -51,7 +55,12 @@ type GetScheduleItemsParameters struct {
 }
 
 func (r *Repository) GetScheduleItems(ctx context.Context, parameters *GetScheduleItemsParameters) ([]*ent.ScheduleItem, int, error) {
-	predicates := []predicate.ScheduleItem{scheduleitem.ProjectID(parameters.ProjectID)}
+	// Only top-level items are listed — shifts arrive nested on their block
+	// (the calendar and the upload-timeline picker both want blocks).
+	predicates := []predicate.ScheduleItem{
+		scheduleitem.ProjectID(parameters.ProjectID),
+		scheduleitem.ParentIDIsNil(),
+	}
 	if parameters.From != nil {
 		predicates = append(predicates, scheduleitem.EndGT(*parameters.From))
 	}
@@ -59,7 +68,11 @@ func (r *Repository) GetScheduleItems(ctx context.Context, parameters *GetSchedu
 		predicates = append(predicates, scheduleitem.StartLT(*parameters.To))
 	}
 	if parameters.AssigneeID != nil {
-		predicates = append(predicates, scheduleitem.HasAssigneesWith(user.IDEQ(*parameters.AssigneeID)))
+		// "mine" covers both claim surfaces: the item itself or one of its shifts.
+		predicates = append(predicates, scheduleitem.Or(
+			scheduleitem.HasAssigneesWith(user.IDEQ(*parameters.AssigneeID)),
+			scheduleitem.HasShiftsWith(scheduleitem.HasAssigneesWith(user.IDEQ(*parameters.AssigneeID))),
+		))
 	}
 	where := scheduleitem.And(predicates...)
 
@@ -120,6 +133,8 @@ type CreateScheduleItemParameters struct {
 	Cardinality int
 	ProjectID   string
 	TagIDs      []string
+	ParentID    string // non-empty -> this is a shift/break inside that block
+	Kind        string // "item" (default) | "break"
 }
 
 func (r *Repository) CreateScheduleItem(ctx context.Context, parameters *CreateScheduleItemParameters) (*ent.ScheduleItem, error) {
@@ -137,6 +152,12 @@ func (r *Repository) CreateScheduleItem(ctx context.Context, parameters *CreateS
 		SetUpdatedBy(util.GetActorID(ctx))
 	if parameters.Cardinality > 0 {
 		create = create.SetCardinality(parameters.Cardinality)
+	}
+	if parameters.ParentID != "" {
+		create = create.SetParentID(parameters.ParentID)
+	}
+	if parameters.Kind != "" {
+		create = create.SetKind(scheduleitem.Kind(parameters.Kind))
 	}
 	item, err := create.Save(ctx)
 	if err != nil {

--- a/api/internal/repository/schedule_item_test.go
+++ b/api/internal/repository/schedule_item_test.go
@@ -133,6 +133,56 @@ func TestScheduleItemAssignIdempotentAndOverbooking(t *testing.T) {
 	assert.Len(t, got.Edges.Assignees, 1)
 }
 
+// Shifts: nested on the block, hidden from the top-level list, "mine" matches
+// via a claimed shift, and deleting the block cascades to its shifts.
+func TestScheduleItemShifts(t *testing.T) {
+	ctx := context.Background()
+	repo, m := seededRepo(t)
+	t0 := m.ReferenceNow
+
+	block, err := repo.CreateScheduleItem(ctx, &repository.CreateScheduleItemParameters{
+		Title: "Endurance", Start: t0, End: t0.Add(10 * time.Hour), ProjectID: m.Project,
+	})
+	require.NoError(t, err)
+	shift1, err := repo.CreateScheduleItem(ctx, &repository.CreateScheduleItemParameters{
+		Title: "Shift 1", Start: t0, End: t0.Add(90 * time.Minute), ProjectID: m.Project, ParentID: block.ID,
+	})
+	require.NoError(t, err)
+	pause, err := repo.CreateScheduleItem(ctx, &repository.CreateScheduleItemParameters{
+		Title: "Break", Start: t0.Add(90 * time.Minute), End: t0.Add(150 * time.Minute),
+		ProjectID: m.Project, ParentID: block.ID, Kind: "break",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "break", string(pause.Kind))
+
+	// top-level list hides the shifts and nests them on the block, start-ordered.
+	items, total, err := repo.GetScheduleItems(ctx, &repository.GetScheduleItemsParameters{
+		ProjectID: m.Project, PaginationParameters: &repository.PaginationParameters{},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, items, 1)
+	require.Len(t, items[0].Edges.Shifts, 2)
+	assert.Equal(t, shift1.ID, items[0].Edges.Shifts[0].ID)
+
+	// "mine" finds the block through a claimed shift.
+	editor := m.Users["projectEditor"]
+	_, err = repo.AssignScheduleItemUser(ctx, shift1.ID, editor)
+	require.NoError(t, err)
+	items, total, err = repo.GetScheduleItems(ctx, &repository.GetScheduleItemsParameters{
+		ProjectID: m.Project, AssigneeID: &editor, PaginationParameters: &repository.PaginationParameters{},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	require.Len(t, items, 1)
+	assert.Equal(t, block.ID, items[0].ID)
+
+	// deleting the block cascades to the shifts.
+	require.NoError(t, repo.DeleteScheduleItem(ctx, block.ID))
+	_, err = repo.GetScheduleItem(ctx, shift1.ID)
+	assert.Error(t, err, "shift must be gone with its block")
+}
+
 func TestScheduleItemTagProjectMismatch(t *testing.T) {
 	ctx := context.Background()
 	repo, m := seededRepo(t)

--- a/api/internal/server/ai_controller.go
+++ b/api/internal/server/ai_controller.go
@@ -339,6 +339,38 @@ func (s *Server) aiPersonImages(c *gin.Context) {
 	})
 }
 
+// personImageIDs resolves a personRef to the project's image ids via the AI
+// server, for the gallery's implicit person filter. An unknown/stale ref
+// yields an empty list (empty grid), not an error. Reports ok=false only when
+// it already wrote an HTTP error.
+func (s *Server) personImageIDs(c *gin.Context, projectID, personRef string) ([]string, bool) {
+	remote, ok := s.remote(c)
+	if !ok {
+		return nil, false
+	}
+	ids := []string{}
+	// ponytail: person appearances are at most a few hundred; cap at 1000 ids
+	// (10 pages) instead of streaming — revisit if clustering ever exceeds that.
+	for page := 0; page < 10; page++ {
+		resp, err := remote.PersonImages(c.Request.Context(), projectID, personRef, page, aiserver.MaxPageSize)
+		if errors.Is(err, aiserver.ErrNotFound) {
+			return []string{}, true
+		}
+		if err != nil {
+			log.Error().Err(err).Msg("AI server request failed")
+			apiError(c, http.StatusBadGateway, "ai_server_error", "AI server request failed")
+			return nil, false
+		}
+		for _, item := range resp.Items {
+			ids = append(ids, item.ImageRef)
+		}
+		if len(resp.Items) < aiserver.MaxPageSize || len(ids) >= resp.Total {
+			break
+		}
+	}
+	return ids, true
+}
+
 // otherViewableProjectIDs lists the projects (minus exclude) the user may view:
 // all of them for admins, assigned ones otherwise. Sorted so cross-project
 // paging walks the projects in a stable order.

--- a/api/internal/server/ai_controller_test.go
+++ b/api/internal/server/ai_controller_test.go
@@ -285,6 +285,23 @@ func TestAIPersonImagesDropsUnknownRefs(t *testing.T) {
 	assert.Equal(t, 1, body.Total)
 }
 
+// The gallery person filter: an unknown/stale personRef yields an empty 200
+// page, not an error (the grid just shows nothing).
+func TestListImagesUnknownPersonFilter(t *testing.T) {
+	s, m := newAITestServer(t)
+	s.aiRemote = &fakeRemote{personTotals: map[string]int{}} // every ref -> 404
+	c, rec := aiCtx(t, adminUser(), http.MethodGet, "/api/v1/images?projectId="+m.Project+"&personRef=stale", "")
+	s.listImages(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Total int   `json:"total"`
+		Items []any `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Zero(t, body.Total)
+	assert.Empty(t, body.Items)
+}
+
 // crossProject=true fans out over the user's viewable projects (all of them
 // for admins, assigned ones otherwise) and sums the totals; without the flag
 // only the requested project is queried.

--- a/api/internal/server/images_controller.go
+++ b/api/internal/server/images_controller.go
@@ -63,6 +63,17 @@ func (s *Server) listImages(c *gin.Context) {
 		}
 		params.Orientation = &v
 	}
+	if v := c.Query("personRef"); v != "" {
+		ids, ok := s.personImageIDs(c, projectID, v)
+		if !ok {
+			return
+		}
+		if len(ids) == 0 {
+			c.JSON(http.StatusOK, ListResponse[*ImageResponse]{Limit: pagination.Limit, Offset: pagination.Offset, Total: 0, Items: []*ImageResponse{}})
+			return
+		}
+		params.IDs = ids
+	}
 
 	items, total, err := s.Repository.GetImages(c.Request.Context(), params)
 	if abortRepoListError(c, err) {

--- a/api/internal/server/schedule_items_controller.go
+++ b/api/internal/server/schedule_items_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/shutterbase/shutterbase/ent"
+	"github.com/shutterbase/shutterbase/ent/scheduleitem"
 	"github.com/shutterbase/shutterbase/internal/authorization"
 	"github.com/shutterbase/shutterbase/internal/event"
 	"github.com/shutterbase/shutterbase/internal/repository"
@@ -36,19 +37,31 @@ func (s *Server) scheduleItemResponse(ctx context.Context, it *ent.ScheduleItem)
 	for _, t := range it.Edges.Tags {
 		tags = append(tags, gin.H{"id": t.ID, "name": t.Name, "type": t.Type})
 	}
-	return gin.H{
+	resp := gin.H{
 		"id":          it.ID,
 		"title":       it.Title,
 		"description": it.Description,
 		"start":       it.Start,
 		"end":         it.End,
 		"cardinality": it.Cardinality,
+		"kind":        it.Kind,
+		"parentId":    it.ParentID,
 		"assignees":   assignees,
 		"tags":        tags,
 		"project":     projectRefByID(ctx, s.Repository, it.ProjectID),
 		"createdAt":   it.CreatedAt,
 		"updatedAt":   it.UpdatedAt,
 	}
+	// Shifts arrive nested on their block (one level deep; children carry no
+	// shifts edge of their own).
+	if it.ParentID == "" {
+		shifts := make([]gin.H, 0, len(it.Edges.Shifts))
+		for _, sh := range it.Edges.Shifts {
+			shifts = append(shifts, s.scheduleItemResponse(ctx, sh))
+		}
+		resp["shifts"] = shifts
+	}
+	return resp
 }
 
 func (s *Server) registerScheduleItemRoutes(api *gin.RouterGroup) {
@@ -124,6 +137,44 @@ type createScheduleItemPayload struct {
 	Cardinality int       `json:"cardinality"`
 	ProjectID   string    `json:"projectId" binding:"required"`
 	TagIDs      []string  `json:"tagIds"`
+	ParentID    string    `json:"parentId"` // set -> shift/break inside that block
+	Kind        string    `json:"kind"`     // "item" (default) | "break"
+}
+
+// validateShiftPlacement guards the shift rules on create: the parent must
+// exist in the same project, must itself be top-level (one nesting level), and
+// the shift window must lie inside the parent's. Breaks only exist inside a
+// block. Returns the parent (nil for top-level items) so the caller skips a
+// second lookup.
+func (s *Server) validateShiftPlacement(c *gin.Context, payload *createScheduleItemPayload) bool {
+	if payload.Kind != "" && payload.Kind != "item" && payload.Kind != "break" {
+		apiError(c, http.StatusBadRequest, "invalid_kind", "kind must be 'item' or 'break'")
+		return false
+	}
+	if payload.ParentID == "" {
+		if payload.Kind == "break" {
+			apiError(c, http.StatusBadRequest, "break_needs_block", "a break only exists inside a block")
+			return false
+		}
+		return true
+	}
+	parent, err := s.Repository.GetScheduleItem(c.Request.Context(), payload.ParentID)
+	if abortGetError(c, err) {
+		return false
+	}
+	if parent.ProjectID != payload.ProjectID {
+		apiError(c, http.StatusBadRequest, "parent_project_mismatch", "the block belongs to another project")
+		return false
+	}
+	if parent.ParentID != "" {
+		apiError(c, http.StatusBadRequest, "nested_shift", "shifts cannot be nested inside shifts")
+		return false
+	}
+	if payload.Start.Before(parent.Start) || payload.End.After(parent.End) {
+		apiError(c, http.StatusBadRequest, "shift_outside_block", "the shift must lie within the block's window")
+		return false
+	}
+	return true
 }
 
 // validateItemWindow guards start < end and a sane cardinality.
@@ -164,6 +215,9 @@ func (s *Server) createScheduleItem(c *gin.Context) {
 	if !validateItemWindow(c, payload.Start, payload.End, payload.Cardinality) {
 		return
 	}
+	if !s.validateShiftPlacement(c, &payload) {
+		return
+	}
 	item, err := s.Repository.CreateScheduleItem(c.Request.Context(), &repository.CreateScheduleItemParameters{
 		Title:       payload.Title,
 		Description: payload.Description,
@@ -172,6 +226,8 @@ func (s *Server) createScheduleItem(c *gin.Context) {
 		Cardinality: payload.Cardinality,
 		ProjectID:   payload.ProjectID,
 		TagIDs:      payload.TagIDs,
+		ParentID:    payload.ParentID,
+		Kind:        payload.Kind,
 	})
 	if abortScheduleMutationError(c, err) {
 		return
@@ -216,6 +272,25 @@ func (s *Server) updateScheduleItem(c *gin.Context) {
 	}
 	if !validateItemWindow(c, start, end, cardinality) {
 		return
+	}
+	if existing.ParentID != "" {
+		// a shift stays inside its block
+		parent, err := s.Repository.GetScheduleItem(c.Request.Context(), existing.ParentID)
+		if abortGetError(c, err) {
+			return
+		}
+		if start.Before(parent.Start) || end.After(parent.End) {
+			apiError(c, http.StatusBadRequest, "shift_outside_block", "the shift must lie within the block's window")
+			return
+		}
+	} else {
+		// a block cannot shrink away from its shifts
+		for _, sh := range existing.Edges.Shifts {
+			if sh.Start.Before(start) || sh.End.After(end) {
+				apiError(c, http.StatusBadRequest, "shifts_outside_block", "adjust or remove the shifts outside the new window first")
+				return
+			}
+		}
 	}
 	item, err := s.Repository.UpdateScheduleItem(c.Request.Context(), id, &repository.UpdateScheduleItemParameters{
 		Title:       payload.Title,
@@ -277,6 +352,17 @@ func (s *Server) assigneeParams(c *gin.Context) (item *ent.ScheduleItem, target 
 func (s *Server) assignScheduleItem(c *gin.Context) {
 	item, target, ok := s.assigneeParams(c)
 	if !ok {
+		return
+	}
+	// Claim guards: breaks are never claimable, and a subdivided block is
+	// claimed via its shifts. Unassign stays unguarded — dropping a stale
+	// claim must always work.
+	if item.Kind == scheduleitem.KindBreak {
+		apiError(c, http.StatusBadRequest, "not_claimable", "breaks cannot be claimed")
+		return
+	}
+	if len(item.Edges.Shifts) > 0 {
+		apiError(c, http.StatusBadRequest, "claim_shift_instead", "this block is subdivided — claim one of its shifts")
 		return
 	}
 	// An assignee must be a member of the item's project — an admin must not be

--- a/api/internal/server/schedule_shifts_controller_test.go
+++ b/api/internal/server/schedule_shifts_controller_test.go
@@ -1,0 +1,115 @@
+// Shift-rule validation on the schedule controller: placement guards on
+// create/update and the claim guards (breaks, subdivided blocks).
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shutterbase/shutterbase/internal/repository"
+)
+
+func createItemViaAPI(t *testing.T, s *Server, body string) (int, map[string]any) {
+	t.Helper()
+	c, rec := aiCtx(t, adminUser(), http.MethodPost, "/api/v1/schedule-items", body)
+	s.createScheduleItem(c)
+	var out map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	return rec.Code, out
+}
+
+func TestScheduleShiftPlacementRules(t *testing.T) {
+	s, m := newAITestServer(t)
+	t0 := time.Now().UTC().Truncate(time.Second)
+	iso := func(d time.Duration) string { return t0.Add(d).Format(time.RFC3339) }
+
+	code, block := createItemViaAPI(t, s, fmt.Sprintf(
+		`{"title":"Endurance","start":"%s","end":"%s","projectId":"%s"}`, iso(0), iso(10*time.Hour), m.Project))
+	require.Equal(t, http.StatusCreated, code)
+	blockID := block["id"].(string)
+
+	// a break needs a block
+	code, out := createItemViaAPI(t, s, fmt.Sprintf(
+		`{"title":"Pause","kind":"break","start":"%s","end":"%s","projectId":"%s"}`, iso(0), iso(time.Hour), m.Project))
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "break_needs_block", out["code"])
+
+	// shift outside the block window
+	code, out = createItemViaAPI(t, s, fmt.Sprintf(
+		`{"title":"Early","parentId":"%s","start":"%s","end":"%s","projectId":"%s"}`, blockID, iso(-time.Hour), iso(time.Hour), m.Project))
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "shift_outside_block", out["code"])
+
+	// valid shift
+	code, shift := createItemViaAPI(t, s, fmt.Sprintf(
+		`{"title":"Shift 1","parentId":"%s","start":"%s","end":"%s","projectId":"%s"}`, blockID, iso(0), iso(90*time.Minute), m.Project))
+	require.Equal(t, http.StatusCreated, code)
+	shiftID := shift["id"].(string)
+
+	// no nesting below a shift
+	code, out = createItemViaAPI(t, s, fmt.Sprintf(
+		`{"title":"Nested","parentId":"%s","start":"%s","end":"%s","projectId":"%s"}`, shiftID, iso(0), iso(time.Minute), m.Project))
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "nested_shift", out["code"])
+
+	// a block cannot shrink away from its shifts
+	c, rec := aiCtx(t, adminUser(), http.MethodPut, "/api/v1/schedule-items/"+blockID,
+		fmt.Sprintf(`{"end":"%s"}`, iso(time.Hour)))
+	c.Params = gin.Params{{Key: "id", Value: blockID}}
+	s.updateScheduleItem(c)
+	var upd map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &upd))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "shifts_outside_block", upd["code"])
+}
+
+func TestScheduleShiftClaimGuards(t *testing.T) {
+	s, m := newAITestServer(t)
+	ctx := context.Background()
+	t0 := time.Now().UTC().Truncate(time.Second)
+
+	block, err := s.Repository.CreateScheduleItem(ctx, &repository.CreateScheduleItemParameters{
+		Title: "Endurance", Start: t0, End: t0.Add(10 * time.Hour), ProjectID: m.Project,
+	})
+	require.NoError(t, err)
+	shift, err := s.Repository.CreateScheduleItem(ctx, &repository.CreateScheduleItemParameters{
+		Title: "Shift 1", Start: t0, End: t0.Add(90 * time.Minute), ProjectID: m.Project, ParentID: block.ID,
+	})
+	require.NoError(t, err)
+	pause, err := s.Repository.CreateScheduleItem(ctx, &repository.CreateScheduleItemParameters{
+		Title: "Break", Start: t0.Add(90 * time.Minute), End: t0.Add(150 * time.Minute),
+		ProjectID: m.Project, ParentID: block.ID, Kind: "break",
+	})
+	require.NoError(t, err)
+
+	editor, err := s.Repository.GetEffectiveUser(ctx, m.Users["projectEditor"])
+	require.NoError(t, err)
+	claim := func(itemID string) (int, map[string]any) {
+		c, rec := aiCtx(t, editor, http.MethodPut, "/api/v1/schedule-items/"+itemID+"/assignees/"+editor.ID.String(), "")
+		c.Params = gin.Params{{Key: "id", Value: itemID}, {Key: "userId", Value: editor.ID.String()}}
+		s.assignScheduleItem(c)
+		var out map[string]any
+		_ = json.Unmarshal(rec.Body.Bytes(), &out)
+		return rec.Code, out
+	}
+
+	code, out := claim(pause.ID)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "not_claimable", out["code"])
+
+	code, out = claim(block.ID)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "claim_shift_instead", out["code"])
+
+	code, out = claim(shift.ID)
+	require.Equal(t, http.StatusOK, code)
+	assert.Len(t, out["assignees"], 1)
+}

--- a/api/internal/service/ai_service.go
+++ b/api/internal/service/ai_service.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"time"
@@ -66,7 +67,7 @@ type AIService struct {
 // injection keeps it unit-testable with StubInference). Use NewInference to build
 // the config-selected provider for production wiring.
 func NewAIService(repo *repository.Repository, s3Client *s3.S3Client, inference ImageInference) *AIService {
-	timeout := 60 * time.Second
+	timeout := 180 * time.Second
 	if d, err := time.ParseDuration(config.Get().String("AI_TIMEOUT")); err == nil && d > 0 {
 		timeout = d
 	}
@@ -246,9 +247,15 @@ func (s *AIService) handle(ctx context.Context, imageID string) {
 		return
 	}
 	update := img.Update().SetAiAttempts(img.AiAttempts + 1).SetAiError(err.Error())
-	if img.AiAttempts+1 >= maxAIAttempts {
+	switch {
+	case img.AiAttempts+1 >= maxAIAttempts:
 		update.SetAiStatus(entimage.AiStatusError)
-	} else {
+	case errors.Is(err, context.DeadlineExceeded):
+		// Inference deadline exceeded: this one image is slow (e.g. a cold GPU
+		// lane), not the provider — retry at the BACK of the FIFO so the rest
+		// of the queue keeps flowing, and arm no global backoff.
+		update.SetAiStatus(entimage.AiStatusPending).SetAiQueuedAt(time.Now())
+	default:
 		// keep aiQueuedAt: the retry stays at the front of the FIFO.
 		update.SetAiStatus(entimage.AiStatusPending)
 		s.lock.Lock()

--- a/api/internal/service/ai_service_test.go
+++ b/api/internal/service/ai_service_test.go
@@ -7,6 +7,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -246,6 +247,59 @@ func TestBackoffAndDeadLetter(t *testing.T) {
 	svc.Enqueue(img)
 	assert.Equal(t, "pending", aiStatus(t, svc, img))
 	assert.Equal(t, 0, svc.repo.Client.Image.GetX(ctx, img).AiAttempts)
+}
+
+// deadlineInference times out for one image id and succeeds for the rest.
+type deadlineInference struct {
+	failFor string
+	seen    []string
+}
+
+func (d *deadlineInference) Infer(_ context.Context, req InferenceRequest) ([]InferredTag, error) {
+	d.seen = append(d.seen, req.ImageID)
+	if req.ImageID == d.failFor {
+		return nil, fmt.Errorf("infer: %w", context.DeadlineExceeded)
+	}
+	return []InferredTag{}, nil
+}
+
+// A deadline-exceeded inference retries at the BACK of the FIFO without arming
+// the global backoff, and still dead-letters once attempts are exhausted.
+func TestDeadlineRetryRequeuesAtBack(t *testing.T) {
+	t.Setenv("SESSION_SECRET_KEY", "x")
+	require.NoError(t, util.InitConfig())
+	inf := &deadlineInference{}
+	svc, m := newSvc(t, inf)
+	ctx := context.Background()
+	slow, fast := m.Images[0], m.Images[1]
+	inf.failFor = slow
+
+	base := time.Now().Add(-time.Minute)
+	svc.Enqueue(slow)
+	svc.repo.Client.Image.UpdateOneID(slow).SetAiQueuedAt(base).SaveX(ctx)
+	svc.Enqueue(fast)
+	svc.repo.Client.Image.UpdateOneID(fast).SetAiQueuedAt(base.Add(time.Second)).SaveX(ctx)
+
+	// 1st claim: the slow image times out -> pending again, requeued behind
+	// the fast one, no global backoff.
+	require.True(t, svc.step(ctx))
+	assert.Equal(t, []string{slow}, inf.seen)
+	assert.Equal(t, "pending", aiStatus(t, svc, slow))
+	assert.True(t, svc.backoffUntil.IsZero(), "deadline errors must not arm the global backoff")
+	row := svc.repo.Client.Image.GetX(ctx, slow)
+	assert.Equal(t, 1, row.AiAttempts)
+	assert.True(t, row.AiQueuedAt.After(base.Add(time.Second)), "timed-out image must move to the back of the queue")
+
+	// 2nd claim: the fast image goes first now.
+	require.True(t, svc.step(ctx))
+	assert.Equal(t, fast, inf.seen[1])
+	assert.Equal(t, "done", aiStatus(t, svc, fast))
+
+	// remaining attempts drain into the dead-letter cap.
+	for svc.step(ctx) {
+	}
+	assert.Equal(t, "error", aiStatus(t, svc, slow), "attempts exhausted -> dead-letter")
+	assert.Equal(t, maxAIAttempts, svc.repo.Client.Image.GetX(ctx, slow).AiAttempts)
 }
 
 // Boot recovery: STALE processing rows are re-queued by Start; fresh ones are

--- a/api/internal/util/config.go
+++ b/api/internal/util/config.go
@@ -108,7 +108,7 @@ func InitConfig() error {
 		config.String("AI_PROVIDER").Default("stub"),
 		config.String("AI_MODEL").Default("gpt-4o"),
 		config.String("AI_API_KEY").Sensitive().Default(""),
-		config.String("AI_TIMEOUT").Default("60s"),
+		config.String("AI_TIMEOUT").Default("180s"),
 		config.String("OPENAI_API_KEY").Sensitive().Default(""),
 		// Base URL of an AI server speaking the pkg/aiserver contract
 		// (AI_PROVIDER=http), e.g. https://fsai.fsintra.net

--- a/ui/src/api/ai.ts
+++ b/ui/src/api/ai.ts
@@ -32,22 +32,6 @@ export interface AiFace {
   personRef?: string;
 }
 
-export interface AiPersonImage {
-  image: Image;
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}
-
-export interface AiPersonImagesPage {
-  items: AiPersonImage[];
-  total: number; // crossProject: summed over all queried projects
-  page: number;
-  pageSize: number;
-  hasMore: boolean;
-}
-
 export interface AiSimilarImage {
   image: Image;
   similarity: number;
@@ -92,13 +76,6 @@ export async function rerunBatch(projectId: string, imageIds: string[]): Promise
 export async function faces(imageId: string): Promise<AiFace[]> {
   const { data } = await http.get<{ faces: AiFace[] }>(`/images/${imageId}/ai/faces`);
   return data.faces;
-}
-
-export async function personImages(projectId: string, personRef: string, page: number, pageSize = 20, crossProject = false): Promise<AiPersonImagesPage> {
-  const { data } = await http.get<AiPersonImagesPage>(`/projects/${projectId}/ai/persons/${encodeURIComponent(personRef)}/images`, {
-    params: { page, pageSize, ...(crossProject ? { crossProject: "true" } : {}) },
-  });
-  return data;
 }
 
 export async function similar(imageId: string, page: number, pageSize = 20): Promise<AiSimilarPage> {

--- a/ui/src/api/images.ts
+++ b/ui/src/api/images.ts
@@ -8,6 +8,7 @@ export interface ImageListParams {
   userId?: string;
   search?: string;
   tagId?: string[]; // repeated, AND-combined server-side
+  personRef?: string; // implicit person filter (AI face clustering handle)
   orientation?: "portrait" | "landscape";
   limit?: number;
   offset?: number;

--- a/ui/src/api/scheduleItems.ts
+++ b/ui/src/api/scheduleItems.ts
@@ -20,6 +20,8 @@ export interface ScheduleItemCreate {
   cardinality?: number;
   projectId: string;
   tagIds?: string[];
+  parentId?: string; // set -> shift/break inside that block
+  kind?: "item" | "break";
 }
 
 export interface ScheduleItemUpdate {

--- a/ui/src/components/image/AiImageListDialog.vue
+++ b/ui/src/components/image/AiImageListDialog.vue
@@ -7,32 +7,16 @@
         class="mx-auto max-w-4xl transform overflow-hidden rounded-xl border border-primary-200 bg-surface shadow-2xl transition-all dark:border-primary-800 dark:bg-surface-dark"
       >
         <div class="flex items-center justify-between border-b border-primary-200 px-5 py-4 dark:border-primary-800">
-          <div>
-            <h3 class="display text-lg text-primary-900 dark:text-white">{{ title }}</h3>
-            <p class="label-mono-sm mt-0.5 text-primary-500 dark:text-primary-400">{{ subtitle }}</p>
-          </div>
-          <div class="flex items-center gap-4">
-            <label v-if="mode === 'person'" class="flex cursor-pointer items-center gap-1.5 text-sm text-primary-600 dark:text-primary-300">
-              <input v-model="crossProject" type="checkbox" class="accent-accent-600" />
-              all my projects
-            </label>
-            <XMarkIcon class="h-5 w-5 cursor-pointer text-primary-400 hover:text-primary-600 dark:hover:text-primary-200" @click="emit('close')" />
-          </div>
+          <h3 class="display text-lg text-primary-900 dark:text-white">Similar images</h3>
+          <XMarkIcon class="h-5 w-5 cursor-pointer text-primary-400 hover:text-primary-600 dark:hover:text-primary-200" @click="emit('close')" />
         </div>
 
         <div class="max-h-[65vh] overflow-y-auto p-5">
           <div v-if="items.length" class="grid grid-cols-3 gap-2 sm:grid-cols-4 lg:grid-cols-5">
             <div v-for="entry in items" :key="entry.image.id" class="relative">
               <ImageGridTile :image="entry.image" density="dense" @select="(id) => emit('select', id)" />
-              <span
-                v-if="mode === 'similar' && entry.similarity !== undefined"
-                class="label-mono-sm pointer-events-none absolute bottom-1 right-1 rounded bg-primary-950/70 px-1 text-accent-300"
+              <span v-if="entry.similarity !== undefined" class="label-mono-sm pointer-events-none absolute bottom-1 right-1 rounded bg-primary-950/70 px-1 text-accent-300"
                 >{{ Math.round(entry.similarity * 100) }}%</span
-              >
-              <span
-                v-if="entry.image.project.id !== projectId"
-                class="label-mono-sm pointer-events-none absolute bottom-1 right-1 max-w-full truncate rounded bg-primary-950/70 px-1 text-accent-300"
-                >{{ entry.image.project.name }}</span
               >
             </div>
           </div>
@@ -50,10 +34,10 @@
           >
             previous
           </button>
-          <span class="label-mono-sm text-primary-500 dark:text-primary-400">{{ pageLabel }}</span>
+          <span class="label-mono-sm text-primary-500 dark:text-primary-400">page {{ page + 1 }}</span>
           <button
             class="text-sm font-medium text-accent-600 underline disabled:cursor-default disabled:text-primary-400 disabled:no-underline dark:text-accent-400 dark:disabled:text-primary-600"
-            :disabled="!hasNext || loading"
+            :disabled="!hasMore || loading"
             @click="page++"
           >
             next
@@ -65,10 +49,10 @@
 </template>
 
 <script setup lang="ts">
-// Paginated result grid for the two AI lookups: "photos of this person"
-// (mode=person, from a clicked face box) and "similar images" (mode=similar).
-// Selecting a result hands the image id back to the viewer.
-import { computed, ref, watch } from "vue";
+// Paginated "similar images" result grid for the current viewer image.
+// Selecting a result hands the image id back to the viewer. (Person browsing
+// lives in the normal grid via the implicit person filter, not here.)
+import { ref, watch } from "vue";
 import { XMarkIcon } from "@heroicons/vue/24/outline";
 import ImageGridTile from "src/components/image/ImageGridTile.vue";
 import { api } from "src/api";
@@ -83,10 +67,6 @@ interface Entry {
 
 interface Props {
   shown: boolean;
-  mode: "person" | "similar";
-  projectId: string;
-  // person mode: the AI server's person handle; similar mode: the query image
-  personRef?: string;
   imageId?: string;
 }
 const props = defineProps<Props>();
@@ -94,27 +74,12 @@ const emit = defineEmits<{ close: []; select: [string] }>();
 
 const items = ref<Entry[]>([]);
 const page = ref(0);
-const total = ref(0);
 const hasMore = ref(false);
 const loading = ref(false);
 const notAnalyzed = ref(false);
-// person mode: also query the user's other projects (person ids are global)
-const crossProject = ref(false);
-
-const title = computed(() => (props.mode === "person" ? "Photos of this person" : "Similar images"));
-const subtitle = computed(() => {
-  if (props.mode === "person" && total.value > 0) return `${total.value} photo${total.value === 1 ? "" : "s"} ${crossProject.value ? "across your projects" : "in this project"}`;
-  return "";
-});
-const hasNext = computed(() => (props.mode === "person" && !crossProject.value ? (page.value + 1) * PAGE_SIZE < total.value : hasMore.value));
-const pageLabel = computed(() => {
-  // cross-project pages are per-project slices, so total/PAGE_SIZE math doesn't apply
-  if (props.mode === "person" && !crossProject.value && total.value > 0) return `page ${page.value + 1} / ${Math.max(1, Math.ceil(total.value / PAGE_SIZE))}`;
-  return `page ${page.value + 1}`;
-});
 
 watch(
-  () => [props.shown, props.mode, props.personRef, props.imageId, crossProject.value],
+  () => [props.shown, props.imageId],
   () => {
     if (!props.shown) return;
     page.value = 0;
@@ -124,25 +89,17 @@ watch(
 watch(page, load);
 
 async function load() {
-  if (!props.shown) return;
+  if (!props.shown || !props.imageId) return;
   loading.value = true;
   notAnalyzed.value = false;
   items.value = [];
   try {
-    if (props.mode === "person" && props.personRef) {
-      const result = await api.ai.personImages(props.projectId, props.personRef, page.value, PAGE_SIZE, crossProject.value);
-      items.value = result.items.map((i) => ({ image: i.image }));
-      total.value = result.total;
-      hasMore.value = result.hasMore;
-    } else if (props.mode === "similar" && props.imageId) {
-      const result = await api.ai.similar(props.imageId, page.value, PAGE_SIZE);
-      items.value = result.items.map((i) => ({ image: i.image, similarity: i.similarity }));
-      hasMore.value = result.hasMore;
-    }
+    const result = await api.ai.similar(props.imageId, page.value, PAGE_SIZE);
+    items.value = result.items.map((i) => ({ image: i.image, similarity: i.similarity }));
+    hasMore.value = result.hasMore;
   } catch (error: any) {
-    // 404 = not analyzed yet (or a stale person ref after re-clustering)
+    // 404 = not analyzed yet
     notAnalyzed.value = error?.response?.status === 404;
-    total.value = 0;
     hasMore.value = false;
   } finally {
     loading.value = false;

--- a/ui/src/components/schedule/AssignPhotographerModal.vue
+++ b/ui/src/components/schedule/AssignPhotographerModal.vue
@@ -1,7 +1,15 @@
 <template>
   <TransitionRoot as="template" :show="show">
     <Dialog as="div" class="relative z-50" @close="emit('closed')">
-      <TransitionChild as="template" enter="ease-out duration-200" enter-from="opacity-0" enter-to="opacity-100" leave="ease-in duration-150" leave-from="opacity-100" leave-to="opacity-0">
+      <TransitionChild
+        as="template"
+        enter="ease-out duration-200"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="ease-in duration-150"
+        leave-from="opacity-100"
+        leave-to="opacity-0"
+      >
         <div class="fixed inset-0 bg-primary-950/60 backdrop-blur-sm transition-opacity"></div>
       </TransitionChild>
 
@@ -16,7 +24,9 @@
             leave-from="opacity-100 scale-100"
             leave-to="opacity-0 scale-95"
           >
-            <DialogPanel class="w-full max-w-sm transform rounded-lg border border-primary-200 bg-surface p-5 text-left shadow-panel transition-all dark:border-primary-800 dark:bg-surface-dark dark:shadow-panel-dark">
+            <DialogPanel
+              class="w-full max-w-sm transform rounded-lg border border-primary-200 bg-surface p-5 text-left shadow-panel transition-all dark:border-primary-800 dark:bg-surface-dark dark:shadow-panel-dark"
+            >
               <DialogTitle as="h3" class="display text-lg text-primary-900 dark:text-white">Assign photographer</DialogTitle>
               <input
                 v-model="query"

--- a/ui/src/components/schedule/ScheduleItemDialog.vue
+++ b/ui/src/components/schedule/ScheduleItemDialog.vue
@@ -32,7 +32,9 @@
               <!-- header -->
               <div class="flex items-start justify-between gap-4 border-b border-primary-100 px-6 py-5 dark:border-primary-800">
                 <div class="flex items-start gap-3">
-                  <span class="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-accent-500/10 text-accent-600 dark:bg-accent-500/15 dark:text-accent-400">
+                  <span
+                    class="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-accent-500/10 text-accent-600 dark:bg-accent-500/15 dark:text-accent-400"
+                  >
                     <CalendarDaysIcon class="h-5 w-5" aria-hidden="true" />
                   </span>
                   <div>
@@ -155,9 +157,11 @@ interface Props {
   create: boolean;
   item?: ScheduleItem | null;
   projectTags: ImageTag[];
+  // create mode: pre-filled window (ISO), e.g. from a drag on the calendar
+  prefill?: { start: string; end: string } | null;
 }
 
-const props = withDefaults(defineProps<Props>(), { item: null });
+const props = withDefaults(defineProps<Props>(), { item: null, prefill: null });
 
 const emit = defineEmits<{
   closed: [];
@@ -184,6 +188,8 @@ watch(
         cardinality: props.item.cardinality,
         tagIds: props.item.tags.map((t) => t.id),
       };
+    } else if (props.prefill) {
+      draft.value = { title: "", description: "", start: toLocal(props.prefill.start), end: toLocal(props.prefill.end), cardinality: 1, tagIds: [] };
     } else {
       const start = DateTime.now().startOf("hour").plus({ hours: 1 });
       draft.value = {

--- a/ui/src/components/schedule/ScheduleItemPopover.vue
+++ b/ui/src/components/schedule/ScheduleItemPopover.vue
@@ -53,6 +53,10 @@
             <UserGroupIcon class="h-4 w-4" />
             Assign
           </button>
+          <button v-if="canManage" type="button" class="pop-btn-secondary" @click="emit('openShifts')">
+            <Squares2X2Icon class="h-4 w-4" />
+            Shifts
+          </button>
         </div>
       </div>
     </div>
@@ -60,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import { UserGroupIcon, UserMinusIcon, UserPlusIcon, XMarkIcon } from "@heroicons/vue/24/outline";
+import { Squares2X2Icon, UserGroupIcon, UserMinusIcon, UserPlusIcon, XMarkIcon } from "@heroicons/vue/24/outline";
 import { DateTime } from "luxon";
 import { computed, onBeforeUnmount, onMounted } from "vue";
 import UserBubble from "src/components/schedule/UserBubble.vue";
@@ -81,6 +85,7 @@ const emit = defineEmits<{
   drop: [];
   unassign: [string];
   openAssign: [];
+  openShifts: [];
 }>();
 
 const status = computed(() => occupancyStatus(props.item?.assignees.length ?? 0, props.item?.cardinality ?? 1));

--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -13,6 +13,12 @@
         @rerun-ai="rerunSelection"
       />
       <div v-if="displayMode === DisplayMode.GRID">
+        <div v-if="personFilter" class="mt-6">
+          <span class="label-mono-sm inline-flex items-center gap-2 rounded-full border border-accent-400/60 px-3 py-1 text-accent-600 dark:text-accent-300">
+            photos of one person
+            <button class="cursor-pointer font-bold hover:text-accent-400" title="Clear person filter" @click="filterByPerson(null)">×</button>
+          </span>
+        </div>
         <div :class="['mt-8 select-none', gridClasses]">
           <ImageGridTile
             v-for="(image, index) in images"
@@ -54,7 +60,7 @@
                   face.personRef ? 'cursor-pointer hover:border-accent-200 hover:bg-accent-400/20' : '',
                 ]"
                 :title="face.personRef ? 'Show photos of this person' : ''"
-                @click="face.personRef && openPersonDialog(face.personRef)"
+                @click="face.personRef && showPersonInGrid(face.personRef)"
               ></div>
             </template>
           </div>
@@ -76,15 +82,7 @@
     @selected="addImageTag"
     :image="images[imageIndex]"
   />
-  <AiImageListDialog
-    :shown="aiDialogVisible"
-    :mode="aiDialogMode"
-    :project-id="activeProject.id"
-    :person-ref="aiDialogPersonRef"
-    :image-id="imageIndex !== -1 ? images[imageIndex]?.id : undefined"
-    @close="aiDialogVisible = false"
-    @select="selectFromAiDialog"
-  />
+  <AiImageListDialog :shown="aiDialogVisible" :image-id="imageIndex !== -1 ? images[imageIndex]?.id : undefined" @close="aiDialogVisible = false" @select="selectFromAiDialog" />
   <UnexpectedErrorMessage :show="showUnexpectedErrorMessage" :error="unexpectedError" @closed="showUnexpectedErrorMessage = false" />
 </template>
 <script setup lang="ts">
@@ -109,7 +107,18 @@ import { faceBoxStyle } from "src/util/aiDetection";
 import * as websocket from "src/util/websocket";
 
 import { DisplayMode, loadImages, triggerInfiniteScroll } from "./imageQueryLogic";
-import { preferredImageSortOrder, searchText, updateSearchText, filterTags, updateFilterTags, aspectRatioFilter, updateAspectRatioFilter, filtered } from "./imageQueryLogic";
+import {
+  preferredImageSortOrder,
+  searchText,
+  updateSearchText,
+  filterTags,
+  updateFilterTags,
+  aspectRatioFilter,
+  updateAspectRatioFilter,
+  filtered,
+  personFilter,
+  filterByPerson,
+} from "./imageQueryLogic";
 import { totalImageCount, images, imageIndex, imageIndices, multiselectStart, multiselectEnd, loading, activeProject } from "./imageQueryLogic";
 import { taggingDialogVisible, addImageTag } from "./imageQueryLogic";
 import { showUnexpectedErrorMessage, unexpectedError } from "./imageQueryLogic";
@@ -195,6 +204,7 @@ function showDetail() {
 onMounted(clearFilterTags);
 function clearFilterTags() {
   filterTags.value = [];
+  personFilter.value = null; // module state survives navigation — fresh mount, fresh view
 }
 
 const taggingDialog = ref<InstanceType<typeof TaggingDialog> | null>(null);
@@ -303,8 +313,6 @@ function scrollToSelectedImage() {
 const faces = ref<AiFace[]>([]);
 const facesVisible = ref(false);
 const aiDialogVisible = ref(false);
-const aiDialogMode = ref<"person" | "similar">("similar");
-const aiDialogPersonRef = ref<string | undefined>(undefined);
 
 emitter.on("ai-toggle-faces", toggleFaces);
 emitter.on("ai-show-similar", showSimilarDialog);
@@ -338,14 +346,17 @@ watch(imageIndex, () => {
   if (facesVisible.value) loadFaces();
 });
 
-function openPersonDialog(personRef: string) {
-  aiDialogMode.value = "person";
-  aiDialogPersonRef.value = personRef;
-  aiDialogVisible.value = true;
+// Clicking a face filters the normal grid by that person — no result dialog.
+function showPersonInGrid(personRef: string) {
+  imageIndex.value = -1;
+  imageIndices.value = [];
+  multiselectStart.value = null;
+  multiselectEnd.value = null;
+  displayMode.value = DisplayMode.GRID;
+  filterByPerson(personRef);
 }
 
 function showSimilarDialog() {
-  aiDialogMode.value = "similar";
   aiDialogVisible.value = true;
 }
 

--- a/ui/src/pages/image/imageListParams.ts
+++ b/ui/src/pages/image/imageListParams.ts
@@ -7,6 +7,7 @@ export function buildImageListParams(input: {
   projectId: string;
   search?: string;
   tags?: { id: string }[];
+  personRef?: string;
   orientation?: string;
   sortOrder?: SORT_ORDER;
   limit?: number;
@@ -19,6 +20,9 @@ export function buildImageListParams(input: {
   }
   if (input.tags && input.tags.length > 0) {
     params.tagId = input.tags.map((t) => t.id); // repeated -> AND
+  }
+  if (input.personRef) {
+    params.personRef = input.personRef;
   }
   if (input.orientation && input.orientation !== "neutral") {
     params.orientation = input.orientation as "portrait" | "landscape";

--- a/ui/src/pages/image/imageQueryLogic.ts
+++ b/ui/src/pages/image/imageQueryLogic.ts
@@ -54,6 +54,14 @@ export function updateAspectRatioFilter(aspectRatioState: string) {
   aspectRatioFilter.value = aspectRatioState;
 }
 
+// Implicit person filter: set by clicking a face box in the detail view,
+// cleared via the chip above the grid. No picker UI — the face IS the picker.
+export const personFilter = ref<string | null>(null);
+export function filterByPerson(personRef: string | null) {
+  personFilter.value = personRef;
+  loadImages(true);
+}
+
 export async function triggerInfiniteScroll() {
   if (totalImageCount.value > 0 && images.value.length < totalImageCount.value) {
     loadImages(false);
@@ -74,12 +82,13 @@ export async function loadImages(reload: boolean) {
   try {
     if (reload) page.value = 1;
 
-    filtered.value = !!searchText.value || filterTags.value.length > 0 || aspectRatioFilter.value !== "neutral";
+    filtered.value = !!searchText.value || filterTags.value.length > 0 || aspectRatioFilter.value !== "neutral" || !!personFilter.value;
 
     const params = buildImageListParams({
       projectId: activeProject.value.id,
       search: searchText.value,
       tags: filterTags.value,
+      personRef: personFilter.value ?? undefined,
       orientation: aspectRatioFilter.value,
       sortOrder: preferredImageSortOrder.value,
       limit: PAGE_SIZE,

--- a/ui/src/pages/schedule/Schedule.vue
+++ b/ui/src/pages/schedule/Schedule.vue
@@ -4,9 +4,7 @@
       <div class="flex flex-wrap items-end justify-between gap-4">
         <div class="min-w-0">
           <h1 class="display text-3xl text-primary-900 dark:text-white">Schedule</h1>
-          <p class="mt-2 text-sm text-primary-500 dark:text-primary-400">
-            Pull items into your schedule — photos you upload from that window get the item's tags suggested.
-          </p>
+          <p class="mt-2 text-sm text-primary-500 dark:text-primary-400">Pull items into your schedule — photos you upload from that window get the item's tags suggested.</p>
         </div>
 
         <div class="flex flex-wrap items-center gap-3">
@@ -75,7 +73,21 @@
             <div class="flex h-9 items-center justify-center border-b border-primary-100 text-sm font-medium text-primary-700 dark:border-primary-800 dark:text-primary-200">
               {{ formatDay(day) }}
             </div>
-            <div class="relative" :class="bodyHeightClass" :data-testid="`day-${dayKey(day)}`">
+            <div
+              class="relative"
+              :class="bodyHeightClass"
+              :data-testid="`day-${dayKey(day)}`"
+              @pointerdown="onColDown(day, $event)"
+              @pointermove="onColMove"
+              @pointerup="onColUp"
+              @pointercancel="dragState = null"
+            >
+              <!-- drag-create ghost -->
+              <div
+                v-if="dragState && dragState.dayKey === dayKey(day)"
+                class="pointer-events-none absolute inset-x-1 z-10 rounded-md border-2 border-dashed border-accent-500 bg-accent-500/10"
+                :style="ghostStyle"
+              ></div>
               <!-- hour grid lines -->
               <div
                 v-for="hour in hourMarks"
@@ -93,17 +105,20 @@
                 :ref="(el) => registerItemEl(entry.item.id, el as HTMLElement | null)"
                 role="button"
                 tabindex="0"
-                @click="openPopover(entry.item)"
-                @keydown.enter="openPopover(entry.item)"
+                @click="openItem(entry.item)"
+                @keydown.enter="openItem(entry.item)"
                 :class="[
                   'group absolute cursor-pointer overflow-hidden rounded-md border-l-4 px-1.5 py-0.5 text-left text-xs shadow-sm transition-shadow hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500',
                   OCCUPANCY_CLASSES[entry.status],
-                  isAssigned(entry.item, userStore.user?.id) ? 'ring-1 ring-accent-500/60' : '',
+                  isAssignedInBlock(entry.item, userStore.user?.id) ? 'ring-1 ring-accent-500/60' : '',
                 ]"
                 :style="entry.style"
               >
                 <p class="truncate pr-5 font-semibold">{{ entry.item.title }}</p>
-                <p class="truncate tabular-nums opacity-75">{{ formatTime(entry.item.start) }}–{{ formatTime(entry.item.end) }}</p>
+                <p class="truncate tabular-nums opacity-75">
+                  {{ formatTime(entry.item.start) }}–{{ formatTime(entry.item.end)
+                  }}<span v-if="entry.item.shifts?.length"> · {{ entry.item.shifts.length }} shift{{ entry.item.shifts.length === 1 ? "" : "s" }}</span>
+                </p>
                 <div v-if="entry.item.assignees.length" class="mt-0.5 flex -space-x-1.5">
                   <UserBubble v-for="assignee in entry.item.assignees.slice(0, 3)" :key="assignee.id" :user="assignee" />
                   <span
@@ -144,6 +159,7 @@
       @drop="unassign(popoverItemId!, userStore.user!.id)"
       @unassign="(userId) => unassign(popoverItemId!, userId)"
       @open-assign="assignModalOpen = true"
+      @open-shifts="router.push({ name: 'schedule-item', params: { id: popoverItemId! } })"
     />
 
     <AssignPhotographerModal :show="assignModalOpen" :candidates="assignCandidates" @closed="assignModalOpen = false" @assign="assignFromModal" />
@@ -153,7 +169,8 @@
       :create="dialogCreate"
       :item="dialogItem"
       :project-tags="projectTags"
-      @closed="dialogOpen = false"
+      :prefill="dialogPrefill"
+      @closed="((dialogOpen = false), (dialogPrefill = null))"
       @save="saveItem"
       @deleted="deleteItem"
     />
@@ -185,14 +202,17 @@ import {
   OCCUPANCY_LABEL,
   OccupancyStatus,
   assignLanes,
+  blockStatus,
   calendarDays,
   dayPosition,
-  isAssigned,
+  isAssignedInBlock,
   itemsOnDay,
-  occupancyStatus,
+  pctToTime,
 } from "src/util/schedule";
 import * as websocket from "src/util/websocket";
+import { useRouter } from "vue-router";
 
+const router = useRouter();
 const userStore = useUserStore();
 const { activeProjectId } = storeToRefs(userStore);
 
@@ -250,7 +270,7 @@ function celebrate(next: ScheduleItem[]) {
   if (statusesPrimed) {
     for (const item of next) {
       const before = statusById.get(item.id);
-      const after = occupancyStatus(item.assignees.length, item.cardinality);
+      const after = blockStatus(item);
       if (before === after || before === undefined) continue;
       if (after === "full" && (before === "empty" || before === "partial")) {
         const origin = originOf(item.id);
@@ -262,7 +282,7 @@ function celebrate(next: ScheduleItem[]) {
     }
   }
   statusById.clear();
-  next.forEach((item) => statusById.set(item.id, occupancyStatus(item.assignees.length, item.cardinality)));
+  next.forEach((item) => statusById.set(item.id, blockStatus(item)));
   statusesPrimed = true;
 }
 
@@ -309,7 +329,7 @@ async function loadContext() {
 const bodyHeightClass = "h-[calc(100dvh-21rem)] min-h-[420px]";
 const hourMarks = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22];
 
-const visibleItems = computed(() => (scope.value === "mine" ? items.value.filter((i) => isAssigned(i, userStore.user?.id)) : items.value));
+const visibleItems = computed(() => (scope.value === "mine" ? items.value.filter((i) => isAssignedInBlock(i, userStore.user?.id)) : items.value));
 const days = computed(() => calendarDays(project.value ?? {}, visibleItems.value.length ? visibleItems.value : items.value));
 
 interface DayEntry {
@@ -327,7 +347,7 @@ function dayEntries(day: Date): DayEntry[] {
     const widthPct = 100 / lane.lanes;
     return {
       item,
-      status: occupancyStatus(item.assignees.length, item.cardinality),
+      status: blockStatus(item),
       style: {
         top: `${pos.topPct}%`,
         height: `${pos.heightPct}%`,
@@ -348,6 +368,16 @@ const popoverItemId = ref<string | null>(null);
 const popoverPosition = ref({ x: 0, y: 0 });
 const popoverItem = computed(() => items.value.find((i) => i.id === popoverItemId.value) ?? null);
 
+// A subdivided block opens its detail page (shifts are claimed there); a
+// plain item keeps the quick claim popover.
+function openItem(item: ScheduleItem) {
+  if (item.shifts?.length) {
+    router.push({ name: "schedule-item", params: { id: item.id } });
+    return;
+  }
+  openPopover(item);
+}
+
 function openPopover(item: ScheduleItem) {
   const el = itemEls.get(item.id);
   if (el) {
@@ -365,12 +395,55 @@ function openPopover(item: ScheduleItem) {
 const dialogOpen = ref(false);
 const dialogCreate = ref(false);
 const dialogItem: Ref<ScheduleItem | null> = ref(null);
+const dialogPrefill: Ref<{ start: string; end: string } | null> = ref(null);
 
-function openCreate() {
+function openCreate(prefill: { start: string; end: string } | null = null) {
+  dialogPrefill.value = prefill;
   dialogCreate.value = true;
   dialogItem.value = null;
   dialogOpen.value = true;
 }
+
+// --- drag-create: pull a time span open on a day column (admins) -------------
+
+const dragState = ref<{ dayKey: string; day: Date; fromPct: number; toPct: number } | null>(null);
+
+function colPct(e: PointerEvent): number {
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  return Math.min(100, Math.max(0, ((e.clientY - rect.top) / rect.height) * 100));
+}
+
+function onColDown(day: Date, e: PointerEvent) {
+  if (!canManage.value) return;
+  if ((e.target as HTMLElement).closest("[data-testid^='schedule-item-']")) return; // item clicks stay item clicks
+  (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  const pct = colPct(e);
+  dragState.value = { dayKey: dayKey(day), day, fromPct: pct, toPct: pct };
+}
+
+function onColMove(e: PointerEvent) {
+  if (!dragState.value) return;
+  dragState.value.toPct = colPct(e);
+}
+
+function onColUp() {
+  const d = dragState.value;
+  dragState.value = null;
+  if (!d) return;
+  const [a, b] = [Math.min(d.fromPct, d.toPct), Math.max(d.fromPct, d.toPct)];
+  if (b - a < 2) return; // a click, not a drag
+  const start = pctToTime(d.day, a);
+  const end = pctToTime(d.day, b);
+  if (end.getTime() <= start.getTime()) return;
+  openCreate({ start: start.toISOString(), end: end.toISOString() });
+}
+
+const ghostStyle = computed(() => {
+  const d = dragState.value;
+  if (!d) return {};
+  const top = Math.min(d.fromPct, d.toPct);
+  return { top: `${top}%`, height: `${Math.abs(d.toPct - d.fromPct)}%` };
+});
 
 function openEdit(item: ScheduleItem) {
   popoverItemId.value = null;
@@ -388,8 +461,15 @@ function syncOpenItem() {
 async function saveItem(payload: ScheduleItemCreate | ScheduleItemUpdate) {
   try {
     if (dialogCreate.value) {
-      await api.scheduleItems.create({ ...(payload as ScheduleItemCreate), projectId: activeProjectId.value });
+      const created = await api.scheduleItems.create({ ...(payload as ScheduleItemCreate), projectId: activeProjectId.value });
       showNotificationToast({ headline: "Schedule item added", type: "success" });
+      if (dialogPrefill.value) {
+        // drag-created blocks flow straight into the detail page to add shifts
+        dialogOpen.value = false;
+        dialogPrefill.value = null;
+        router.push({ name: "schedule-item", params: { id: created.id } });
+        return;
+      }
     } else if (dialogItem.value) {
       await api.scheduleItems.update(dialogItem.value.id, payload);
       showNotificationToast({ headline: "Schedule item saved", type: "success" });

--- a/ui/src/pages/schedule/ScheduleItemDetail.vue
+++ b/ui/src/pages/schedule/ScheduleItemDetail.vue
@@ -1,0 +1,386 @@
+<template>
+  <div class="mx-auto w-full max-w-4xl px-4 pb-16 pt-6 sm:px-6 lg:px-8">
+    <router-link :to="{ name: 'schedule' }" class="inline-flex items-center gap-1.5 text-sm font-medium text-accent-600 hover:text-accent-500 dark:text-accent-400">
+      <ArrowLeftIcon class="h-4 w-4" />
+      Schedule
+    </router-link>
+
+    <div v-if="item" class="mt-4">
+      <!-- block header -->
+      <div class="rounded-lg border border-primary-200 bg-surface p-5 dark:border-primary-800 dark:bg-surface-dark">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="min-w-0">
+            <h1 class="display text-2xl text-primary-900 dark:text-white">{{ item.title }}</h1>
+            <p class="mt-1 text-sm tabular-nums text-primary-500 dark:text-primary-400">{{ windowLabel(item) }}</p>
+            <p v-if="item.description" class="mt-2 max-w-prose text-sm text-primary-600 dark:text-primary-300">{{ item.description }}</p>
+          </div>
+          <div class="flex items-center gap-2">
+            <span :class="['rounded-full border px-2.5 py-1 text-xs font-medium', OCCUPANCY_CLASSES[status]]">{{ OCCUPANCY_LABEL[status] }}</span>
+            <button v-if="canManage" type="button" class="btn-secondary" @click="editOpen = true">
+              <PencilIcon class="h-4 w-4" />
+              Edit
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- shifts -->
+      <div class="mt-6">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <h2 class="text-lg font-semibold text-primary-900 dark:text-white">Shifts</h2>
+          <div v-if="canManage" class="flex flex-wrap gap-2">
+            <button
+              v-for="minutes in [60, 90, 120]"
+              :key="minutes"
+              type="button"
+              class="btn-secondary"
+              :disabled="!nextShiftWindow(item, minutes)"
+              @click="quickAdd(minutes, 'item')"
+            >
+              <PlusIcon class="h-4 w-4" />
+              {{ minutes }} min
+            </button>
+            <button type="button" class="btn-secondary" :disabled="!nextShiftWindow(item, 60)" @click="quickAdd(60, 'break')">
+              <PauseIcon class="h-4 w-4" />
+              Break
+            </button>
+          </div>
+        </div>
+
+        <p v-if="!shifts.length" class="mt-4 text-sm text-primary-400">
+          No shifts yet — the whole block is claimed as one piece.
+          <template v-if="canManage">Add shifts to subdivide it.</template>
+        </p>
+
+        <ul class="mt-3 space-y-2">
+          <li
+            v-for="shift in shifts"
+            :key="shift.id"
+            :data-testid="`shift-${shift.id}`"
+            :class="[
+              'rounded-lg border p-4',
+              shift.kind === 'break'
+                ? 'border-dashed border-primary-300 bg-primary-100/50 dark:border-primary-700 dark:bg-primary-900/40'
+                : 'border-primary-200 bg-surface dark:border-primary-800 dark:bg-surface-dark',
+            ]"
+          >
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <div class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5">
+                <span v-if="shift.kind === 'break'" class="label-mono-sm inline-flex items-center gap-1 text-primary-500 dark:text-primary-400">
+                  <PauseIcon class="h-4 w-4" /> Break
+                </span>
+                <template v-if="canManage">
+                  <input :value="drafts[shift.id]?.start" type="datetime-local" class="input-field w-auto" @change="commitWindow(shift, 'start', $event)" />
+                  <span class="text-primary-400">–</span>
+                  <input :value="drafts[shift.id]?.end" type="datetime-local" class="input-field w-auto" @change="commitWindow(shift, 'end', $event)" />
+                </template>
+                <span v-else class="text-sm tabular-nums text-primary-700 dark:text-primary-200">{{ windowLabel(shift) }}</span>
+                <span class="label-mono-sm text-primary-400">{{ durationLabel(shift) }}</span>
+                <label v-if="canManage && shift.kind !== 'break'" class="inline-flex items-center gap-1.5 text-xs text-primary-500 dark:text-primary-400">
+                  target
+                  <input :value="shift.cardinality" type="number" min="1" class="input-field w-16" @change="commitCardinality(shift, $event)" />
+                </label>
+                <span v-if="shift.kind !== 'break'" :class="['rounded-full border px-2 py-0.5 text-[10px] font-medium', OCCUPANCY_CLASSES[shiftStatus(shift)]]">
+                  {{ shift.assignees.length }}/{{ shift.cardinality }}
+                </span>
+              </div>
+              <button
+                v-if="canManage"
+                type="button"
+                class="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-primary-400 transition-colors hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400"
+                :aria-label="`Delete ${shift.kind === 'break' ? 'break' : 'shift'}`"
+                @click="removeShift(shift)"
+              >
+                <TrashIcon class="h-4 w-4" />
+              </button>
+            </div>
+
+            <div v-if="shift.kind !== 'break'" class="mt-3 flex flex-wrap items-center gap-3">
+              <div class="flex items-center -space-x-1.5">
+                <UserBubble v-for="assignee in shift.assignees" :key="assignee.id" :user="assignee" />
+              </div>
+              <span v-if="!shift.assignees.length" class="text-sm text-primary-400">Nobody yet — be the first.</span>
+              <div class="ml-auto flex flex-wrap gap-2">
+                <button v-if="canJoin" type="button" :class="isAssigned(shift, userStore.user?.id) ? 'btn-secondary' : 'btn-primary'" @click="toggleClaim(shift)">
+                  <UserMinusIcon v-if="isAssigned(shift, userStore.user?.id)" class="h-4 w-4" />
+                  <UserPlusIcon v-else class="h-4 w-4" />
+                  {{ isAssigned(shift, userStore.user?.id) ? "Leave" : "Take this shift" }}
+                </button>
+                <button v-if="canManage" type="button" class="btn-secondary" @click="assignShiftId = shift.id">
+                  <UserGroupIcon class="h-4 w-4" />
+                  Assign
+                </button>
+              </div>
+            </div>
+            <ul v-if="canManage && shift.assignees.length" class="mt-2 space-y-1">
+              <li v-for="assignee in shift.assignees" :key="assignee.id" class="flex items-center justify-between gap-2 text-sm text-primary-600 dark:text-primary-300">
+                <span class="truncate">{{ assignee.firstName }} {{ assignee.lastName }}</span>
+                <button
+                  type="button"
+                  class="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-primary-400 transition-colors hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400"
+                  :aria-label="`Remove ${assignee.firstName} ${assignee.lastName}`"
+                  @click="unassign(shift, assignee.id)"
+                >
+                  <XMarkIcon class="h-4 w-4" />
+                </button>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <AssignPhotographerModal :show="assignShiftId !== null" :candidates="assignCandidates" @closed="assignShiftId = null" @assign="assignFromModal" />
+    <ScheduleItemDialog :show="editOpen" :create="false" :item="item" :project-tags="projectTags" @closed="editOpen = false" @save="saveBlock" @deleted="deleteBlock" />
+    <UnexpectedErrorMessage :show="showUnexpectedErrorMessage" :error="unexpectedError" @closed="showUnexpectedErrorMessage = false" />
+  </div>
+</template>
+
+<script setup lang="ts">
+// Detail page of one schedule block: edit the frame (admins), subdivide it
+// into shifts and breaks (quick-add 60/90/120, freely editable windows), and
+// claim individual shifts. Reached from the calendar (subdivided blocks open
+// here; plain items via the popover's "Shifts" button).
+import { ArrowLeftIcon, PauseIcon, PencilIcon, PlusIcon, TrashIcon, UserGroupIcon, UserMinusIcon, UserPlusIcon, XMarkIcon } from "@heroicons/vue/24/outline";
+import { DateTime } from "luxon";
+import { computed, onBeforeUnmount, onMounted, ref, Ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { api } from "src/api";
+import { ScheduleItemCreate, ScheduleItemUpdate } from "src/api/scheduleItems";
+import AssignPhotographerModal from "src/components/schedule/AssignPhotographerModal.vue";
+import ScheduleItemDialog from "src/components/schedule/ScheduleItemDialog.vue";
+import UserBubble from "src/components/schedule/UserBubble.vue";
+import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
+import { showNotificationToast } from "src/boot/mitt";
+import { useUserStore } from "src/stores/user-store";
+import { EmbeddedUser, ImageTag, ScheduleItem } from "src/types/api";
+import { OCCUPANCY_CLASSES, OCCUPANCY_LABEL, blockStatus, isAssigned, nextShiftWindow, occupancyStatus } from "src/util/schedule";
+import * as websocket from "src/util/websocket";
+
+const route = useRoute();
+const router = useRouter();
+const userStore = useUserStore();
+
+const canManage = computed(() => userStore.isProjectAdminOrHigher());
+const canJoin = computed(() => userStore.isProjectEditorOrHigher());
+
+const item: Ref<ScheduleItem | null> = ref(null);
+const projectTags: Ref<ImageTag[]> = ref([]);
+const members: Ref<EmbeddedUser[]> = ref([]);
+const editOpen = ref(false);
+
+const showUnexpectedErrorMessage = ref(false);
+const unexpectedError = ref(null);
+
+const shifts = computed(() => item.value?.shifts ?? []);
+const status = computed(() => (item.value ? blockStatus(item.value) : "empty"));
+const shiftStatus = (s: ScheduleItem) => occupancyStatus(s.assignees.length, s.cardinality);
+
+// datetime-local drafts per shift, refreshed on every (re)load
+const drafts = ref<Record<string, { start: string; end: string }>>({});
+const toLocal = (iso: string) => DateTime.fromISO(iso).toFormat("yyyy-MM-dd'T'HH:mm");
+const toISO = (local: string) => DateTime.fromISO(local).toUTC().toISO() ?? "";
+
+function windowLabel(it: { start: string; end: string }): string {
+  const s = DateTime.fromISO(it.start);
+  const e = DateTime.fromISO(it.end);
+  return s.hasSame(e, "day") ? `${s.toFormat("ccc dd.LL. HH:mm")} – ${e.toFormat("HH:mm")}` : `${s.toFormat("ccc dd.LL. HH:mm")} – ${e.toFormat("ccc dd.LL. HH:mm")}`;
+}
+
+function durationLabel(it: { start: string; end: string }): string {
+  const minutes = DateTime.fromISO(it.end).diff(DateTime.fromISO(it.start), "minutes").minutes;
+  return `${Math.round(minutes)} min`;
+}
+
+async function load() {
+  try {
+    item.value = await api.scheduleItems.get(route.params.id as string);
+    drafts.value = Object.fromEntries((item.value.shifts ?? []).map((s) => [s.id, { start: toLocal(s.start), end: toLocal(s.end) }]));
+  } catch (error: any) {
+    unexpectedError.value = error;
+    showUnexpectedErrorMessage.value = true;
+  }
+}
+
+async function loadContext() {
+  if (!canManage.value || !item.value) return;
+  try {
+    const [tags, assignments] = await Promise.all([
+      api.imageTags.list({ projectId: item.value.project.id, limit: 500, sort: "name", order: "asc" }),
+      api.projectAssignments.list({ projectId: item.value.project.id, limit: 500 }),
+    ]);
+    projectTags.value = tags.items;
+    const seen = new Map<string, EmbeddedUser>();
+    assignments.items.forEach((a) => seen.set(a.user.id, a.user));
+    members.value = [...seen.values()];
+  } catch (error: any) {
+    unexpectedError.value = error;
+    showUnexpectedErrorMessage.value = true;
+  }
+}
+
+// API errors here are mostly rule violations (shift_outside_block …) — show
+// the server's message instead of the generic error modal.
+function toastApiError(error: any) {
+  const message = error?.response?.data?.message;
+  if (message) {
+    showNotificationToast({ headline: message, type: "warning" });
+  } else {
+    unexpectedError.value = error;
+    showUnexpectedErrorMessage.value = true;
+  }
+}
+
+// --- shift management (admins) ----------------------------------------------
+
+async function quickAdd(minutes: number, kind: "item" | "break") {
+  if (!item.value) return;
+  const window = nextShiftWindow(item.value, minutes);
+  if (!window) return;
+  try {
+    await api.scheduleItems.create({
+      title: kind === "break" ? "Break" : `Shift ${shifts.value.filter((s) => s.kind !== "break").length + 1}`,
+      start: window.start.toISOString(),
+      end: window.end.toISOString(),
+      projectId: item.value.project.id,
+      parentId: item.value.id,
+      kind,
+    });
+    await load();
+  } catch (error: any) {
+    toastApiError(error);
+  }
+}
+
+async function commitWindow(shift: ScheduleItem, field: "start" | "end", event: Event) {
+  const local = (event.target as HTMLInputElement).value;
+  if (!local) return;
+  try {
+    await api.scheduleItems.update(shift.id, { [field]: toISO(local) } as ScheduleItemUpdate);
+  } catch (error: any) {
+    toastApiError(error);
+  }
+  await load(); // reload either way — a rejected edit resets the input
+}
+
+async function commitCardinality(shift: ScheduleItem, event: Event) {
+  const value = Number((event.target as HTMLInputElement).value);
+  if (!Number.isInteger(value) || value < 1) return;
+  try {
+    await api.scheduleItems.update(shift.id, { cardinality: value });
+  } catch (error: any) {
+    toastApiError(error);
+  }
+  await load();
+}
+
+async function removeShift(shift: ScheduleItem) {
+  try {
+    await api.scheduleItems.remove(shift.id);
+    await load();
+  } catch (error: any) {
+    toastApiError(error);
+  }
+}
+
+// --- claiming ---------------------------------------------------------------
+
+async function toggleClaim(shift: ScheduleItem) {
+  const userId = userStore.user?.id;
+  if (!userId) return;
+  try {
+    if (isAssigned(shift, userId)) {
+      await api.scheduleItems.unassign(shift.id, userId);
+    } else {
+      await api.scheduleItems.assign(shift.id, userId);
+    }
+    await load();
+  } catch (error: any) {
+    toastApiError(error);
+  }
+}
+
+async function unassign(shift: ScheduleItem, userId: string) {
+  try {
+    await api.scheduleItems.unassign(shift.id, userId);
+    await load();
+  } catch (error: any) {
+    toastApiError(error);
+  }
+}
+
+const assignShiftId = ref<string | null>(null);
+const assignCandidates = computed(() => {
+  const shift = shifts.value.find((s) => s.id === assignShiftId.value);
+  const assigned = new Set(shift?.assignees.map((a) => a.id));
+  return members.value.filter((m) => !assigned.has(m.id));
+});
+
+async function assignFromModal(userId: string) {
+  const shiftId = assignShiftId.value;
+  assignShiftId.value = null;
+  if (!shiftId) return;
+  try {
+    await api.scheduleItems.assign(shiftId, userId);
+    await load();
+  } catch (error: any) {
+    toastApiError(error);
+  }
+}
+
+// --- block edit / delete ----------------------------------------------------
+
+async function saveBlock(payload: ScheduleItemCreate | ScheduleItemUpdate) {
+  if (!item.value) return;
+  try {
+    await api.scheduleItems.update(item.value.id, payload as ScheduleItemUpdate);
+    editOpen.value = false;
+    showNotificationToast({ headline: "Schedule item saved", type: "success" });
+    await load();
+  } catch (error: any) {
+    toastApiError(error);
+  }
+}
+
+async function deleteBlock() {
+  if (!item.value) return;
+  try {
+    await api.scheduleItems.remove(item.value.id);
+    showNotificationToast({ headline: "Schedule item deleted", type: "success" });
+    router.push({ name: "schedule" });
+  } catch (error: any) {
+    toastApiError(error);
+  }
+}
+
+// --- live updates -------------------------------------------------------------
+
+let wsListenerId = "";
+
+onMounted(async () => {
+  await load();
+  await loadContext();
+  websocket.connect();
+  wsListenerId = websocket.on({ object: "scheduleItem", action: "changed" }, (message) => {
+    if (message.data?.projectId === item.value?.project.id) {
+      load();
+    }
+  });
+});
+
+onBeforeUnmount(() => {
+  if (wsListenerId) websocket.off(wsListenerId);
+});
+</script>
+
+<style scoped>
+.input-field {
+  @apply block rounded-md border border-primary-200 bg-surface px-2.5 py-1.5 text-sm text-primary-900 shadow-sm focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-primary-700 dark:bg-surface-dark dark:text-white;
+}
+.btn-primary {
+  @apply inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-accent-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition-colors hover:bg-accent-500 active:bg-accent-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 disabled:cursor-not-allowed disabled:opacity-50;
+}
+.btn-secondary {
+  @apply inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-primary-200 bg-surface px-3 py-1.5 text-xs font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:text-white;
+}
+</style>

--- a/ui/src/router/routes.ts
+++ b/ui/src/router/routes.ts
@@ -25,6 +25,11 @@ const routes: RouteRecordRaw[] = [
         component: () => import("pages/schedule/Schedule.vue"),
       },
       {
+        name: "schedule-item",
+        path: "/schedule/items/:id",
+        component: () => import("pages/schedule/ScheduleItemDetail.vue"),
+      },
+      {
         name: "sandbox",
         path: "/sandbox",
         component: () => import("pages/Sandbox.vue"),

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -137,7 +137,9 @@ export interface Project {
 }
 
 // One coverable block of the event schedule (S15). cardinality is the TARGET
-// headcount, not a cap — overbooking is allowed (violett).
+// headcount, not a cap — overbooking is allowed (violett). A block may be
+// subdivided into shifts (nested, one level; kind=break marks an unclaimable
+// pause tile) — claiming then happens on the shifts.
 export interface ScheduleItem {
   id: string;
   title: string;
@@ -145,8 +147,11 @@ export interface ScheduleItem {
   start: string;
   end: string;
   cardinality: number;
+  kind: "item" | "break";
+  parentId: string; // "" for top-level blocks
   assignees: EmbeddedUser[];
   tags: EmbeddedTag[];
+  shifts?: ScheduleItem[]; // present on top-level items only, start-ordered
   project: EmbeddedProject;
   createdAt: string;
   updatedAt: string;

--- a/ui/src/util/schedule.ts
+++ b/ui/src/util/schedule.ts
@@ -61,11 +61,7 @@ function daySpan(from: Date, to: Date, cap: number): Date[] {
 // calendarDays: the day columns to render. Project period wins; without one
 // the span of the existing items; without items the current week (Mon–Sun).
 // Capped at 31 columns so a typo'd period cannot render a year.
-export function calendarDays(
-  project: { startAt?: string | null; endAt?: string | null },
-  items: ScheduleItemLike[],
-  now: Date = new Date(),
-): Date[] {
+export function calendarDays(project: { startAt?: string | null; endAt?: string | null }, items: ScheduleItemLike[], now: Date = new Date()): Date[] {
   const cap = 31;
   if (project.startAt && project.endAt) {
     const from = new Date(project.startAt);
@@ -148,4 +144,53 @@ export function assignLanes(items: ScheduleItemLike[]): Map<string, { lane: numb
 // isAssigned: whether the user covers this item.
 export function isAssigned(item: ScheduleItemLike, userId: string | undefined): boolean {
   return !!userId && item.assignees.some((a) => a.id === userId);
+}
+
+// --- blocks with shifts ------------------------------------------------------
+
+export interface BlockLike extends ScheduleItemLike {
+  kind?: string;
+  shifts?: (ScheduleItemLike & { kind?: string })[];
+}
+
+// claimableShifts: the shifts that count for coverage — breaks never do.
+export function claimableShifts(item: BlockLike): (ScheduleItemLike & { kind?: string })[] {
+  return (item.shifts ?? []).filter((s) => s.kind !== "break");
+}
+
+// blockStatus: occupancy of a calendar tile. A plain item scores itself; a
+// subdivided block aggregates its claimable shifts — full only when every
+// shift is covered, over when covered with at least one overbooked shift.
+export function blockStatus(item: BlockLike): OccupancyStatus {
+  const shifts = claimableShifts(item);
+  if (shifts.length === 0) return occupancyStatus(item.assignees.length, item.cardinality);
+  const statuses = shifts.map((s) => occupancyStatus(s.assignees.length, s.cardinality));
+  if (statuses.every((s) => s === "empty")) return "empty";
+  if (statuses.some((s) => s === "empty" || s === "partial")) return "partial";
+  return statuses.some((s) => s === "over") ? "over" : "full";
+}
+
+// isAssignedInBlock: the user covers the item itself or one of its shifts.
+export function isAssignedInBlock(item: BlockLike, userId: string | undefined): boolean {
+  return isAssigned(item, userId) || (item.shifts ?? []).some((s) => isAssigned(s, userId));
+}
+
+// nextShiftWindow: where a quick-added shift of the given length lands —
+// after the last existing shift (or at the block start), clamped to the block.
+// null when there is no room left.
+export function nextShiftWindow(block: BlockLike, minutes: number): { start: Date; end: Date } | null {
+  const blockStart = new Date(block.start).getTime();
+  const blockEnd = new Date(block.end).getTime();
+  const lastEnd = Math.max(blockStart, ...(block.shifts ?? []).map((s) => new Date(s.end).getTime()));
+  const end = Math.min(lastEnd + minutes * 60_000, blockEnd);
+  if (end <= lastEnd) return null;
+  return { start: new Date(lastEnd), end: new Date(end) };
+}
+
+// pctToTime: invert the calendar's percentage-of-24h mapping (drag-create),
+// snapped to 15-minute steps.
+export function pctToTime(day: Date, pct: number, snapMinutes = 15): Date {
+  const minutes = (Math.min(100, Math.max(0, pct)) / 100) * 24 * 60;
+  const snapped = Math.round(minutes / snapMinutes) * snapMinutes;
+  return new Date(startOfDay(day).getTime() + snapped * 60_000);
 }

--- a/ui/tests/imageListParams.spec.ts
+++ b/ui/tests/imageListParams.spec.ts
@@ -40,6 +40,11 @@ describe("buildImageListParams (UI state -> §4.3 list params)", () => {
     expect(params.tagId).toBeUndefined();
   });
 
+  it("maps the implicit person filter and drops it when unset", () => {
+    expect(buildImageListParams({ projectId: "p1", personRef: "person-7" }).personRef).toBe("person-7");
+    expect(buildImageListParams({ projectId: "p1" }).personRef).toBeUndefined();
+  });
+
   it("maps the updated-sort orders to updatedAt", () => {
     expect(buildImageListParams({ projectId: "p", sortOrder: SORT_ORDER.MOST_RECENTLY_UPDATED })).toMatchObject({ sort: "updatedAt", order: "desc" });
     expect(buildImageListParams({ projectId: "p", sortOrder: SORT_ORDER.LEAST_RECENTLY_UPDATED })).toMatchObject({ sort: "updatedAt", order: "asc" });

--- a/ui/tests/schedule.spec.ts
+++ b/ui/tests/schedule.spec.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { assignLanes, calendarDays, dayPosition, isAssigned, itemsOnDay, occupancyStatus, startOfDay, ScheduleItemLike } from "src/util/schedule";
+import {
+  assignLanes,
+  blockStatus,
+  calendarDays,
+  dayPosition,
+  isAssigned,
+  isAssignedInBlock,
+  itemsOnDay,
+  nextShiftWindow,
+  occupancyStatus,
+  pctToTime,
+  startOfDay,
+  ScheduleItemLike,
+} from "src/util/schedule";
 
 function item(id: string, start: string, end: string, cardinality = 1, assignees: string[] = []): ScheduleItemLike {
   return { id, start, end, cardinality, assignees: assignees.map((a) => ({ id: a })) };
@@ -102,5 +115,60 @@ describe("isAssigned", () => {
     expect(isAssigned(a, "u1")).toBe(true);
     expect(isAssigned(a, "u2")).toBe(false);
     expect(isAssigned(a, undefined)).toBe(false);
+  });
+});
+
+describe("blockStatus", () => {
+  const block = (shifts: (ScheduleItemLike & { kind?: string })[]) => ({
+    ...item("b", "2026-08-11T08:00:00", "2026-08-11T18:00:00"),
+    shifts,
+  });
+  it("falls back to own occupancy without shifts", () => {
+    expect(blockStatus(item("a", "2026-08-11T08:00:00", "2026-08-11T10:00:00", 1, ["u1"]))).toBe("full");
+  });
+  it("aggregates claimable shifts and ignores breaks", () => {
+    const s1 = item("s1", "2026-08-11T08:00:00", "2026-08-11T09:30:00", 1, ["u1"]);
+    const s2 = item("s2", "2026-08-11T11:00:00", "2026-08-11T12:30:00", 1, []);
+    const pause = { ...item("p", "2026-08-11T09:30:00", "2026-08-11T11:00:00"), kind: "break" };
+    expect(blockStatus(block([s1, s2, pause]))).toBe("partial");
+    expect(blockStatus(block([s1, pause]))).toBe("full");
+    expect(blockStatus(block([{ ...s2 }, pause]))).toBe("empty");
+    const over = item("s3", "2026-08-11T11:00:00", "2026-08-11T12:30:00", 1, ["u1", "u2"]);
+    expect(blockStatus(block([s1, over, pause]))).toBe("over");
+  });
+});
+
+describe("isAssignedInBlock", () => {
+  it("matches through a claimed shift", () => {
+    const b = { ...item("b", "2026-08-11T08:00:00", "2026-08-11T18:00:00"), shifts: [item("s", "2026-08-11T08:00:00", "2026-08-11T09:00:00", 1, ["u1"])] };
+    expect(isAssignedInBlock(b, "u1")).toBe(true);
+    expect(isAssignedInBlock(b, "u2")).toBe(false);
+  });
+});
+
+describe("nextShiftWindow", () => {
+  const block = (shifts: ScheduleItemLike[] = []) => ({ ...item("b", "2026-08-11T08:00:00", "2026-08-11T12:00:00"), shifts });
+  it("starts at the block start when empty", () => {
+    const w = nextShiftWindow(block(), 90)!;
+    expect(w.start).toEqual(new Date("2026-08-11T08:00:00"));
+    expect(w.end).toEqual(new Date("2026-08-11T09:30:00"));
+  });
+  it("appends after the last shift and clamps to the block end", () => {
+    const w = nextShiftWindow(block([item("s", "2026-08-11T08:00:00", "2026-08-11T11:00:00")]), 120)!;
+    expect(w.start).toEqual(new Date("2026-08-11T11:00:00"));
+    expect(w.end).toEqual(new Date("2026-08-11T12:00:00")); // clamped
+  });
+  it("returns null when the block is full", () => {
+    expect(nextShiftWindow(block([item("s", "2026-08-11T08:00:00", "2026-08-11T12:00:00")]), 60)).toBeNull();
+  });
+});
+
+describe("pctToTime", () => {
+  const day = new Date("2026-08-11T00:00:00");
+  it("maps percentages onto the 24h axis with 15min snapping", () => {
+    expect(pctToTime(day, 50)).toEqual(new Date("2026-08-11T12:00:00"));
+    expect(pctToTime(day, 34.9)).toEqual(new Date("2026-08-11T08:30:00"));
+    expect(pctToTime(day, -5)).toEqual(new Date("2026-08-11T00:00:00"));
+    expect(pctToTime(day, 105)).toEqual(new Date("2026-08-12T00:00:00"));
   });
 });


### PR DESCRIPTION
Three changes in one cut:

Scheduling: blocks can be subdivided into shifts — self-referential
ScheduleItem (parentId, one level, kind item|break, cascade delete).
Claiming moves to the shifts of a subdivided block; breaks are never
claimable. Calendar gains drag-create (15-min snap) and aggregate
block coloring; new detail page /schedule/items/:id with quick-add
60/90/120-min shifts, break tiles, free window editing, and per-shift
claim/assign. The upload timeline keeps consuming top-level items only.

Person search: clicking a face filters the normal image grid implicitly
by person (GET /images?personRef= resolves ids via the AI server) with
a clearable chip; the AI dialog is similar-images-only now, replacing
the person result list and its cross-project toggle (the crossProject
API param stays).

AI detection: AI_TIMEOUT default 60s -> 180s; a deadline-exceeded
inference requeues at the BACK of the FIFO without arming the global
backoff, still dead-lettering after maxAIAttempts.
