### PR TITLE
fix(schedule): allow the same tag suggestion on multiple schedule items

### DIFF
--- a/.claude/skills/shutterbase-api/SKILL.md
+++ b/.claude/skills/shutterbase-api/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: shutterbase-api
+description: Call the Shutterbase REST API (prod or local) to manage projects, image tags, and schedule items without reading the API source. Use when the user wants to query or mutate Shutterbase data via HTTP/curl — projects, tags, schedule items, assignments, users — or check API connectivity.
+---
+
+# Shutterbase API usage
+
+## Base URL & auth
+
+- **Prod:** `https://shutterbase.fsg.one/api/v1`
+- **Local dev:** `http://localhost:8080/api/v1`
+- **API key:** `SHUTTERBASE_PROD_API_KEY` in `api/.env` (format `keyId.secret`). Send it as:
+
+```sh
+KEY=$(grep '^SHUTTERBASE_PROD_API_KEY=' api/.env | cut -d= -f2)
+curl -s -H "Authorization: ApiKey $KEY" https://shutterbase.fsg.one/api/v1/users/me
+```
+
+The key authenticates as a full user (currently the platform admin), so every endpoint below works with it.
+
+**Gotchas**
+- The base path is `/api/v1`, **not** `/api`. Any unknown path (wrong base, typo) falls through to the SPA and returns **200 with HTML** — a 200 that isn't JSON means your URL is wrong, not that it worked.
+- **Mutations (POST/PUT/PATCH/DELETE) must send a same-origin `Origin` header** or the CSRF check rejects them with 403 `csrf_origin` — even with a valid API key. Always add `-H "Origin: https://shutterbase.fsg.one"` (match the host you're calling). GETs don't need it.
+- Connectivity check: `GET /health` → `{"status":"ok","version":"<image tag>"}` (no auth needed). `GET /users/me` verifies the key.
+- Errors come back as `{"error":"<code>","message":"<human text>"}` with 400/401/403/404.
+
+## List envelope & pagination
+
+Every list endpoint returns `{"limit":N,"offset":N,"total":N,"items":[...]}` and accepts:
+
+| Query | Default | Notes |
+|---|---|---|
+| `limit` | 100 | max 500 |
+| `offset` | 0 | |
+| `order` | `desc` | `asc` or `desc` |
+| `sort` | — | field name, endpoint-specific |
+| `search` | — | where supported (projects, image-tags) |
+
+## Projects
+
+| Method & path | Auth | Notes |
+|---|---|---|
+| `GET /projects` | any (admin sees all, others only assigned) | `?search=` |
+| `GET /projects/:id` | admin or member | |
+| `POST /projects` | **global admin only** | |
+| `PUT /projects/:id` | admin or projectAdmin of the project | partial update — send only changed fields |
+| `DELETE /projects/:id` | **global admin only** | 204 on success |
+
+Create payload (all strings **required** unless marked optional):
+
+```json
+{
+  "name": "FSA26", "description": "...", "copyright": "...",
+  "copyrightReference": "...", "locationName": "...", "locationCode": "...",
+  "locationCity": "...",
+  "aiSystemMessage": null, "uploadReviewEnabled": false,
+  "startAt": "2026-08-01T00:00:00Z", "endAt": "2026-08-07T00:00:00Z"
+}
+```
+
+`aiSystemMessage`, `uploadReviewEnabled`, `startAt`, `endAt` are optional. Update accepts the same fields, all optional. `endAt` before `startAt` → 400 `invalid_period`; a zero timestamp clears a bound. Setting `uploadReviewEnabled: true` auto-creates the reserved custom tag `error` in the project.
+
+## Image tags
+
+| Method & path | Auth | Notes |
+|---|---|---|
+| `GET /image-tags?projectId=<id>` | project member | `projectId` **required**; `?search=`, `?type=` |
+| `GET /image-tags/:id` | member of the tag's project | |
+| `POST /image-tags` | by type: `default`/`manual`/`template` → admin/projectAdmin; `custom` → any member | |
+| `PUT /image-tags/:id` | by *resulting* type, same rule | partial update |
+| `DELETE /image-tags/:id` | admin/projectAdmin | 204 |
+
+Create payload:
+
+```json
+{ "name": "podium", "description": "…", "isAlbum": false,
+  "type": "manual", "projectId": "<project id>" }
+```
+
+- `type` ∈ `template | default | manual | custom`. `default` tags are auto-applied to new uploads; `custom` tags are personal/unofficial and never exported.
+- A `template` tag's name **must start with `$`** (`$PROJECT`, `$DATE`, `$WEEKDAY`, `$COPYRIGHT`) or the API rejects it with `invalid_template_name`.
+- The tag named `error` is reserved for upload review — creating/renaming it needs admin/projectAdmin.
+
+## Schedule items
+
+| Method & path | Auth | Notes |
+|---|---|---|
+| `GET /schedule-items?projectId=<id>` | project member | `projectId` **required**; filters: `from`/`to` (RFC3339), `mine=true` |
+| `GET /schedule-items/:id` | project member | |
+| `POST /schedule-items` | admin/projectAdmin | |
+| `PUT /schedule-items/:id` | admin/projectAdmin | partial update |
+| `DELETE /schedule-items/:id` | admin/projectAdmin | 204 |
+| `PUT /schedule-items/:id/assignees/:userId` | admin/projectAdmin | add assignee |
+| `DELETE /schedule-items/:id/assignees/:userId` | admin/projectAdmin | remove assignee |
+
+Create payload:
+
+```json
+{ "title": "Autocross heats", "description": "…",
+  "start": "2026-08-05T08:00:00Z", "end": "2026-08-05T12:00:00Z",
+  "cardinality": 2, "projectId": "<project id>",
+  "tagIds": ["<image-tag id>", "…"] }
+```
+
+- `title`, `start`, `end`, `projectId` required; `end` must be after `start` (`invalid_window`), `cardinality` ≥ 0 (how many photographers are wanted; 0 = unbounded).
+- `tagIds` must belong to the same project (`tag_project_mismatch`); on update, `tagIds` **replaces** the whole set.
+- Assignees must be members of the item's project (or global admins), else 400 `not_a_member`. Responses embed `assignees` (id, name, email) and `tags` (id, name, type).
+
+## Supporting lookups
+
+| Method & path | Purpose |
+|---|---|
+| `GET /users` (admin) / `GET /users/:id` | find `userId`s for assignees |
+| `GET /users/me` | who the API key acts as; includes `activeProject` |
+| `GET /roles` | find `roleId`s — project roles are `projectAdmin`, `projectEditor`, `projectViewer` |
+| `GET /project-assignments?projectId=<id>` | project roster (admin, self-scoped, or projectAdmin of that project) |
+| `POST /project-assignments` `{projectId, userId, roleId}` | add a member (admin or projectAdmin); only the three project roles are assignable |
+| `PUT /project-assignments/:id` / `DELETE …/:id` | change role / remove member |
+| `GET /version` | deployed image tag + signup flag (no auth) |
+
+## End-to-end example: schedule item with tags and an assignee
+
+```sh
+BASE=https://shutterbase.fsg.one/api/v1
+AUTH="Authorization: ApiKey $KEY"
+
+PROJECT=$(curl -s -H "$AUTH" "$BASE/projects?search=FSA26" | jq -r '.items[0].id')
+TAG=$(curl -s -H "$AUTH" "$BASE/image-tags" -d '{"name":"autocross","type":"manual","projectId":"'$PROJECT'"}' -H 'Content-Type: application/json' | jq -r .id)
+ITEM=$(curl -s -H "$AUTH" "$BASE/schedule-items" -H 'Content-Type: application/json' -d '{
+  "title":"Autocross heats","start":"2026-08-05T08:00:00Z","end":"2026-08-05T12:00:00Z",
+  "cardinality":2,"projectId":"'$PROJECT'","tagIds":["'$TAG'"]}' | jq -r .id)
+USER=$(curl -s -H "$AUTH" "$BASE/project-assignments?projectId=$PROJECT" | jq -r '.items[0].user.id')
+curl -s -X PUT -H "$AUTH" "$BASE/schedule-items/$ITEM/assignees/$USER" | jq '.assignees'
+```

--- a/api/ent/client.go
+++ b/api/ent/client.go
@@ -1140,6 +1140,22 @@ func (c *ImageTagClient) QueryTagAssignments(_m *ImageTag) *ImageTagAssignmentQu
 	return query
 }
 
