### PR TITLE
feat: calendar views, popover shift claiming, grid history nav, AI + EXIF fixes

### DIFF
--- a/api/internal/repository/repository.go
+++ b/api/internal/repository/repository.go
@@ -92,10 +92,13 @@ func (p *PaginationParameters) build(allow map[string]string, defaultKey string)
 	if !ok {
 		return 0, 0, nil, ErrInvalidSort
 	}
+	// Secondary sort by id: equal primary keys otherwise come back in the DB's
+	// physical row order, which changes whenever ANY row is updated — the
+	// calendar's parallel lanes visibly reshuffled on unrelated claims.
 	if p.Order == "asc" {
-		return limit, offset, ent.Asc(col), nil
+		return limit, offset, func(s *sql.Selector) { ent.Asc(col)(s); ent.Asc("id")(s) }, nil
 	}
-	return limit, offset, ent.Desc(col), nil
+	return limit, offset, func(s *sql.Selector) { ent.Desc(col)(s); ent.Asc("id")(s) }, nil
 }
 
 // modelUpdateStatus tracks field-level changes during an Update so a no-op

--- a/api/internal/server/ai_controller.go
+++ b/api/internal/server/ai_controller.go
@@ -33,6 +33,7 @@ const (
 func (s *Server) registerAIRoutes(api *gin.RouterGroup) {
 	api.GET("/projects/:id/ai/status", s.aiQueueStatus)
 	api.POST("/projects/:id/ai/rerun", s.aiRerunBatch)
+	api.POST("/projects/:id/ai/rerun-failed", s.aiRerunFailed)
 	api.GET("/projects/:id/ai/persons/:personRef/images", s.aiPersonImages)
 	api.GET("/uploads/:id/ai", s.aiUploadStatus)
 	api.POST("/uploads/:id/ai/rerun", s.aiRerunUpload)
@@ -197,6 +198,29 @@ func (s *Server) aiRerunUpload(c *gin.Context) {
 		q = q.Where(entimage.AiStatusEQ(entimage.AiStatusError))
 	}
 	ids, err := q.IDs(c.Request.Context())
+	if err != nil {
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	for _, imageID := range ids {
+		s.ai.Enqueue(imageID)
+	}
+	c.JSON(http.StatusOK, gin.H{"queued": len(ids)})
+}
+
+// aiRerunFailed re-queues every dead-lettered (aiStatus=error) image of the
+// project. Settings-page action, so projectAdmin+ (CanEditProject).
+func (s *Server) aiRerunFailed(c *gin.Context) {
+	projectID, ok := getIdParam(c)
+	if !ok {
+		return
+	}
+	if !allow(c, authorization.CanEditProject(authUser(c), projectID)) {
+		return
+	}
+	ids, err := s.Repository.Client.Image.Query().
+		Where(entimage.ProjectID(projectID), entimage.AiStatusEQ(entimage.AiStatusError)).
+		IDs(c.Request.Context())
 	if err != nil {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return

--- a/api/internal/server/ai_controller_test.go
+++ b/api/internal/server/ai_controller_test.go
@@ -193,6 +193,37 @@ func TestAIRerunBatchScopesToProject(t *testing.T) {
 	assert.Equal(t, 2, body.Queued)
 }
 
+// rerun-failed re-queues exactly the dead-lettered images of the project;
+// non-admins without projectAdmin are refused.
+func TestAIRerunFailed(t *testing.T) {
+	s, m := newAITestServer(t)
+	ctx := context.Background()
+	s.Repository.Client.Image.UpdateOneID(m.Images[0]).SetAiStatus(entimage.AiStatusError).SetAiAttempts(3).SaveX(ctx)
+	s.Repository.Client.Image.UpdateOneID(m.Images[1]).SetAiStatus(entimage.AiStatusDone).SaveX(ctx)
+
+	c, rec := aiCtx(t, plainUser(), http.MethodPost, "/api/v1/projects/"+m.Project+"/ai/rerun-failed", "")
+	c.Params = gin.Params{{Key: "id", Value: m.Project}}
+	s.aiRerunFailed(c)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	c, rec = aiCtx(t, adminUser(), http.MethodPost, "/api/v1/projects/"+m.Project+"/ai/rerun-failed", "")
+	c.Params = gin.Params{{Key: "id", Value: m.Project}}
+	s.aiRerunFailed(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Queued int `json:"queued"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, 1, body.Queued)
+
+	row := s.Repository.Client.Image.GetX(ctx, m.Images[0])
+	require.NotNil(t, row.AiStatus)
+	assert.Equal(t, entimage.AiStatusPending, *row.AiStatus)
+	assert.Zero(t, row.AiAttempts, "re-enqueue resets the attempt counter")
+	done := s.Repository.Client.Image.GetX(ctx, m.Images[1])
+	assert.Equal(t, entimage.AiStatusDone, *done.AiStatus, "done images stay untouched")
+}
+
 // fakeRemote implements aiserver.Server for the proxy tests.
 type fakeRemote struct {
 	faces    aiserver.FacesResponse

--- a/api/internal/service/ai_service.go
+++ b/api/internal/service/ai_service.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"errors"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -250,10 +251,10 @@ func (s *AIService) handle(ctx context.Context, imageID string) {
 	switch {
 	case img.AiAttempts+1 >= maxAIAttempts:
 		update.SetAiStatus(entimage.AiStatusError)
-	case errors.Is(err, context.DeadlineExceeded):
-		// Inference deadline exceeded: this one image is slow (e.g. a cold GPU
-		// lane), not the provider — retry at the BACK of the FIFO so the rest
-		// of the queue keeps flowing, and arm no global backoff.
+	case isTimeoutErr(err):
+		// Inference timed out: this one image is slow (e.g. a cold GPU lane),
+		// not the provider — retry at the BACK of the FIFO so the rest of the
+		// queue keeps flowing, and arm no global backoff.
 		update.SetAiStatus(entimage.AiStatusPending).SetAiQueuedAt(time.Now())
 	default:
 		// keep aiQueuedAt: the retry stays at the front of the FIFO.
@@ -265,6 +266,17 @@ func (s *AIService) handle(ctx context.Context, imageID string) {
 	if img, err := update.Save(ctx); err == nil {
 		s.publish(ctx, img)
 	}
+}
+
+// isTimeoutErr matches every timeout shape an inference call can produce: the
+// ctx deadline (AI_TIMEOUT) and net/http-level timeouts (http.Client.Timeout,
+// dial/TLS timeouts), which surface as net.Error rather than DeadlineExceeded.
+func isTimeoutErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
 }
 
 // InferNow runs inference synchronously for a single image using an explicit

--- a/api/internal/service/ai_service_test.go
+++ b/api/internal/service/ai_service_test.go
@@ -302,6 +302,39 @@ func TestDeadlineRetryRequeuesAtBack(t *testing.T) {
 	assert.Equal(t, maxAIAttempts, svc.repo.Client.Image.GetX(ctx, slow).AiAttempts)
 }
 
+// netTimeoutErr mimics http.Client.Timeout's error shape: a net.Error with
+// Timeout()=true that does NOT wrap context.DeadlineExceeded.
+type netTimeoutErr struct{}
+
+func (netTimeoutErr) Error() string   { return "Client.Timeout exceeded while awaiting headers" }
+func (netTimeoutErr) Timeout() bool   { return true }
+func (netTimeoutErr) Temporary() bool { return true }
+
+type netTimeoutInference struct{}
+
+func (netTimeoutInference) Infer(_ context.Context, _ InferenceRequest) ([]InferredTag, error) {
+	return nil, fmt.Errorf("infer: %w", netTimeoutErr{})
+}
+
+// An http-client-level timeout (net.Error, not DeadlineExceeded) classifies as
+// a timeout too: back of the queue, no global backoff.
+func TestClientTimeoutClassifiesAsTimeout(t *testing.T) {
+	t.Setenv("SESSION_SECRET_KEY", "x")
+	require.NoError(t, util.InitConfig())
+	svc, m := newSvc(t, netTimeoutInference{})
+	ctx := context.Background()
+	img := m.Images[0]
+	base := time.Now().Add(-time.Minute)
+	svc.Enqueue(img)
+	svc.repo.Client.Image.UpdateOneID(img).SetAiQueuedAt(base).SaveX(ctx)
+
+	require.True(t, svc.step(ctx))
+	assert.Equal(t, "pending", aiStatus(t, svc, img))
+	assert.True(t, svc.backoffUntil.IsZero(), "client timeouts must not arm the global backoff")
+	row := svc.repo.Client.Image.GetX(ctx, img)
+	assert.True(t, row.AiQueuedAt.After(base), "timed-out image must move to the back of the queue")
+}
+
 // Boot recovery: STALE processing rows are re-queued by Start; fresh ones are
 // left alone (they belong to another replica mid-flight during a rolling deploy).
 func TestBootRecovery(t *testing.T) {

--- a/image-wasm/src/time_offset.rs
+++ b/image-wasm/src/time_offset.rs
@@ -66,12 +66,15 @@ fn closest_offset(
 
 /// Parse the camera's capture time from EXIF `DateTimeOriginal` (+ `OffsetTimeOriginal`,
 /// falling back to the local zone when the camera didn't record one).
+///
+/// A valid capture time is a hard upload requirement (standing rule) — an
+/// image without one is rejected, but with a message naming the actual
+/// problem instead of a confusing parse error on the bare offset string.
 pub fn camera_time(metadata: &ImageMetadata) -> Result<DateTime<Utc>> {
-    let date_time = metadata
-        .tags
-        .get("DateTimeOriginal")
-        .map(String::as_str)
-        .unwrap_or("");
+    let date_time = match metadata.tags.get("DateTimeOriginal") {
+        Some(value) if !value.trim().is_empty() => value.as_str(),
+        _ => return Err(Error::msg("image has no EXIF capture time (DateTimeOriginal) — images without a valid timestamp cannot be uploaded")),
+    };
 
     let local_offset = Local::now().offset().to_string();
     let zone = metadata
@@ -110,6 +113,19 @@ mod tests {
         let meta = metadata_with("2026-06-27 12:00:00", "+00:00");
         let time = camera_time(&meta).unwrap();
         assert_eq!(time.timestamp(), 1782561600);
+    }
+
+    // Standing rule: no valid capture time -> no upload. The rejection must
+    // name the missing tag, not stumble over the bare offset string.
+    #[test]
+    fn missing_capture_time_is_a_clear_error() {
+        let mut meta = metadata_with("", "+02:00");
+        let err = camera_time(&meta).unwrap_err().to_string();
+        assert!(err.contains("no EXIF capture time"), "got: {err}");
+        meta.tags.remove("DateTimeOriginal");
+        assert!(camera_time(&meta).is_err(), "absent DateTimeOriginal -> error");
+        assert!(corrected_camera_time(&meta, &[]).is_err());
+        assert!(from_qr(&meta, "1782561610").is_err(), "QR sync also needs a camera time");
     }
 
     #[test]

--- a/pkg/aiserver/client.go
+++ b/pkg/aiserver/client.go
@@ -17,9 +17,16 @@ import (
 type Client struct {
 	BaseURL string
 	APIKey  string
-	// HTTP defaults to a 120s-timeout client (Ingest waits on real inference).
+	// HTTP defaults to a client whose Timeout is only a hang safety net — the
+	// per-request ctx is the real deadline (e.g. shutterbase's AI_TIMEOUT).
+	// The net must stay far above any sane ctx deadline, or it silently caps
+	// it: a 120s Client.Timeout once ate a 180s AI_TIMEOUT.
 	HTTP *http.Client
 }
+
+// clientSafetyTimeout bounds requests whose ctx carries no deadline (proxy
+// calls run on plain request contexts) so a hung server can't leak forever.
+const clientSafetyTimeout = 10 * time.Minute
 
 var _ Server = (*Client)(nil)
 
@@ -27,7 +34,7 @@ func NewClient(baseURL, apiKey string) *Client {
 	return &Client{
 		BaseURL: strings.TrimRight(baseURL, "/"),
 		APIKey:  apiKey,
-		HTTP:    &http.Client{Timeout: 120 * time.Second},
+		HTTP:    &http.Client{Timeout: clientSafetyTimeout},
 	}
 }
 
@@ -97,7 +104,7 @@ func (c *Client) do(ctx context.Context, method, path string, in, out any) error
 	}
 	httpClient := c.HTTP
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 120 * time.Second}
+		httpClient = &http.Client{Timeout: clientSafetyTimeout}
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/ui/src/api/ai.ts
+++ b/ui/src/api/ai.ts
@@ -73,6 +73,12 @@ export async function rerunBatch(projectId: string, imageIds: string[]): Promise
   return data.queued;
 }
 
+// Re-queues every dead-lettered (aiStatus=error) image of the project.
+export async function rerunFailed(projectId: string): Promise<number> {
+  const { data } = await http.post<{ queued: number }>(`/projects/${projectId}/ai/rerun-failed`);
+  return data.queued;
+}
+
 export async function faces(imageId: string): Promise<AiFace[]> {
   const { data } = await http.get<{ faces: AiFace[] }>(`/images/${imageId}/ai/faces`);
   return data.faces;

--- a/ui/src/components/schedule/ScheduleItemPopover.vue
+++ b/ui/src/components/schedule/ScheduleItemPopover.vue
@@ -7,7 +7,10 @@
     <div v-if="item" class="fixed inset-0 z-30" @click="emit('closed')" @keydown.esc="emit('closed')">
       <div
         data-testid="schedule-popover"
-        class="fixed z-40 w-72 rounded-lg border border-primary-200 bg-surface p-4 shadow-panel dark:border-primary-700 dark:bg-surface-dark dark:shadow-panel-dark"
+        :class="[
+          'fixed z-40 rounded-lg border border-primary-200 bg-surface p-4 shadow-panel dark:border-primary-700 dark:bg-surface-dark dark:shadow-panel-dark',
+          hasShifts ? 'w-80' : 'w-72',
+        ]"
         :style="{ left: `${position.x}px`, top: `${position.y}px` }"
         @click.stop
       >
@@ -17,13 +20,54 @@
             <p class="text-xs tabular-nums text-primary-500 dark:text-primary-400">{{ window }}</p>
           </div>
           <span :class="['flex-shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium', OCCUPANCY_CLASSES[status]]">
-            {{ item.assignees.length }}/{{ item.cardinality }}
+            {{ chipText }}
           </span>
         </div>
 
         <p :class="['mt-2 text-xs font-medium', statusTextClasses[status]]">{{ OCCUPANCY_LABEL[status] }}</p>
 
-        <ul class="mt-3 max-h-44 space-y-1.5 overflow-y-auto">
+        <!-- subdivided block: claim per shift, same pull principle -->
+        <ul v-if="hasShifts" class="mt-3 max-h-64 space-y-1.5 overflow-y-auto">
+          <li
+            v-for="shift in item.shifts"
+            :key="shift.id"
+            :data-testid="`popover-shift-${shift.id}`"
+            :class="[
+              'rounded-md border px-2 py-1.5',
+              shift.kind === 'break'
+                ? 'border-dashed border-primary-200 bg-primary-100/40 dark:border-primary-700 dark:bg-primary-900/40'
+                : 'border-primary-100 dark:border-primary-800',
+            ]"
+          >
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-xs tabular-nums text-primary-700 dark:text-primary-200">{{ shiftWindow(shift) }}</span>
+              <span v-if="shift.kind === 'break'" class="label-mono-sm text-primary-400">Break</span>
+              <span v-else :class="['rounded-full border px-1.5 py-px text-[10px] font-medium', OCCUPANCY_CLASSES[shiftStatus(shift)]]">
+                {{ shift.assignees.length }}/{{ shift.cardinality }}
+              </span>
+            </div>
+            <div v-if="shift.kind !== 'break'" class="mt-1 flex items-center justify-between gap-2">
+              <div class="flex min-w-0 items-center -space-x-1.5">
+                <UserBubble v-for="assignee in shift.assignees.slice(0, 4)" :key="assignee.id" :user="assignee" />
+                <span v-if="shift.assignees.length > 4" class="pl-2.5 text-xs text-primary-400">+{{ shift.assignees.length - 4 }}</span>
+                <span v-if="!shift.assignees.length" class="text-xs text-primary-400">nobody yet</span>
+              </div>
+              <button
+                v-if="canJoin"
+                type="button"
+                :class="isAssigned(shift, currentUserId) ? 'pop-btn-secondary' : 'pop-btn-primary'"
+                @click="emit(isAssigned(shift, currentUserId) ? 'dropShift' : 'claimShift', shift.id)"
+              >
+                <UserMinusIcon v-if="isAssigned(shift, currentUserId)" class="h-3.5 w-3.5" />
+                <UserPlusIcon v-else class="h-3.5 w-3.5" />
+                {{ isAssigned(shift, currentUserId) ? "Leave" : "Take" }}
+              </button>
+            </div>
+          </li>
+        </ul>
+
+        <!-- plain item: claim the whole thing -->
+        <ul v-else class="mt-3 max-h-44 space-y-1.5 overflow-y-auto">
           <li v-for="assignee in item.assignees" :key="assignee.id" class="flex items-center justify-between gap-2">
             <span class="flex min-w-0 items-center gap-2 text-sm text-primary-700 dark:text-primary-200">
               <UserBubble :user="assignee" />
@@ -44,12 +88,12 @@
         </ul>
 
         <div class="mt-4 flex flex-wrap gap-2">
-          <button v-if="canJoin" type="button" :class="assigned ? 'pop-btn-secondary' : 'pop-btn-primary'" @click="emit(assigned ? 'drop' : 'claim')">
+          <button v-if="canJoin && !hasShifts" type="button" :class="assigned ? 'pop-btn-secondary' : 'pop-btn-primary'" @click="emit(assigned ? 'drop' : 'claim')">
             <UserMinusIcon v-if="assigned" class="h-4 w-4" />
             <UserPlusIcon v-else class="h-4 w-4" />
             {{ assigned ? "Leave" : "Add to my schedule" }}
           </button>
-          <button v-if="canManage" type="button" class="pop-btn-secondary" @click="emit('openAssign')">
+          <button v-if="canManage && !hasShifts" type="button" class="pop-btn-secondary" @click="emit('openAssign')">
             <UserGroupIcon class="h-4 w-4" />
             Assign
           </button>
@@ -69,7 +113,7 @@ import { DateTime } from "luxon";
 import { computed, onBeforeUnmount, onMounted } from "vue";
 import UserBubble from "src/components/schedule/UserBubble.vue";
 import { ScheduleItem } from "src/types/api";
-import { OCCUPANCY_CLASSES, OCCUPANCY_LABEL, OccupancyStatus, isAssigned, occupancyStatus } from "src/util/schedule";
+import { OCCUPANCY_CLASSES, OCCUPANCY_LABEL, OccupancyStatus, blockStatus, claimableShifts, isAssigned, occupancyStatus } from "src/util/schedule";
 
 const props = defineProps<{
   item: ScheduleItem | null;
@@ -83,13 +127,28 @@ const emit = defineEmits<{
   closed: [];
   claim: [];
   drop: [];
+  claimShift: [string];
+  dropShift: [string];
   unassign: [string];
   openAssign: [];
   openShifts: [];
 }>();
 
-const status = computed(() => occupancyStatus(props.item?.assignees.length ?? 0, props.item?.cardinality ?? 1));
+const hasShifts = computed(() => (props.item?.shifts?.length ?? 0) > 0);
+const status = computed(() => (props.item ? blockStatus(props.item) : "empty"));
 const assigned = computed(() => !!props.item && isAssigned(props.item, props.currentUserId));
+const shiftStatus = (shift: ScheduleItem) => occupancyStatus(shift.assignees.length, shift.cardinality);
+
+// header chip: people for a plain item, covered shifts for a block
+const chipText = computed(() => {
+  if (!props.item) return "";
+  if (!hasShifts.value) return `${props.item.assignees.length}/${props.item.cardinality}`;
+  const shifts = claimableShifts(props.item);
+  const covered = shifts.filter((s) => s.assignees.length >= s.cardinality).length;
+  return `${covered}/${shifts.length} shifts`;
+});
+
+const shiftWindow = (shift: ScheduleItem) => `${DateTime.fromISO(shift.start).toFormat("HH:mm")}–${DateTime.fromISO(shift.end).toFormat("HH:mm")}`;
 
 const statusTextClasses: Record<OccupancyStatus, string> = {
   empty: "text-blue-600 dark:text-blue-300",

--- a/ui/src/components/upload/ImageUploadGrid.vue
+++ b/ui/src/components/upload/ImageUploadGrid.vue
@@ -21,10 +21,7 @@
 
           <!-- progress overlay while the pipeline runs (transcript 19:22:
                "sieht auf dem Image Preview, dass der grad hochgeladen wird") -->
-          <div
-            v-if="image.status !== ImageStatus.DONE"
-            class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-primary-950/60 backdrop-blur-[1px]"
-          >
+          <div v-if="image.status !== ImageStatus.DONE" class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-primary-950/60 backdrop-blur-[1px]">
             <ExclamationTriangleIcon v-if="image.status === ImageStatus.ERROR" class="h-6 w-6 text-error-400" />
             <template v-else>
               <span class="h-6 w-6 animate-spin rounded-full border-2 border-white/30 border-t-white"></span>
@@ -32,7 +29,10 @@
                 <div class="h-full rounded-full bg-white transition-all" :style="{ width: `${image.progress}%` }"></div>
               </div>
             </template>
-            <span class="text-[10px] font-medium uppercase tracking-wide text-white/90">{{ image.status }}</span>
+            <span v-if="image.status === ImageStatus.ERROR && image.errorMessage" class="px-2 text-center text-[10px] font-medium leading-tight text-white/90">
+              {{ image.errorMessage }}
+            </span>
+            <span v-else class="text-[10px] font-medium uppercase tracking-wide text-white/90">{{ image.status }}</span>
           </div>
 
           <!-- remove, on hover, only once persisted -->

--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -16,7 +16,7 @@
         <div v-if="personFilter" class="mt-6">
           <span class="label-mono-sm inline-flex items-center gap-2 rounded-full border border-accent-400/60 px-3 py-1 text-accent-600 dark:text-accent-300">
             photos of one person
-            <button class="cursor-pointer font-bold hover:text-accent-400" title="Clear person filter" @click="filterByPerson(null)">×</button>
+            <button class="cursor-pointer font-bold hover:text-accent-400" title="Clear person filter" @click="clearPersonFilter()">×</button>
           </span>
         </div>
         <div :class="['mt-8 select-none', gridClasses]">
@@ -97,7 +97,7 @@ import FilmStrip from "src/components/image/FilmStrip.vue";
 import { devPlaceholder } from "src/util/devPlaceholder";
 import { ImageWithTagsType } from "src/types/custom";
 import { onMounted, onUnmounted, reactive, ref, computed, watch, nextTick } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { useDebounceFn, useStorage } from "@vueuse/core";
 
 import AiImageListDialog from "src/components/image/AiImageListDialog.vue";
@@ -117,7 +117,9 @@ import {
   updateAspectRatioFilter,
   filtered,
   personFilter,
-  filterByPerson,
+  snapshotGrid,
+  restoreGridSnapshot,
+  invalidateGridSnapshot,
 } from "./imageQueryLogic";
 import { totalImageCount, images, imageIndex, imageIndices, multiselectStart, multiselectEnd, loading, activeProject } from "./imageQueryLogic";
 import { taggingDialogVisible, addImageTag } from "./imageQueryLogic";
@@ -129,8 +131,91 @@ import { emitter, showNotificationToast } from "src/boot/mitt";
 import { debug } from "src/util/logger";
 
 const router = useRouter();
+const route = useRoute();
 
 const displayMode = ref(DisplayMode.GRID);
+
+// --- history-backed view state ----------------------------------------------
+// The visible view is encoded in the route query — ?person=<ref> for the
+// implicit person filter, ?image=<id> for the detail view — so the browser
+// back button walks grid ⇄ detail ⇄ filter states. UI events only push/replace
+// the query; applyRoute() is the single place state actually changes.
+
+function pushQuery(mutate: (q: Record<string, any>) => void, replace = false) {
+  const q: Record<string, any> = { ...route.query };
+  mutate(q);
+  if (JSON.stringify(q) === JSON.stringify(route.query)) return;
+  const target = { query: q };
+  if (replace) router.replace(target);
+  else router.push(target);
+}
+
+const openDetail = (imageId: string) => pushQuery((q) => (q.image = imageId));
+const closeDetail = () => pushQuery((q) => delete q.image);
+const clearPersonFilter = () => pushQuery((q) => delete q.person);
+
+async function applyRoute(initial = false) {
+  if (route.name !== "images") return;
+  const person = (route.query.person as string) || null;
+  const imageId = (route.query.image as string) || null;
+
+  if (initial || person !== personFilter.value) {
+    if (person) {
+      // entering a person filter from the unfiltered grid: remember where we were
+      if (!initial && !personFilter.value) snapshotGrid();
+      personFilter.value = person;
+      imageIndex.value = -1;
+      imageIndices.value = [];
+      multiselectStart.value = null;
+      multiselectEnd.value = null;
+      await loadImages(true);
+    } else {
+      personFilter.value = null;
+      const scrollY = initial ? null : restoreGridSnapshot();
+      if (scrollY === null) {
+        await loadImages(true);
+      } else {
+        await nextTick();
+        window.scrollTo({ top: scrollY, behavior: "instant" as ScrollBehavior });
+      }
+    }
+  }
+
+  if (imageId) {
+    const index = images.value.findIndex((image) => image.id === imageId);
+    if (index === -1) {
+      // deep link beyond the loaded pages (or a deleted image) — stay in the grid
+      displayMode.value = DisplayMode.GRID;
+      return;
+    }
+    imageIndex.value = index;
+    if (displayMode.value !== DisplayMode.DETAIL) {
+      multiselectStart.value = null;
+      multiselectEnd.value = null;
+      imageIndices.value = [];
+      displayMode.value = DisplayMode.DETAIL;
+    }
+  } else if (displayMode.value !== DisplayMode.GRID) {
+    displayMode.value = DisplayMode.GRID;
+    nextTick(() => {
+      if (imageIndex.value !== -1) scrollToSelectedImage();
+      if (imagesHeader.value) imagesHeader.value.setFilteredTags(filterTags.value);
+    });
+  }
+}
+
+watch(
+  () => route.query,
+  () => applyRoute(),
+);
+
+// Stepping through images inside the detail view (hotkeys, film strip) keeps
+// the URL current without growing the history.
+watch(imageIndex, () => {
+  if (displayMode.value !== DisplayMode.DETAIL) return;
+  const id = images.value[imageIndex.value]?.id;
+  if (id && route.query.image !== id) pushQuery((q) => (q.image = id), true);
+});
 
 // Grid density: relaxed fine-art masonry, comfortable grid, or Immich-dense.
 type Density = "gallery" | "comfortable" | "dense";
@@ -155,9 +240,16 @@ async function onScroll() {
 }
 window.addEventListener("scroll", onScroll);
 
-onMounted(() => loadImages(true));
-const reloadDebounced = useDebounceFn(() => loadImages(true), 500);
-watch(preferredImageSortOrder, () => loadImages(true));
+onMounted(() => applyRoute(true));
+// any other filter/sort change makes the saved unfiltered-grid position stale
+const reloadDebounced = useDebounceFn(() => {
+  invalidateGridSnapshot();
+  loadImages(true);
+}, 500);
+watch(preferredImageSortOrder, () => {
+  invalidateGridSnapshot();
+  loadImages(true);
+});
 watch(searchText, reloadDebounced);
 watch(filterTags, reloadDebounced);
 watch(aspectRatioFilter, reloadDebounced);
@@ -178,33 +270,16 @@ useTagHotkey(toggleTagByName);
 
 function toggleGridDetail() {
   if (displayMode.value === DisplayMode.GRID) {
-    showDetail();
-    displayMode.value = DisplayMode.DETAIL;
+    const id = images.value[imageIndex.value === -1 ? 0 : imageIndex.value]?.id;
+    if (id) openDetail(id);
   } else {
-    displayMode.value = DisplayMode.GRID;
-    nextTick(() => {
-      scrollToSelectedImage();
-      if (imagesHeader.value) {
-        imagesHeader.value.setFilteredTags(filterTags.value);
-      }
-    });
+    closeDetail();
   }
-}
-
-function showDetail() {
-  multiselectStart.value = null;
-  multiselectEnd.value = null;
-  imageIndices.value = [];
-  if (imageIndex.value === -1) {
-    imageIndex.value = 0;
-  }
-  displayMode.value = DisplayMode.DETAIL;
 }
 
 onMounted(clearFilterTags);
 function clearFilterTags() {
-  filterTags.value = [];
-  personFilter.value = null; // module state survives navigation — fresh mount, fresh view
+  filterTags.value = []; // person filter comes from the route query instead
 }
 
 const taggingDialog = ref<InstanceType<typeof TaggingDialog> | null>(null);
@@ -269,7 +344,7 @@ function selectImage(imageId: string, event: MouseEvent) {
     imageIndex.value = index;
   } else {
     imageIndex.value = index;
-    showDetail();
+    openDetail(imageId);
   }
 
   if (multiselectStart.value !== null && multiselectEnd.value !== null) {
@@ -347,13 +422,12 @@ watch(imageIndex, () => {
 });
 
 // Clicking a face filters the normal grid by that person — no result dialog.
+// A route push, so browser-back returns to the view the face was clicked in.
 function showPersonInGrid(personRef: string) {
-  imageIndex.value = -1;
-  imageIndices.value = [];
-  multiselectStart.value = null;
-  multiselectEnd.value = null;
-  displayMode.value = DisplayMode.GRID;
-  filterByPerson(personRef);
+  pushQuery((q) => {
+    q.person = personRef;
+    delete q.image;
+  });
 }
 
 function showSimilarDialog() {
@@ -368,7 +442,7 @@ function selectFromAiDialog(imageId: string) {
   }
   aiDialogVisible.value = false;
   imageIndex.value = index;
-  showDetail();
+  openDetail(imageId);
 }
 
 // selection rerun (button in the header, active when a selection exists)

--- a/ui/src/pages/image/imageQueryLogic.ts
+++ b/ui/src/pages/image/imageQueryLogic.ts
@@ -56,10 +56,51 @@ export function updateAspectRatioFilter(aspectRatioState: string) {
 
 // Implicit person filter: set by clicking a face box in the detail view,
 // cleared via the chip above the grid. No picker UI — the face IS the picker.
+// The value is driven by the route query (?person=) so the browser history
+// walks through filter states; Images.vue owns the sync.
 export const personFilter = ref<string | null>(null);
-export function filterByPerson(personRef: string | null) {
-  personFilter.value = personRef;
-  loadImages(true);
+
+// --- grid snapshot -----------------------------------------------------------
+// Applying the person filter replaces the loaded (possibly deeply scrolled)
+// grid. A snapshot of that state lets "clear filter" / browser-back land on
+// the exact position instead of page 1.
+// ponytail: single snapshot — any other filter/sort change invalidates it.
+
+interface GridSnapshot {
+  images: ImageWithTagsType[];
+  page: number;
+  total: number;
+  imageIndex: number;
+  scrollY: number;
+}
+
+let gridSnapshot: GridSnapshot | null = null;
+
+export function snapshotGrid() {
+  gridSnapshot = {
+    images: images.value,
+    page: page.value,
+    total: totalImageCount.value,
+    imageIndex: imageIndex.value,
+    scrollY: window.scrollY,
+  };
+}
+
+export function invalidateGridSnapshot() {
+  gridSnapshot = null;
+}
+
+// restoreGridSnapshot puts the saved grid back and returns the scroll offset
+// to restore, or null when there is nothing to restore.
+export function restoreGridSnapshot(): number | null {
+  if (!gridSnapshot) return null;
+  const snap = gridSnapshot;
+  gridSnapshot = null;
+  images.value = snap.images;
+  page.value = snap.page;
+  totalImageCount.value = snap.total;
+  imageIndex.value = snap.imageIndex;
+  return snap.scrollY;
 }
 
 export async function triggerInfiniteScroll() {

--- a/ui/src/pages/project/ProjectGeneral.vue
+++ b/ui/src/pages/project/ProjectGeneral.vue
@@ -25,7 +25,26 @@
         :fields="copyrightFields"
         :item="item"
       />
-      <DetailEditGroup :allow-edit="userStore.isProjectAdminOrHigher()" @edit-save="saveItem" headline="AI Options" subtitle="Options for AI image tagging" :fields="aiFields" :item="item" />
+      <div>
+        <DetailEditGroup
+          :allow-edit="userStore.isProjectAdminOrHigher()"
+          @edit-save="saveItem"
+          headline="AI Options"
+          subtitle="Options for AI image tagging"
+          :fields="aiFields"
+          :item="item"
+        />
+        <button
+          v-if="userStore.isProjectAdminOrHigher()"
+          type="button"
+          class="mt-4 inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-primary-200 bg-surface px-3.5 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:text-white"
+          :disabled="rerunningFailed"
+          @click="rerunFailed"
+        >
+          <ArrowPathIcon class="h-4 w-4" />
+          Re-queue failed images
+        </button>
+      </div>
       <DetailEditGroup
         :allow-edit="userStore.isProjectAdminOrHigher()"
         @edit-save="saveItem"
@@ -42,6 +61,7 @@
 <script setup lang="ts">
 import { Ref, onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
+import { ArrowPathIcon } from "@heroicons/vue/24/outline";
 import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
 import DetailEditGroup, { Field, FieldType, EditData } from "src/components/DetailEditGroup.vue";
 import { ProjectsResponse } from "src/types/pocketbase";
@@ -100,6 +120,24 @@ async function saveItem(editData: EditData<ITEM_TYPE>) {
   }
 }
 
+const rerunningFailed = ref(false);
+async function rerunFailed() {
+  if (!item.value) return;
+  rerunningFailed.value = true;
+  try {
+    const queued = await api.ai.rerunFailed(item.value.id);
+    showNotificationToast({
+      headline: queued === 0 ? "No failed images to re-queue" : `AI detection re-queued for ${queued} image${queued === 1 ? "" : "s"}`,
+      type: "success",
+    });
+  } catch (error: any) {
+    unexpectedError.value = error;
+    showUnexpectedErrorMessage.value = true;
+  } finally {
+    rerunningFailed.value = false;
+  }
+}
+
 const informationFields: Field<ITEM_TYPE>[] = [
   { key: "name", label: "Name", type: FieldType.TEXT },
   { key: "description", label: "Description", type: FieldType.TEXT },
@@ -112,9 +150,7 @@ const periodFields: Field<ITEM_TYPE>[] = [
   { key: "endAt", label: "Ends", type: FieldType.DATETIME },
 ];
 
-const reviewFields: Field<ITEM_TYPE>[] = [
-  { key: "uploadReviewEnabled", label: "Upload reviews", type: FieldType.BOOLEAN, hint: "Enable the open / ready / reviewed flow" },
-];
+const reviewFields: Field<ITEM_TYPE>[] = [{ key: "uploadReviewEnabled", label: "Upload reviews", type: FieldType.BOOLEAN, hint: "Enable the open / ready / reviewed flow" }];
 
 const copyrightFields: Field<ITEM_TYPE>[] = [
   { key: "copyright", label: "Copyright", type: FieldType.TEXT },

--- a/ui/src/pages/schedule/Schedule.vue
+++ b/ui/src/pages/schedule/Schedule.vue
@@ -27,6 +27,45 @@
             </button>
           </div>
 
+          <!-- view range: day / 3 days / week / whole event -->
+          <div class="flex rounded-lg border border-primary-200 bg-surface p-0.5 dark:border-primary-700 dark:bg-surface-dark">
+            <button
+              v-for="option in viewOptions"
+              :key="option.value"
+              type="button"
+              @click="viewMode = option.value"
+              :class="[
+                'inline-flex h-8 cursor-pointer items-center rounded-md px-2.5 text-xs font-medium transition-colors',
+                viewMode === option.value
+                  ? 'bg-accent-500/15 text-accent-700 dark:bg-accent-500/20 dark:text-accent-200'
+                  : 'text-primary-500 hover:bg-primary-100 hover:text-primary-700 dark:text-primary-400 dark:hover:bg-primary-800 dark:hover:text-primary-200',
+              ]"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+          <div v-if="viewMode !== 'all'" class="flex items-center gap-1">
+            <button
+              type="button"
+              class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-primary-500 transition-colors hover:bg-primary-100 hover:text-primary-700 disabled:cursor-default disabled:opacity-40 dark:hover:bg-primary-800 dark:hover:text-primary-200"
+              :disabled="!canPrev"
+              aria-label="Previous"
+              @click="shiftAnchor(-1)"
+            >
+              <ChevronLeftIcon class="h-4 w-4" />
+            </button>
+            <span class="min-w-28 text-center text-xs tabular-nums text-primary-600 dark:text-primary-300">{{ rangeLabel }}</span>
+            <button
+              type="button"
+              class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-primary-500 transition-colors hover:bg-primary-100 hover:text-primary-700 disabled:cursor-default disabled:opacity-40 dark:hover:bg-primary-800 dark:hover:text-primary-200"
+              :disabled="!canNext"
+              aria-label="Next"
+              @click="shiftAnchor(1)"
+            >
+              <ChevronRightIcon class="h-4 w-4" />
+            </button>
+          </div>
+
           <button
             v-if="canManage"
             type="button"
@@ -52,7 +91,7 @@
          scrolls vertically, only the day columns scroll horizontally. -->
     <div class="mt-4 px-4 pb-6 sm:px-6 lg:px-8">
       <div class="overflow-x-auto rounded-lg border border-primary-200 bg-surface dark:border-primary-800 dark:bg-surface-dark">
-        <div class="flex min-w-max">
+        <div :class="['flex', viewMode === 'all' ? 'min-w-max' : 'w-full']">
           <!-- hour gutter -->
           <div class="sticky left-0 z-[5] w-14 flex-shrink-0 border-r border-primary-100 bg-surface dark:border-primary-800 dark:bg-surface-dark">
             <div class="h-9 border-b border-primary-100 dark:border-primary-800"></div>
@@ -69,7 +108,11 @@
           </div>
 
           <!-- day columns -->
-          <div v-for="day in days" :key="day.getTime()" class="w-48 flex-shrink-0 border-r border-primary-100 last:border-r-0 dark:border-primary-800">
+          <div
+            v-for="day in days"
+            :key="day.getTime()"
+            :class="[viewMode === 'all' ? 'w-48 flex-shrink-0' : 'min-w-40 flex-1', 'border-r border-primary-100 last:border-r-0 dark:border-primary-800']"
+          >
             <div class="flex h-9 items-center justify-center border-b border-primary-100 text-sm font-medium text-primary-700 dark:border-primary-800 dark:text-primary-200">
               {{ formatDay(day) }}
             </div>
@@ -119,13 +162,13 @@
                   {{ formatTime(entry.item.start) }}–{{ formatTime(entry.item.end)
                   }}<span v-if="entry.item.shifts?.length"> · {{ entry.item.shifts.length }} shift{{ entry.item.shifts.length === 1 ? "" : "s" }}</span>
                 </p>
-                <div v-if="entry.item.assignees.length" class="mt-0.5 flex -space-x-1.5">
-                  <UserBubble v-for="assignee in entry.item.assignees.slice(0, 3)" :key="assignee.id" :user="assignee" />
+                <div v-if="tileAssignees(entry.item).length" class="mt-0.5 flex -space-x-1.5">
+                  <UserBubble v-for="assignee in tileAssignees(entry.item).slice(0, 3)" :key="assignee.id" :user="assignee" />
                   <span
-                    v-if="entry.item.assignees.length > 3"
+                    v-if="tileAssignees(entry.item).length > 3"
                     class="flex h-6 w-6 items-center justify-center rounded-full bg-primary-200 text-[10px] font-medium text-primary-700 ring-2 ring-surface dark:bg-primary-700 dark:text-primary-200 dark:ring-surface-dark"
                   >
-                    +{{ entry.item.assignees.length - 3 }}
+                    +{{ tileAssignees(entry.item).length - 3 }}
                   </span>
                 </div>
 
@@ -157,6 +200,8 @@
       @closed="popoverItemId = null"
       @claim="assign(popoverItemId!, userStore.user!.id)"
       @drop="unassign(popoverItemId!, userStore.user!.id)"
+      @claim-shift="(shiftId) => assign(shiftId, userStore.user!.id)"
+      @drop-shift="(shiftId) => unassign(shiftId, userStore.user!.id)"
       @unassign="(userId) => unassign(popoverItemId!, userId)"
       @open-assign="assignModalOpen = true"
       @open-shifts="router.push({ name: 'schedule-item', params: { id: popoverItemId! } })"
@@ -181,7 +226,7 @@
 
 <script setup lang="ts">
 import confetti from "canvas-confetti";
-import { CalendarDaysIcon, PencilIcon, PlusIcon, UserIcon } from "@heroicons/vue/24/outline";
+import { CalendarDaysIcon, ChevronLeftIcon, ChevronRightIcon, PencilIcon, PlusIcon, UserIcon } from "@heroicons/vue/24/outline";
 import { DateTime } from "luxon";
 import { storeToRefs } from "pinia";
 import { computed, onBeforeUnmount, onMounted, ref, Ref } from "vue";
@@ -198,9 +243,12 @@ import { showNotificationToast } from "src/boot/mitt";
 import { useUserStore } from "src/stores/user-store";
 import { EmbeddedUser, ImageTag, Project, ScheduleItem } from "src/types/api";
 import {
+  CalendarView,
   OCCUPANCY_CLASSES,
   OCCUPANCY_LABEL,
   OccupancyStatus,
+  VIEW_STEP_DAYS,
+  addDays,
   assignLanes,
   blockStatus,
   calendarDays,
@@ -208,6 +256,8 @@ import {
   isAssignedInBlock,
   itemsOnDay,
   pctToTime,
+  startOfDay,
+  viewDays,
 } from "src/util/schedule";
 import * as websocket from "src/util/websocket";
 import { useRouter } from "vue-router";
@@ -330,7 +380,43 @@ const bodyHeightClass = "h-[calc(100dvh-21rem)] min-h-[420px]";
 const hourMarks = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22];
 
 const visibleItems = computed(() => (scope.value === "mine" ? items.value.filter((i) => isAssignedInBlock(i, userStore.user?.id)) : items.value));
-const days = computed(() => calendarDays(project.value ?? {}, visibleItems.value.length ? visibleItems.value : items.value));
+
+// --- view range (day / 3day / week / all) ------------------------------------
+
+const viewMode = useStorage<CalendarView>("schedule-view", "all");
+const viewOptions: { value: CalendarView; label: string }[] = [
+  { value: "day", label: "Day" },
+  { value: "3day", label: "3 days" },
+  { value: "week", label: "Week" },
+  { value: "all", label: "Event" },
+];
+
+// the project-wide span bounds the anchor so prev/next cannot wander into
+// empty months; anchor defaults to today (clamped into the span)
+const allDays = computed(() => calendarDays(project.value ?? {}, visibleItems.value.length ? visibleItems.value : items.value));
+const anchorOverride = ref<Date | null>(null);
+const anchor = computed(() => {
+  const bounds = allDays.value;
+  const t = startOfDay(anchorOverride.value ?? new Date()).getTime();
+  const first = bounds[0].getTime();
+  const last = bounds[bounds.length - 1].getTime();
+  return new Date(Math.min(Math.max(t, first), last));
+});
+
+const days = computed(() => (viewMode.value === "all" ? allDays.value : viewDays(viewMode.value, anchor.value, project.value ?? {}, visibleItems.value)));
+
+const canPrev = computed(() => days.value[0].getTime() > allDays.value[0].getTime());
+const canNext = computed(() => days.value[days.value.length - 1].getTime() < allDays.value[allDays.value.length - 1].getTime());
+
+function shiftAnchor(direction: 1 | -1) {
+  anchorOverride.value = addDays(anchor.value, direction * VIEW_STEP_DAYS[viewMode.value]);
+}
+
+const rangeLabel = computed(() => {
+  const first = days.value[0];
+  const last = days.value[days.value.length - 1];
+  return days.value.length === 1 ? formatDay(first) : `${formatDay(first)} – ${formatDay(last)}`;
+});
 
 interface DayEntry {
   item: ScheduleItem;
@@ -358,6 +444,16 @@ function dayEntries(day: Date): DayEntry[] {
   });
 }
 
+// tile bubbles: a subdivided block's people live on its shifts — show the
+// distinct union of both claim surfaces.
+function tileAssignees(item: ScheduleItem): EmbeddedUser[] {
+  if (!item.shifts?.length) return item.assignees;
+  const seen = new Map<string, EmbeddedUser>();
+  item.assignees.forEach((a) => seen.set(a.id, a));
+  item.shifts.forEach((s) => s.assignees.forEach((a) => seen.set(a.id, a)));
+  return [...seen.values()];
+}
+
 const formatDay = (day: Date) => DateTime.fromJSDate(day).toFormat("ccc dd.LL.");
 const formatTime = (iso: string) => DateTime.fromISO(iso).toFormat("HH:mm");
 const dayKey = (day: Date) => DateTime.fromJSDate(day).toFormat("yyyy-LL-dd");
@@ -368,13 +464,10 @@ const popoverItemId = ref<string | null>(null);
 const popoverPosition = ref({ x: 0, y: 0 });
 const popoverItem = computed(() => items.value.find((i) => i.id === popoverItemId.value) ?? null);
 
-// A subdivided block opens its detail page (shifts are claimed there); a
-// plain item keeps the quick claim popover.
+// Every item opens the claim popover — subdivided blocks list their shifts
+// there (claim per shift, same pull principle); the detail page stays the
+// admin surface for editing shifts.
 function openItem(item: ScheduleItem) {
-  if (item.shifts?.length) {
-    router.push({ name: "schedule-item", params: { id: item.id } });
-    return;
-  }
   openPopover(item);
 }
 
@@ -383,7 +476,8 @@ function openPopover(item: ScheduleItem) {
   if (el) {
     const rect = el.getBoundingClientRect();
     popoverPosition.value = {
-      x: Math.max(8, Math.min(rect.right + 8, window.innerWidth - 296)),
+      // 344 = widest popover (w-80 for blocks) + margin
+      x: Math.max(8, Math.min(rect.right + 8, window.innerWidth - 344)),
       y: Math.max(8, Math.min(rect.top, window.innerHeight - 360)),
     };
   }

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -19,7 +19,9 @@ export default route(function (/* { store, ssrContext } */) {
   const createHistory = process.env.SERVER ? createMemoryHistory : process.env.VUE_ROUTER_MODE === "history" ? createWebHistory : createWebHashHistory;
 
   const Router = createRouter({
-    scrollBehavior: () => ({ left: 0, top: 0 }),
+    // Query-only navigation (e.g. the image grid's view/filter state) must not
+    // touch the scroll position; real page changes start at the top.
+    scrollBehavior: (to, from) => (to.path === from.path ? false : { left: 0, top: 0 }),
     routes,
 
     // Leave this as is and make changes in quasar.conf.js instead!

--- a/ui/src/util/fileProcessor.ts
+++ b/ui/src/util/fileProcessor.ts
@@ -6,6 +6,7 @@ import { API_BASE } from "src/boot/axios";
 import { api } from "src/api";
 import { useUserStore } from "src/stores/user-store";
 import { getLogLevelString, debug, info, error } from "./logger";
+import { showNotificationToast } from "src/boot/mitt";
 import { Upload, Image as BackendImage } from "src/types/api";
 import { parseBackendTime } from "src/util/dateTimeUtil";
 
@@ -46,6 +47,7 @@ export type Image = {
   cameraTime?: DateTime;
   correctedTime?: DateTime;
   data: ArrayBuffer | null;
+  errorMessage?: string; // human-readable reason when status === ERROR
   thumbnail?: string;
   downloadUrls?: { [key: string]: string };
   size: number;
@@ -225,6 +227,11 @@ export class FileProcessor {
 
         resolve();
       } catch (err: any) {
+        // surface the reason to the human, not just the console — e.g. the
+        // hard timestamp rule: "image has no EXIF capture time"
+        const reason = String(err?.message ?? err).replace(/^Error:\s*/, "");
+        image.errorMessage = reason;
+        showNotificationToast({ headline: `${image.originalFileName}: ${reason}`, type: "error" });
         error(`Failed to process image: ${err}`);
         reject();
         return;

--- a/ui/src/util/schedule.ts
+++ b/ui/src/util/schedule.ts
@@ -81,6 +81,35 @@ export function calendarDays(project: { startAt?: string | null; endAt?: string 
   return daySpan(monday, addDays(monday, 6), 7);
 }
 
+// --- calendar view ranges ----------------------------------------------------
+
+export type CalendarView = "day" | "3day" | "week" | "all";
+
+export function mondayOf(d: Date): Date {
+  return addDays(startOfDay(d), -((d.getDay() + 6) % 7));
+}
+
+// viewDays: the day columns for the selected view. day/3day start at the
+// anchor, week is the anchor's Monday-based week, all is the project-wide
+// span (calendarDays).
+export function viewDays(view: CalendarView, anchor: Date, project: { startAt?: string | null; endAt?: string | null }, items: ScheduleItemLike[], now: Date = new Date()): Date[] {
+  switch (view) {
+    case "day":
+      return [startOfDay(anchor)];
+    case "3day":
+      return [0, 1, 2].map((i) => addDays(startOfDay(anchor), i));
+    case "week": {
+      const monday = mondayOf(anchor);
+      return [0, 1, 2, 3, 4, 5, 6].map((i) => addDays(monday, i));
+    }
+    default:
+      return calendarDays(project, items, now);
+  }
+}
+
+// viewStepDays: how far prev/next moves the anchor in each view.
+export const VIEW_STEP_DAYS: Record<CalendarView, number> = { day: 1, "3day": 3, week: 7, all: 0 };
+
 // itemsOnDay: items whose [start, end) window intersects the given day.
 export function itemsOnDay<T extends ScheduleItemLike>(items: T[], day: Date): T[] {
   const dayStart = startOfDay(day).getTime();
@@ -106,7 +135,9 @@ export function dayPosition(item: ScheduleItemLike, day: Date): { topPct: number
 // (interval partitioning, greedy by start). Returns per-item lane index and
 // the total lane count of its overlap cluster.
 export function assignLanes(items: ScheduleItemLike[]): Map<string, { lane: number; lanes: number }> {
-  const sorted = [...items].sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+  // id tie-break: equal starts must place deterministically regardless of the
+  // input order, or parallel items swap lanes on unrelated refetches.
+  const sorted = [...items].sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime() || a.id.localeCompare(b.id));
   const laneEnds: number[] = [];
   const laneOf = new Map<string, number>();
   // cluster = maximal run of transitively overlapping items; lanes reset per cluster

--- a/ui/tests/schedule.spec.ts
+++ b/ui/tests/schedule.spec.ts
@@ -11,6 +11,7 @@ import {
   occupancyStatus,
   pctToTime,
   startOfDay,
+  viewDays,
   ScheduleItemLike,
 } from "src/util/schedule";
 
@@ -99,6 +100,15 @@ describe("assignLanes", () => {
     expect(lanes.get("c")).toEqual({ lane: 0, lanes: 1 }); // separate cluster: full width
   });
 
+  it("places equal-start items deterministically regardless of input order", () => {
+    const a = item("a", "2026-08-11T09:00:00", "2026-08-11T12:00:00");
+    const b = item("b", "2026-08-11T09:00:00", "2026-08-11T11:00:00");
+    const forward = assignLanes([a, b]);
+    const backward = assignLanes([b, a]);
+    expect(forward.get("a")).toEqual(backward.get("a"));
+    expect(forward.get("b")).toEqual(backward.get("b"));
+  });
+
   it("reuses a freed lane (boundary touch does not overlap)", () => {
     const a = item("a", "2026-08-11T09:00:00", "2026-08-11T10:00:00");
     const b = item("b", "2026-08-11T09:30:00", "2026-08-11T11:00:00");
@@ -115,6 +125,29 @@ describe("isAssigned", () => {
     expect(isAssigned(a, "u1")).toBe(true);
     expect(isAssigned(a, "u2")).toBe(false);
     expect(isAssigned(a, undefined)).toBe(false);
+  });
+});
+
+describe("viewDays", () => {
+  const anchor = new Date("2026-08-12T15:30:00"); // a Wednesday
+  it("day view is exactly the anchor's day", () => {
+    expect(viewDays("day", anchor, {}, [])).toEqual([new Date("2026-08-12T00:00:00")]);
+  });
+  it("3day view starts at the anchor", () => {
+    const days = viewDays("3day", anchor, {}, []);
+    expect(days).toHaveLength(3);
+    expect(days[0]).toEqual(new Date("2026-08-12T00:00:00"));
+    expect(days[2]).toEqual(new Date("2026-08-14T00:00:00"));
+  });
+  it("week view is the anchor's Monday-based week", () => {
+    const days = viewDays("week", anchor, {}, []);
+    expect(days).toHaveLength(7);
+    expect(days[0]).toEqual(new Date("2026-08-10T00:00:00")); // Monday
+    expect(days[6]).toEqual(new Date("2026-08-16T00:00:00")); // Sunday
+  });
+  it("all view falls through to the project-wide span", () => {
+    const project = { startAt: "2026-08-11T00:00:00", endAt: "2026-08-13T00:00:00" };
+    expect(viewDays("all", anchor, project, [])).toEqual(calendarDays(project, []));
   });
 });
 


### PR DESCRIPTION
- Schedule calendar: day / 3-day / week views next to the project-wide
  view, with bounded prev/next navigation; subdivided blocks now claim
  their shifts inline in the item popover (confetti intact) instead of
  navigating to the detail page; calendar tiles show shift assignees;
  parallel lane order is deterministic (id tie-break in the lane sort
  and a secondary id sort on all list queries — equal keys previously
  came back in mutable physical row order).
- Images: view state (detail image, person filter) lives in the route
  query, so browser back/forward walks grid <-> detail <-> person-filter
  states and clearing the person filter restores the exact grid position
  via a snapshot; query-only navigation keeps the scroll position.
- Project settings: 'Re-queue failed images' re-enqueues all
  dead-lettered AI detections (POST /projects/:id/ai/rerun-failed).
- AI: the aiserver HTTP client's 120s cap silently ate AI_TIMEOUT=180s
  ('Client.Timeout exceeded while awaiting headers') — the client cap is
  now only a 10min hang safety net and the ctx deadline governs; timeout
  classification covers net.Error shapes.
- image-wasm: a missing EXIF DateTimeOriginal no longer fails the upload
  ('could not parse camera time from +02:00') — capture time is optional
  end-to-end; QR time-sync still requires it with a clear message.