+// QueryScheduleItems queries the scheduleItems edge of a ImageTag.
+func (c *ImageTagClient) QueryScheduleItems(_m *ImageTag) *ScheduleItemQuery {
+	query := (&ScheduleItemClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(imagetag.Table, imagetag.FieldID, id),
+			sqlgraph.To(scheduleitem.Table, scheduleitem.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, imagetag.ScheduleItemsTable, imagetag.ScheduleItemsPrimaryKey...),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // Hooks returns the client hooks.
 func (c *ImageTagClient) Hooks() []Hook {
 	return c.hooks.ImageTag
@@ -2037,7 +2053,7 @@ func (c *ScheduleItemClient) QueryTags(_m *ScheduleItem) *ImageTagQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(scheduleitem.Table, scheduleitem.FieldID, id),
 			sqlgraph.To(imagetag.Table, imagetag.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, scheduleitem.TagsTable, scheduleitem.TagsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, scheduleitem.TagsTable, scheduleitem.TagsPrimaryKey...),
 		)
 		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
 		return fromV, nil

--- a/api/ent/imagetag.go
+++ b/api/ent/imagetag.go
@@ -39,9 +39,8 @@ type ImageTag struct {
 	ProjectID string `json:"-"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ImageTagQuery when eager-loading is set.
-	Edges              ImageTagEdges `json:"edges"`
-	schedule_item_tags *string
-	selectValues       sql.SelectValues
+	Edges        ImageTagEdges `json:"edges"`
+	selectValues sql.SelectValues
 }
 
 // ImageTagEdges holds the relations/edges for other nodes in the graph.
@@ -50,9 +49,11 @@ type ImageTagEdges struct {
 	Project *Project `json:"project,omitempty"`
 	// TagAssignments holds the value of the tagAssignments edge.
 	TagAssignments []*ImageTagAssignment `json:"tagAssignments,omitempty"`
+	// ScheduleItems holds the value of the scheduleItems edge.
+	ScheduleItems []*ScheduleItem `json:"scheduleItems,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [2]bool
+	loadedTypes [3]bool
 }
 
 // ProjectOrErr returns the Project value or an error if the edge
@@ -75,6 +76,15 @@ func (e ImageTagEdges) TagAssignmentsOrErr() ([]*ImageTagAssignment, error) {
 	return nil, &NotLoadedError{edge: "tagAssignments"}
 }
 
+// ScheduleItemsOrErr returns the ScheduleItems value or an error if the edge
+// was not loaded in eager-loading.
+func (e ImageTagEdges) ScheduleItemsOrErr() ([]*ScheduleItem, error) {
+	if e.loadedTypes[2] {
+		return e.ScheduleItems, nil
+	}
+	return nil, &NotLoadedError{edge: "scheduleItems"}
+}
+
 // scanValues returns the types for scanning values from sql.Rows.
 func (*ImageTag) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
@@ -88,8 +98,6 @@ func (*ImageTag) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullString)
 		case imagetag.FieldCreatedAt, imagetag.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
-		case imagetag.ForeignKeys[0]: // schedule_item_tags
-			values[i] = new(sql.NullString)
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -167,13 +175,6 @@ func (_m *ImageTag) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.ProjectID = value.String
 			}
-		case imagetag.ForeignKeys[0]:
-			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field schedule_item_tags", values[i])
-			} else if value.Valid {
-				_m.schedule_item_tags = new(string)
-				*_m.schedule_item_tags = value.String
-			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -195,6 +196,11 @@ func (_m *ImageTag) QueryProject() *ProjectQuery {
 // QueryTagAssignments queries the "tagAssignments" edge of the ImageTag entity.
 func (_m *ImageTag) QueryTagAssignments() *ImageTagAssignmentQuery {
 	return NewImageTagClient(_m.config).QueryTagAssignments(_m)
+}
+
+// QueryScheduleItems queries the "scheduleItems" edge of the ImageTag entity.
+func (_m *ImageTag) QueryScheduleItems() *ScheduleItemQuery {
+	return NewImageTagClient(_m.config).QueryScheduleItems(_m)
 }
 
 // Update returns a builder for updating this ImageTag.

--- a/api/ent/imagetag/imagetag.go
+++ b/api/ent/imagetag/imagetag.go
@@ -37,6 +37,8 @@ const (
 	EdgeProject = "project"
 	// EdgeTagAssignments holds the string denoting the tagassignments edge name in mutations.
 	EdgeTagAssignments = "tagAssignments"
+	// EdgeScheduleItems holds the string denoting the scheduleitems edge name in mutations.
+	EdgeScheduleItems = "scheduleItems"
 	// Table holds the table name of the imagetag in the database.
 	Table = "image_tags"
 	// ProjectTable is the table that holds the project relation/edge.
@@ -53,6 +55,11 @@ const (
 	TagAssignmentsInverseTable = "image_tag_assignments"
 	// TagAssignmentsColumn is the table column denoting the tagAssignments relation/edge.
 	TagAssignmentsColumn = "image_tag_id"
+	// ScheduleItemsTable is the table that holds the scheduleItems relation/edge. The primary key declared below.
+	ScheduleItemsTable = "schedule_item_tags"
+	// ScheduleItemsInverseTable is the table name for the ScheduleItem entity.
+	// It exists in this package in order to avoid circular dependency with the "scheduleitem" package.
+	ScheduleItemsInverseTable = "schedule_items"
 )
 
 // Columns holds all SQL columns for imagetag fields.
@@ -69,21 +76,16 @@ var Columns = []string{
 	FieldProjectID,
 }
 
-// ForeignKeys holds the SQL foreign-keys that are owned by the "image_tags"
-// table and are not defined as standalone fields in the schema.
-var ForeignKeys = []string{
-	"schedule_item_tags",
-}
+var (
+	// ScheduleItemsPrimaryKey and ScheduleItemsColumn2 are the table columns denoting the
+	// primary key for the scheduleItems relation (M2M).
+	ScheduleItemsPrimaryKey = []string{"schedule_item_id", "image_tag_id"}
+)
 
 // ValidColumn reports if the column name is valid (part of the table columns).
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
-			return true
-		}
-	}
-	for i := range ForeignKeys {
-		if column == ForeignKeys[i] {
 			return true
 		}
 	}
@@ -207,6 +209,20 @@ func ByTagAssignments(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newTagAssignmentsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
+
+// ByScheduleItemsCount orders the results by scheduleItems count.
+func ByScheduleItemsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newScheduleItemsStep(), opts...)
+	}
+}
+
+// ByScheduleItems orders the results by scheduleItems terms.
+func ByScheduleItems(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newScheduleItemsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
 func newProjectStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -219,5 +235,12 @@ func newTagAssignmentsStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(TagAssignmentsInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.O2M, false, TagAssignmentsTable, TagAssignmentsColumn),
+	)
+}
+func newScheduleItemsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ScheduleItemsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, ScheduleItemsTable, ScheduleItemsPrimaryKey...),
 	)
 }

--- a/api/ent/imagetag/where.go
+++ b/api/ent/imagetag/where.go
@@ -557,6 +557,29 @@ func HasTagAssignmentsWith(preds ...predicate.ImageTagAssignment) predicate.Imag
 	})
 }
 
+// HasScheduleItems applies the HasEdge predicate on the "scheduleItems" edge.
+func HasScheduleItems() predicate.ImageTag {
+	return predicate.ImageTag(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, ScheduleItemsTable, ScheduleItemsPrimaryKey...),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasScheduleItemsWith applies the HasEdge predicate on the "scheduleItems" edge with a given conditions (other predicates).
+func HasScheduleItemsWith(preds ...predicate.ScheduleItem) predicate.ImageTag {
+	return predicate.ImageTag(func(s *sql.Selector) {
+		step := newScheduleItemsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.ImageTag) predicate.ImageTag {
 	return predicate.ImageTag(sql.AndPredicates(predicates...))

--- a/api/ent/imagetag_create.go
+++ b/api/ent/imagetag_create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shutterbase/shutterbase/ent/imagetag"
 	"github.com/shutterbase/shutterbase/ent/imagetagassignment"
 	"github.com/shutterbase/shutterbase/ent/project"
+	"github.com/shutterbase/shutterbase/ent/scheduleitem"
 )
 
 // ImageTagCreate is the builder for creating a ImageTag entity.
@@ -149,6 +150,21 @@ func (_c *ImageTagCreate) AddTagAssignments(v ...*ImageTagAssignment) *ImageTagC
 		ids[i] = v[i].ID
 	}
 	return _c.AddTagAssignmentIDs(ids...)
+}
+
+// AddScheduleItemIDs adds the "scheduleItems" edge to the ScheduleItem entity by IDs.
+func (_c *ImageTagCreate) AddScheduleItemIDs(ids ...string) *ImageTagCreate {
+	_c.mutation.AddScheduleItemIDs(ids...)
+	return _c
+}
+
+// AddScheduleItems adds the "scheduleItems" edges to the ScheduleItem entity.
+func (_c *ImageTagCreate) AddScheduleItems(v ...*ScheduleItem) *ImageTagCreate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddScheduleItemIDs(ids...)
 }
 
 // Mutation returns the ImageTagMutation object of the builder.
@@ -343,6 +359,22 @@ func (_c *ImageTagCreate) createSpec() (*ImageTag, *sqlgraph.CreateSpec) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetagassignment.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.ScheduleItemsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   imagetag.ScheduleItemsTable,
+			Columns: imagetag.ScheduleItemsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/api/ent/imagetag_query.go
+++ b/api/ent/imagetag_query.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shutterbase/shutterbase/ent/imagetagassignment"
 	"github.com/shutterbase/shutterbase/ent/predicate"
 	"github.com/shutterbase/shutterbase/ent/project"
+	"github.com/shutterbase/shutterbase/ent/scheduleitem"
 )
 
 // ImageTagQuery is the builder for querying ImageTag entities.
@@ -28,7 +29,7 @@ type ImageTagQuery struct {
 	predicates         []predicate.ImageTag
 	withProject        *ProjectQuery
 	withTagAssignments *ImageTagAssignmentQuery
-	withFKs            bool
+	withScheduleItems  *ScheduleItemQuery
 	modifiers          []func(*sql.Selector)
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
@@ -103,6 +104,28 @@ func (_q *ImageTagQuery) QueryTagAssignments() *ImageTagAssignmentQuery {
 			sqlgraph.From(imagetag.Table, imagetag.FieldID, selector),
 			sqlgraph.To(imagetagassignment.Table, imagetagassignment.FieldID),
 			sqlgraph.Edge(sqlgraph.O2M, false, imagetag.TagAssignmentsTable, imagetag.TagAssignmentsColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryScheduleItems chains the current query on the "scheduleItems" edge.
+func (_q *ImageTagQuery) QueryScheduleItems() *ScheduleItemQuery {
+	query := (&ScheduleItemClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(imagetag.Table, imagetag.FieldID, selector),
+			sqlgraph.To(scheduleitem.Table, scheduleitem.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, imagetag.ScheduleItemsTable, imagetag.ScheduleItemsPrimaryKey...),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -304,6 +327,7 @@ func (_q *ImageTagQuery) Clone() *ImageTagQuery {
 		predicates:         append([]predicate.ImageTag{}, _q.predicates...),
 		withProject:        _q.withProject.Clone(),
 		withTagAssignments: _q.withTagAssignments.Clone(),
+		withScheduleItems:  _q.withScheduleItems.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
 		path: _q.path,
@@ -329,6 +353,17 @@ func (_q *ImageTagQuery) WithTagAssignments(opts ...func(*ImageTagAssignmentQuer
 		opt(query)
 	}
 	_q.withTagAssignments = query
+	return _q
+}
+
+// WithScheduleItems tells the query-builder to eager-load the nodes that are connected to
+// the "scheduleItems" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ImageTagQuery) WithScheduleItems(opts ...func(*ScheduleItemQuery)) *ImageTagQuery {
+	query := (&ScheduleItemClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withScheduleItems = query
 	return _q
 }
 
@@ -409,16 +444,13 @@ func (_q *ImageTagQuery) prepareQuery(ctx context.Context) error {
 func (_q *ImageTagQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*ImageTag, error) {
 	var (
 		nodes       = []*ImageTag{}
-		withFKs     = _q.withFKs
 		_spec       = _q.querySpec()
-		loadedTypes = [2]bool{
+		loadedTypes = [3]bool{
 			_q.withProject != nil,
 			_q.withTagAssignments != nil,
+			_q.withScheduleItems != nil,
 		}
 	)
-	if withFKs {
-		_spec.Node.Columns = append(_spec.Node.Columns, imagetag.ForeignKeys...)
-	}
 	_spec.ScanValues = func(columns []string) ([]any, error) {
 		return (*ImageTag).scanValues(nil, columns)
 	}
@@ -450,6 +482,13 @@ func (_q *ImageTagQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Ima
 		if err := _q.loadTagAssignments(ctx, query, nodes,
 			func(n *ImageTag) { n.Edges.TagAssignments = []*ImageTagAssignment{} },
 			func(n *ImageTag, e *ImageTagAssignment) { n.Edges.TagAssignments = append(n.Edges.TagAssignments, e) }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withScheduleItems; query != nil {
+		if err := _q.loadScheduleItems(ctx, query, nodes,
+			func(n *ImageTag) { n.Edges.ScheduleItems = []*ScheduleItem{} },
+			func(n *ImageTag, e *ScheduleItem) { n.Edges.ScheduleItems = append(n.Edges.ScheduleItems, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -512,6 +551,67 @@ func (_q *ImageTagQuery) loadTagAssignments(ctx context.Context, query *ImageTag
 			return fmt.Errorf(`unexpected referenced foreign-key "image_tag_id" returned %v for node %v`, fk, n.ID)
 		}
 		assign(node, n)
+	}
+	return nil
+}
+func (_q *ImageTagQuery) loadScheduleItems(ctx context.Context, query *ScheduleItemQuery, nodes []*ImageTag, init func(*ImageTag), assign func(*ImageTag, *ScheduleItem)) error {
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[string]*ImageTag)
+	nids := make(map[string]map[*ImageTag]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
+		if init != nil {
+			init(node)
+		}
+	}
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(imagetag.ScheduleItemsTable)
+		s.Join(joinT).On(s.C(scheduleitem.FieldID), joinT.C(imagetag.ScheduleItemsPrimaryKey[0]))
+		s.Where(sql.InValues(joinT.C(imagetag.ScheduleItemsPrimaryKey[1]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(imagetag.ScheduleItemsPrimaryKey[1]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
+	}
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(sql.NullString)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := values[0].(*sql.NullString).String
+				inValue := values[1].(*sql.NullString).String
+				if nids[inValue] == nil {
+					nids[inValue] = map[*ImageTag]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*ScheduleItem](ctx, query, qr, query.inters)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected "scheduleItems" node returned %v`, n.ID)
+		}
+		for kn := range nodes {
+			assign(kn, n)
+		}
 	}
 	return nil
 }

--- a/api/ent/imagetag_update.go
+++ b/api/ent/imagetag_update.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shutterbase/shutterbase/ent/imagetagassignment"
 	"github.com/shutterbase/shutterbase/ent/predicate"
 	"github.com/shutterbase/shutterbase/ent/project"
+	"github.com/shutterbase/shutterbase/ent/scheduleitem"
 )
 
 // ImageTagUpdate is the builder for updating ImageTag entities.
@@ -147,6 +148,21 @@ func (_u *ImageTagUpdate) AddTagAssignments(v ...*ImageTagAssignment) *ImageTagU
 	return _u.AddTagAssignmentIDs(ids...)
 }
 
+// AddScheduleItemIDs adds the "scheduleItems" edge to the ScheduleItem entity by IDs.
+func (_u *ImageTagUpdate) AddScheduleItemIDs(ids ...string) *ImageTagUpdate {
+	_u.mutation.AddScheduleItemIDs(ids...)
+	return _u
+}
+
+// AddScheduleItems adds the "scheduleItems" edges to the ScheduleItem entity.
+func (_u *ImageTagUpdate) AddScheduleItems(v ...*ScheduleItem) *ImageTagUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddScheduleItemIDs(ids...)
+}
+
 // Mutation returns the ImageTagMutation object of the builder.
 func (_u *ImageTagUpdate) Mutation() *ImageTagMutation {
 	return _u.mutation
@@ -177,6 +193,27 @@ func (_u *ImageTagUpdate) RemoveTagAssignments(v ...*ImageTagAssignment) *ImageT
 		ids[i] = v[i].ID
 	}
 	return _u.RemoveTagAssignmentIDs(ids...)
+}
+
+// ClearScheduleItems clears all "scheduleItems" edges to the ScheduleItem entity.
+func (_u *ImageTagUpdate) ClearScheduleItems() *ImageTagUpdate {
+	_u.mutation.ClearScheduleItems()
+	return _u
+}
+
+// RemoveScheduleItemIDs removes the "scheduleItems" edge to ScheduleItem entities by IDs.
+func (_u *ImageTagUpdate) RemoveScheduleItemIDs(ids ...string) *ImageTagUpdate {
+	_u.mutation.RemoveScheduleItemIDs(ids...)
+	return _u
+}
+
+// RemoveScheduleItems removes "scheduleItems" edges to ScheduleItem entities.
+func (_u *ImageTagUpdate) RemoveScheduleItems(v ...*ScheduleItem) *ImageTagUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveScheduleItemIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -348,6 +385,51 @@ func (_u *ImageTagUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if _u.mutation.ScheduleItemsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   imagetag.ScheduleItemsTable,
+			Columns: imagetag.ScheduleItemsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedScheduleItemsIDs(); len(nodes) > 0 && !_u.mutation.ScheduleItemsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   imagetag.ScheduleItemsTable,
+			Columns: imagetag.ScheduleItemsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ScheduleItemsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   imagetag.ScheduleItemsTable,
+			Columns: imagetag.ScheduleItemsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if _node, err = sqlgraph.UpdateNodes(ctx, _u.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{imagetag.Label}
@@ -484,6 +566,21 @@ func (_u *ImageTagUpdateOne) AddTagAssignments(v ...*ImageTagAssignment) *ImageT
 	return _u.AddTagAssignmentIDs(ids...)
 }
 
+// AddScheduleItemIDs adds the "scheduleItems" edge to the ScheduleItem entity by IDs.
+func (_u *ImageTagUpdateOne) AddScheduleItemIDs(ids ...string) *ImageTagUpdateOne {
+	_u.mutation.AddScheduleItemIDs(ids...)
+	return _u
+}
+
+// AddScheduleItems adds the "scheduleItems" edges to the ScheduleItem entity.
+func (_u *ImageTagUpdateOne) AddScheduleItems(v ...*ScheduleItem) *ImageTagUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddScheduleItemIDs(ids...)
+}
+
 // Mutation returns the ImageTagMutation object of the builder.
 func (_u *ImageTagUpdateOne) Mutation() *ImageTagMutation {
 	return _u.mutation
@@ -514,6 +611,27 @@ func (_u *ImageTagUpdateOne) RemoveTagAssignments(v ...*ImageTagAssignment) *Ima
 		ids[i] = v[i].ID
 	}
 	return _u.RemoveTagAssignmentIDs(ids...)
+}
+
+// ClearScheduleItems clears all "scheduleItems" edges to the ScheduleItem entity.
+func (_u *ImageTagUpdateOne) ClearScheduleItems() *ImageTagUpdateOne {
+	_u.mutation.ClearScheduleItems()
+	return _u
+}
+
+// RemoveScheduleItemIDs removes the "scheduleItems" edge to ScheduleItem entities by IDs.
+func (_u *ImageTagUpdateOne) RemoveScheduleItemIDs(ids ...string) *ImageTagUpdateOne {
+	_u.mutation.RemoveScheduleItemIDs(ids...)
+	return _u
+}
+
+// RemoveScheduleItems removes "scheduleItems" edges to ScheduleItem entities.
+func (_u *ImageTagUpdateOne) RemoveScheduleItems(v ...*ScheduleItem) *ImageTagUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveScheduleItemIDs(ids...)
 }
 
 // Where appends a list predicates to the ImageTagUpdate builder.
@@ -708,6 +826,51 @@ func (_u *ImageTagUpdateOne) sqlSave(ctx context.Context) (_node *ImageTag, err 
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetagassignment.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ScheduleItemsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   imagetag.ScheduleItemsTable,
+			Columns: imagetag.ScheduleItemsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedScheduleItemsIDs(); len(nodes) > 0 && !_u.mutation.ScheduleItemsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   imagetag.ScheduleItemsTable,
+			Columns: imagetag.ScheduleItemsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ScheduleItemsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   imagetag.ScheduleItemsTable,
+			Columns: imagetag.ScheduleItemsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(scheduleitem.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -234,7 +234,6 @@ var (
 		{Name: "is_album", Type: field.TypeBool, Default: false},
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"template", "default", "manual", "custom"}},
 		{Name: "project_id", Type: field.TypeString, Size: 15},
-		{Name: "schedule_item_tags", Type: field.TypeString, Nullable: true, Size: 15},
 	}
 	// ImageTagsTable holds the schema information for the "image_tags" table.
 	ImageTagsTable = &schema.Table{
@@ -247,12 +246,6 @@ var (
 				Columns:    []*schema.Column{ImageTagsColumns[9]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.Cascade,
-			},
-			{
-				Symbol:     "image_tags_schedule_items_tags",
-				Columns:    []*schema.Column{ImageTagsColumns[10]},
-				RefColumns: []*schema.Column{ScheduleItemsColumns[0]},
-				OnDelete:   schema.SetNull,
 			},
 		},
 		Indexes: []*schema.Index{
@@ -638,6 +631,31 @@ var (
 			},
 		},
 	}
+	// ScheduleItemTagsColumns holds the columns for the "schedule_item_tags" table.
+	ScheduleItemTagsColumns = []*schema.Column{
+		{Name: "schedule_item_id", Type: field.TypeString, Size: 15},
+		{Name: "image_tag_id", Type: field.TypeString, Size: 15},
+	}
+	// ScheduleItemTagsTable holds the schema information for the "schedule_item_tags" table.
+	ScheduleItemTagsTable = &schema.Table{
+		Name:       "schedule_item_tags",
+		Columns:    ScheduleItemTagsColumns,
+		PrimaryKey: []*schema.Column{ScheduleItemTagsColumns[0], ScheduleItemTagsColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "schedule_item_tags_schedule_item_id",
+				Columns:    []*schema.Column{ScheduleItemTagsColumns[0]},
+				RefColumns: []*schema.Column{ScheduleItemsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "schedule_item_tags_image_tag_id",
+				Columns:    []*schema.Column{ScheduleItemTagsColumns[1]},
+				RefColumns: []*schema.Column{ImageTagsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
 	// Tables holds all the tables in the schema.
 	Tables = []*schema.Table{
 		APIKeysTable,
@@ -654,6 +672,7 @@ var (
 		UploadsTable,
 		UsersTable,
 		ScheduleItemAssigneesTable,
+		ScheduleItemTagsTable,
 	}
 )
 
@@ -665,7 +684,6 @@ func init() {
 	ImagesTable.ForeignKeys[2].RefTable = UploadsTable
 	ImagesTable.ForeignKeys[3].RefTable = UsersTable
 	ImageTagsTable.ForeignKeys[0].RefTable = ProjectsTable
-	ImageTagsTable.ForeignKeys[1].RefTable = ScheduleItemsTable
 	ImageTagAssignmentsTable.ForeignKeys[0].RefTable = ImagesTable
 	ImageTagAssignmentsTable.ForeignKeys[1].RefTable = ImageTagsTable
 	ProjectAssignmentsTable.ForeignKeys[0].RefTable = ProjectsTable
@@ -680,4 +698,6 @@ func init() {
 	UsersTable.ForeignKeys[0].RefTable = ProjectsTable
 	ScheduleItemAssigneesTable.ForeignKeys[0].RefTable = ScheduleItemsTable
 	ScheduleItemAssigneesTable.ForeignKeys[1].RefTable = UsersTable
+	ScheduleItemTagsTable.ForeignKeys[0].RefTable = ScheduleItemsTable
+	ScheduleItemTagsTable.ForeignKeys[1].RefTable = ImageTagsTable
 }

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -5108,6 +5108,9 @@ type ImageTagMutation struct {
 	tagAssignments        map[string]struct{}
 	removedtagAssignments map[string]struct{}
 	clearedtagAssignments bool
+	scheduleItems         map[string]struct{}
+	removedscheduleItems  map[string]struct{}
+	clearedscheduleItems  bool
 	done                  bool
 	oldValue              func(context.Context) (*ImageTag, error)
 	predicates            []predicate.ImageTag
@@ -5648,6 +5651,60 @@ func (m *ImageTagMutation) ResetTagAssignments() {
 	m.removedtagAssignments = nil
 }
 
+// AddScheduleItemIDs adds the "scheduleItems" edge to the ScheduleItem entity by ids.
+func (m *ImageTagMutation) AddScheduleItemIDs(ids ...string) {
+	if m.scheduleItems == nil {
+		m.scheduleItems = make(map[string]struct{})
+	}
+	for i := range ids {
+		m.scheduleItems[ids[i]] = struct{}{}
+	}
+}
+
+// ClearScheduleItems clears the "scheduleItems" edge to the ScheduleItem entity.
+func (m *ImageTagMutation) ClearScheduleItems() {
+	m.clearedscheduleItems = true
+}
+
+// ScheduleItemsCleared reports if the "scheduleItems" edge to the ScheduleItem entity was cleared.
+func (m *ImageTagMutation) ScheduleItemsCleared() bool {
+	return m.clearedscheduleItems
+}
+
+// RemoveScheduleItemIDs removes the "scheduleItems" edge to the ScheduleItem entity by IDs.
+func (m *ImageTagMutation) RemoveScheduleItemIDs(ids ...string) {
+	if m.removedscheduleItems == nil {
+		m.removedscheduleItems = make(map[string]struct{})
+	}
+	for i := range ids {
+		delete(m.scheduleItems, ids[i])
+		m.removedscheduleItems[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedScheduleItems returns the removed IDs of the "scheduleItems" edge to the ScheduleItem entity.
+func (m *ImageTagMutation) RemovedScheduleItemsIDs() (ids []string) {
+	for id := range m.removedscheduleItems {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ScheduleItemsIDs returns the "scheduleItems" edge IDs in the mutation.
+func (m *ImageTagMutation) ScheduleItemsIDs() (ids []string) {
+	for id := range m.scheduleItems {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetScheduleItems resets all changes to the "scheduleItems" edge.
+func (m *ImageTagMutation) ResetScheduleItems() {
+	m.scheduleItems = nil
+	m.clearedscheduleItems = false
+	m.removedscheduleItems = nil
+}
+
 // Where appends a list predicates to the ImageTagMutation builder.
 func (m *ImageTagMutation) Where(ps ...predicate.ImageTag) {
 	m.predicates = append(m.predicates, ps...)
@@ -5932,12 +5989,15 @@ func (m *ImageTagMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ImageTagMutation) AddedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.project != nil {
 		edges = append(edges, imagetag.EdgeProject)
 	}
 	if m.tagAssignments != nil {
 		edges = append(edges, imagetag.EdgeTagAssignments)
+	}
+	if m.scheduleItems != nil {
+		edges = append(edges, imagetag.EdgeScheduleItems)
 	}
 	return edges
 }
@@ -5956,15 +6016,24 @@ func (m *ImageTagMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case imagetag.EdgeScheduleItems:
+		ids := make([]ent.Value, 0, len(m.scheduleItems))
+		for id := range m.scheduleItems {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *ImageTagMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.removedtagAssignments != nil {
 		edges = append(edges, imagetag.EdgeTagAssignments)
+	}
+	if m.removedscheduleItems != nil {
+		edges = append(edges, imagetag.EdgeScheduleItems)
 	}
 	return edges
 }
@@ -5979,18 +6048,27 @@ func (m *ImageTagMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case imagetag.EdgeScheduleItems:
+		ids := make([]ent.Value, 0, len(m.removedscheduleItems))
+		for id := range m.removedscheduleItems {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ImageTagMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.clearedproject {
 		edges = append(edges, imagetag.EdgeProject)
 	}
 	if m.clearedtagAssignments {
 		edges = append(edges, imagetag.EdgeTagAssignments)
+	}
+	if m.clearedscheduleItems {
+		edges = append(edges, imagetag.EdgeScheduleItems)
 	}
 	return edges
 }
@@ -6003,6 +6081,8 @@ func (m *ImageTagMutation) EdgeCleared(name string) bool {
 		return m.clearedproject
 	case imagetag.EdgeTagAssignments:
 		return m.clearedtagAssignments
+	case imagetag.EdgeScheduleItems:
+		return m.clearedscheduleItems
 	}
 	return false
 }
@@ -6027,6 +6107,9 @@ func (m *ImageTagMutation) ResetEdge(name string) error {
 		return nil
 	case imagetag.EdgeTagAssignments:
 		m.ResetTagAssignments()
+		return nil
+	case imagetag.EdgeScheduleItems:
+		m.ResetScheduleItems()
 		return nil
 	}
 	return fmt.Errorf("unknown ImageTag edge %s", name)

--- a/api/ent/project_query.go
+++ b/api/ent/project_query.go
@@ -700,7 +700,6 @@ func (_q *ProjectQuery) loadImageTags(ctx context.Context, query *ImageTagQuery,
 			init(nodes[i])
 		}
 	}
-	query.withFKs = true
 	if len(query.ctx.Fields) > 0 {
 		query.ctx.AppendFieldOnce(imagetag.FieldProjectID)
 	}

--- a/api/ent/scheduleitem/scheduleitem.go
+++ b/api/ent/scheduleitem/scheduleitem.go
@@ -63,13 +63,11 @@ const (
 	// AssigneesInverseTable is the table name for the User entity.
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	AssigneesInverseTable = "users"
-	// TagsTable is the table that holds the tags relation/edge.
-	TagsTable = "image_tags"
+	// TagsTable is the table that holds the tags relation/edge. The primary key declared below.
+	TagsTable = "schedule_item_tags"
 	// TagsInverseTable is the table name for the ImageTag entity.
 	// It exists in this package in order to avoid circular dependency with the "imagetag" package.
 	TagsInverseTable = "image_tags"
-	// TagsColumn is the table column denoting the tags relation/edge.
-	TagsColumn = "schedule_item_tags"
 	// ParentTable is the table that holds the parent relation/edge.
 	ParentTable = "schedule_items"
 	// ParentColumn is the table column denoting the parent relation/edge.
@@ -101,6 +99,9 @@ var (
 	// AssigneesPrimaryKey and AssigneesColumn2 are the table columns denoting the
 	// primary key for the assignees relation (M2M).
 	AssigneesPrimaryKey = []string{"schedule_item_id", "user_id"}
+	// TagsPrimaryKey and TagsColumn2 are the table columns denoting the
+	// primary key for the tags relation (M2M).
+	TagsPrimaryKey = []string{"schedule_item_id", "image_tag_id"}
 )
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -299,7 +300,7 @@ func newTagsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(TagsInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2M, false, TagsTable, TagsColumn),
+		sqlgraph.Edge(sqlgraph.M2M, false, TagsTable, TagsPrimaryKey...),
 	)
 }
 func newParentStep() *sqlgraph.Step {

--- a/api/ent/scheduleitem/where.go
+++ b/api/ent/scheduleitem/where.go
@@ -772,7 +772,7 @@ func HasTags() predicate.ScheduleItem {
 	return predicate.ScheduleItem(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, TagsTable, TagsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, TagsTable, TagsPrimaryKey...),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})

--- a/api/ent/scheduleitem_create.go
+++ b/api/ent/scheduleitem_create.go
@@ -445,10 +445,10 @@ func (_c *ScheduleItemCreate) createSpec() (*ScheduleItem, *sqlgraph.CreateSpec)
 	}
 	if nodes := _c.mutation.TagsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   scheduleitem.TagsTable,
-			Columns: []string{scheduleitem.TagsColumn},
+			Columns: scheduleitem.TagsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),

--- a/api/ent/scheduleitem_query.go
+++ b/api/ent/scheduleitem_query.go
@@ -128,7 +128,7 @@ func (_q *ScheduleItemQuery) QueryTags() *ImageTagQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(scheduleitem.Table, scheduleitem.FieldID, selector),
 			sqlgraph.To(imagetag.Table, imagetag.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, scheduleitem.TagsTable, scheduleitem.TagsColumn),
+			sqlgraph.Edge(sqlgraph.M2M, false, scheduleitem.TagsTable, scheduleitem.TagsPrimaryKey...),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -672,33 +672,63 @@ func (_q *ScheduleItemQuery) loadAssignees(ctx context.Context, query *UserQuery
 	return nil
 }
 func (_q *ScheduleItemQuery) loadTags(ctx context.Context, query *ImageTagQuery, nodes []*ScheduleItem, init func(*ScheduleItem), assign func(*ScheduleItem, *ImageTag)) error {
-	fks := make([]driver.Value, 0, len(nodes))
-	nodeids := make(map[string]*ScheduleItem)
-	for i := range nodes {
-		fks = append(fks, nodes[i].ID)
-		nodeids[nodes[i].ID] = nodes[i]
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[string]*ScheduleItem)
+	nids := make(map[string]map[*ScheduleItem]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
 		if init != nil {
-			init(nodes[i])
+			init(node)
 		}
 	}
-	query.withFKs = true
-	query.Where(predicate.ImageTag(func(s *sql.Selector) {
-		s.Where(sql.InValues(s.C(scheduleitem.TagsColumn), fks...))
-	}))
-	neighbors, err := query.All(ctx)
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(scheduleitem.TagsTable)
+		s.Join(joinT).On(s.C(imagetag.FieldID), joinT.C(scheduleitem.TagsPrimaryKey[1]))
+		s.Where(sql.InValues(joinT.C(scheduleitem.TagsPrimaryKey[0]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(scheduleitem.TagsPrimaryKey[0]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
+	}
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(sql.NullString)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := values[0].(*sql.NullString).String
+				inValue := values[1].(*sql.NullString).String
+				if nids[inValue] == nil {
+					nids[inValue] = map[*ScheduleItem]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*ImageTag](ctx, query, qr, query.inters)
 	if err != nil {
 		return err
 	}
 	for _, n := range neighbors {
-		fk := n.schedule_item_tags
-		if fk == nil {
-			return fmt.Errorf(`foreign-key "schedule_item_tags" is nil for node %v`, n.ID)
-		}
-		node, ok := nodeids[*fk]
+		nodes, ok := nids[n.ID]
 		if !ok {
-			return fmt.Errorf(`unexpected referenced foreign-key "schedule_item_tags" returned %v for node %v`, *fk, n.ID)
+			return fmt.Errorf(`unexpected "tags" node returned %v`, n.ID)
 		}
-		assign(node, n)
+		for kn := range nodes {
+			assign(kn, n)
+		}
 	}
 	return nil
 }

--- a/api/ent/scheduleitem_update.go
+++ b/api/ent/scheduleitem_update.go
@@ -507,10 +507,10 @@ func (_u *ScheduleItemUpdate) sqlSave(ctx context.Context) (_node int, err error
 	}
 	if _u.mutation.TagsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   scheduleitem.TagsTable,
-			Columns: []string{scheduleitem.TagsColumn},
+			Columns: scheduleitem.TagsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),
@@ -520,10 +520,10 @@ func (_u *ScheduleItemUpdate) sqlSave(ctx context.Context) (_node int, err error
 	}
 	if nodes := _u.mutation.RemovedTagsIDs(); len(nodes) > 0 && !_u.mutation.TagsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   scheduleitem.TagsTable,
-			Columns: []string{scheduleitem.TagsColumn},
+			Columns: scheduleitem.TagsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),
@@ -536,10 +536,10 @@ func (_u *ScheduleItemUpdate) sqlSave(ctx context.Context) (_node int, err error
 	}
 	if nodes := _u.mutation.TagsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   scheduleitem.TagsTable,
-			Columns: []string{scheduleitem.TagsColumn},
+			Columns: scheduleitem.TagsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),
@@ -1149,10 +1149,10 @@ func (_u *ScheduleItemUpdateOne) sqlSave(ctx context.Context) (_node *ScheduleIt
 	}
 	if _u.mutation.TagsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   scheduleitem.TagsTable,
-			Columns: []string{scheduleitem.TagsColumn},
+			Columns: scheduleitem.TagsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),
@@ -1162,10 +1162,10 @@ func (_u *ScheduleItemUpdateOne) sqlSave(ctx context.Context) (_node *ScheduleIt
 	}
 	if nodes := _u.mutation.RemovedTagsIDs(); len(nodes) > 0 && !_u.mutation.TagsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   scheduleitem.TagsTable,
-			Columns: []string{scheduleitem.TagsColumn},
+			Columns: scheduleitem.TagsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),
@@ -1178,10 +1178,10 @@ func (_u *ScheduleItemUpdateOne) sqlSave(ctx context.Context) (_node *ScheduleIt
 	}
 	if nodes := _u.mutation.TagsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.M2M,
 			Inverse: false,
 			Table:   scheduleitem.TagsTable,
-			Columns: []string{scheduleitem.TagsColumn},
+			Columns: scheduleitem.TagsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(imagetag.FieldID, field.TypeString),

--- a/api/ent/schema/image_tag.go
+++ b/api/ent/schema/image_tag.go
@@ -27,6 +27,9 @@ func (ImageTag) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("project", Project.Type).Ref("imageTags").Field("project_id").Unique().Required(),
 		edge.To("tagAssignments", ImageTagAssignment.Type),
+		// Non-unique inverse makes tags a real M2M (join table), so one tag can
+		// be suggested on many schedule items — mirrors User.scheduleItems.
+		edge.From("scheduleItems", ScheduleItem.Type).Ref("tags"),
 	}
 }
 

--- a/api/internal/database/connection.go
+++ b/api/internal/database/connection.go
@@ -103,6 +103,9 @@ func (d *Connection) initPostgres() error {
 	if err := ensureGINIndex(context.Background(), db); err != nil {
 		log.Panic().Err(err).Msg("failed to ensure images.imageTags GIN index")
 	}
+	if err := backfillScheduleItemTags(context.Background(), db, d.Options.Schema); err != nil {
+		log.Panic().Err(err).Msg("failed to backfill schedule_item_tags join table")
+	}
 
 	log.Info().Msg("PostgreSQL database client initialized")
 	return nil
@@ -129,6 +132,46 @@ func ensureGINIndex(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("failed to create GIN fallback index: %w", err)
 	}
 	log.Warn().Msg("ent auto-migrate omitted jsonb_path_ops opclass; installed fallback GIN index image_image_tags")
+	return nil
+}
+
+// backfillScheduleItemTags is the one-off migration for the tags edge going
+// O2M -> M2M: it copies the legacy FK column image_tags.schedule_item_tags into
+// the schedule_item_tags join table, then drops the column so this never runs
+// again. No-op (and skipped) once the column is gone; fresh DBs never have it.
+func backfillScheduleItemTags(ctx context.Context, db *sql.DB, schema string) error {
+	if schema == "" {
+		schema = "public"
+	}
+	var exists bool
+	if err := db.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.columns
+		 WHERE table_schema = $1 AND table_name = 'image_tags' AND column_name = 'schedule_item_tags')`,
+		schema).Scan(&exists); err != nil {
+		return fmt.Errorf("failed to check for legacy schedule_item_tags column: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO schedule_item_tags (schedule_item_id, image_tag_id)
+		 SELECT schedule_item_tags, id FROM image_tags WHERE schedule_item_tags IS NOT NULL
+		 ON CONFLICT DO NOTHING`); err != nil {
+		return fmt.Errorf("failed to copy legacy tag links into join table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`ALTER TABLE image_tags DROP COLUMN schedule_item_tags`); err != nil {
+		return fmt.Errorf("failed to drop legacy schedule_item_tags column: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	log.Info().Msg("migrated legacy schedule item tag links to M2M join table")
 	return nil
 }
 

--- a/api/internal/repository/schedule_item_test.go
+++ b/api/internal/repository/schedule_item_test.go
@@ -57,6 +57,37 @@ func TestScheduleItemCRUD(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// Regression: the tags edge was O2M (FK on image_tags), so suggesting the same
+// tag on a second item hit a constraint error -> 409. It is M2M now.
+func TestScheduleItemSameTagOnMultipleItems(t *testing.T) {
+	ctx := context.Background()
+	repo, m := seededRepo(t)
+	tag := []string{m.Tags["Podium"]}
+
+	first, err := repo.CreateScheduleItem(ctx, &repository.CreateScheduleItemParameters{
+		Title: "Design", Start: m.ReferenceNow, End: m.ReferenceNow.Add(time.Hour),
+		ProjectID: m.Project, TagIDs: tag,
+	})
+	require.NoError(t, err)
+
+	second, err := repo.CreateScheduleItem(ctx, &repository.CreateScheduleItemParameters{
+		Title: "Cost", Start: m.ReferenceNow.Add(2 * time.Hour), End: m.ReferenceNow.Add(3 * time.Hour),
+		ProjectID: m.Project, TagIDs: tag,
+	})
+	require.NoError(t, err, "same tag must be suggestible on a second item")
+	require.Len(t, second.Edges.Tags, 1)
+
+	// and via update, the path the 409 was reported on.
+	upd, err := repo.UpdateScheduleItem(ctx, second.ID, &repository.UpdateScheduleItemParameters{TagIDs: &tag})
+	require.NoError(t, err)
+	require.Len(t, upd.Edges.Tags, 1)
+
+	// the first item keeps its suggestion — the tag was not stolen.
+	got, err := repo.GetScheduleItem(ctx, first.ID)
+	require.NoError(t, err)
+	require.Len(t, got.Edges.Tags, 1)
+}
+
 func TestScheduleItemListOverlapAndMine(t *testing.T) {
 	ctx := context.Background()
 	repo, m := seededRepo(t)


### PR DESCRIPTION
The tags edge on schedule items was generated as O2M (FK column on
image_tags), so suggesting a tag already used by another item hit ent's
ownership guard and surfaced as a 409. Add the non-unique inverse edge to
make it a real M2M join table (same pattern as assignees), and backfill
legacy FK links into the join table on startup, dropping the old column.
