### PR TITLE
fix(download): remembered folders, match counts, preview grid, per-file progress

### DIFF
--- a/ui/src/components/download/DownloadConfigDialog.vue
+++ b/ui/src/components/download/DownloadConfigDialog.vue
@@ -222,10 +222,13 @@ watch(
   { immediate: true },
 );
 
-// Any tag type is a valid download filter (albums, custom "error", internal…).
+// Any concrete tag type is a valid download filter (albums, custom "error",
+// internal…). Template tags ($DATE, $WEEKDAY…) are resolved at upload time —
+// no image ever carries the template itself, so offering them here would
+// silently match nothing.
 function tagOptions(exclude: string[]): SearchSelectOption[] {
   return props.projectTags
-    .filter((t) => !exclude.includes(t.id))
+    .filter((t) => t.type !== "template" && !exclude.includes(t.id))
     .map((t) => ({ value: t.id, label: t.name, hint: t.type }))
     .sort((a, b) => a.label.localeCompare(b.label));
 }

--- a/ui/src/pages/download/Download.vue
+++ b/ui/src/pages/download/Download.vue
@@ -19,7 +19,7 @@
         Your browser cannot write into local folders. Bulk download needs the File System Access API — please use Chrome or Edge on desktop.
       </div>
 
-      <!-- active run -->
+      <!-- active run: one overall bar + one bar per parallel download -->
       <div v-if="run" class="mt-6 rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark" data-testid="download-run">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div class="min-w-0">
@@ -39,9 +39,72 @@
             :style="{ width: run.progress.total ? `${(run.progress.done / run.progress.total) * 100}%` : '100%' }"
           ></div>
         </div>
+        <div v-if="!run.finished" class="mt-3 space-y-2">
+          <div v-for="(worker, slot) in run.progress.workers" :key="slot" class="flex items-center gap-3">
+            <span class="w-56 truncate font-mono text-[11px] text-primary-500 dark:text-primary-400">
+              {{ worker ? worker.fileName : "—" }}
+            </span>
+            <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-primary-100 dark:bg-primary-800">
+              <div
+                v-if="worker"
+                class="h-full rounded-full bg-accent-400 transition-all"
+                :class="{ 'animate-pulse': !worker.total }"
+                :style="{ width: worker.total ? `${(worker.received / worker.total) * 100}%` : '100%' }"
+              ></div>
+            </div>
+            <span class="w-20 text-right font-mono text-[11px] tabular-nums text-primary-400">
+              {{ worker ? formatBytes(worker.received) : "" }}
+            </span>
+          </div>
+        </div>
         <div v-if="run.finished && run.progress.failed.length" class="mt-3 text-xs text-red-600 dark:text-red-400">
           <p class="font-medium">Failed after {{ RETRY_COUNT }} retries (a delta run will pick them up again):</p>
           <p class="mt-1 max-h-24 overflow-y-auto font-mono">{{ run.progress.failed.join(", ") }}</p>
+        </div>
+      </div>
+
+      <!-- preview: what a run would do, straight from the shared plan logic -->
+      <div v-if="preview" class="mt-6 rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark" data-testid="download-preview">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="min-w-0">
+            <p class="text-sm font-semibold text-primary-900 dark:text-white">{{ preview.config.name }} — preview</p>
+            <p class="mt-0.5 text-xs tabular-nums text-primary-500 dark:text-primary-400">
+              {{ preview.images.length }} matching · {{ preview.plan.counts.present }} already in folder ·
+              <span class="font-semibold text-accent-600 dark:text-accent-400">{{ preview.plan.counts.new + preview.plan.counts.changed }} to download</span>
+              ({{ preview.plan.counts.new }} new, {{ preview.plan.counts.changed }} changed)
+              <span v-if="preview.plan.counts.excluded"> · {{ preview.plan.counts.excluded }} excluded</span>
+            </p>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <button
+              type="button"
+              class="btn-primary"
+              :disabled="!!activeRun || preview.plan.counts.new + preview.plan.counts.changed === 0"
+              @click="startRun(preview.config, true)"
+            >
+              <ArrowPathIcon class="h-4 w-4" />
+              Download new + changed ({{ preview.plan.counts.new + preview.plan.counts.changed }})
+            </button>
+            <button type="button" class="btn-secondary" :disabled="!!activeRun" @click="startRun(preview.config, false)">
+              <ArrowDownTrayIcon class="h-4 w-4" />
+              Full ({{ preview.images.length - preview.plan.counts.excluded }})
+            </button>
+            <button type="button" class="btn-secondary" @click="preview = null">Dismiss</button>
+          </div>
+        </div>
+        <div class="mt-4 grid max-h-[28rem] grid-cols-[repeat(auto-fill,minmax(7rem,1fr))] gap-1.5 overflow-y-auto">
+          <div v-for="image in preview.images" :key="image.id" class="group relative aspect-[3/2] overflow-hidden rounded-md bg-primary-100 dark:bg-primary-800">
+            <img
+              :src="image.downloadUrls?.['256']"
+              :alt="image.computedFileName"
+              loading="lazy"
+              class="h-full w-full object-cover"
+              :class="{ 'opacity-30': preview.plan.statuses.get(image.id) === 'excluded' }"
+            />
+            <span class="absolute bottom-1 left-1 rounded px-1 py-px text-[10px] font-semibold" :class="statusBadgeClass(preview.plan.statuses.get(image.id))">
+              {{ statusLabel(preview.plan.statuses.get(image.id)) }}
+            </span>
+          </div>
         </div>
       </div>
 
@@ -82,20 +145,40 @@
             <span v-if="!config.whitelistTagIds.length && !config.blacklistTagIds.length" class="text-primary-400">all photos</span>
           </div>
           <p class="mt-2 text-xs text-primary-500 dark:text-primary-400">
-            <span v-if="config.blockedImageIds.length">{{ config.blockedImageIds.length }} blocked · </span>
-            <span v-if="config.deltaSubfolder">delta subfolder · </span>
-            <span v-if="config.groupByDate">by date · </span>
+            <span class="font-semibold text-primary-700 dark:text-primary-200" data-testid="match-count">
+              {{ matchCounts[config.id] !== undefined ? `${matchCounts[config.id]} matching images` : "counting…" }}
+            </span>
+            <span v-if="config.blockedImageIds.length"> · {{ config.blockedImageIds.length }} blocked</span>
+            <span v-if="config.deltaSubfolder"> · delta subfolder</span>
+            <span v-if="config.groupByDate"> · by date</span>
+          </p>
+          <p class="mt-1 flex items-center gap-1 text-xs text-primary-500 dark:text-primary-400">
+            <FolderIcon class="h-3.5 w-3.5 flex-shrink-0" />
+            <span class="truncate">{{ folderNames[config.id] ?? "no folder picked yet" }}</span>
+            <button
+              type="button"
+              class="ml-auto flex-shrink-0 cursor-pointer rounded px-1.5 py-0.5 text-[11px] font-medium text-accent-600 transition-colors hover:bg-accent-500/10 dark:text-accent-400"
+              @click="changeFolder(config)"
+            >
+              {{ folderNames[config.id] ? "change" : "pick" }}
+            </button>
+          </p>
+          <p class="mt-1 text-xs text-primary-500 dark:text-primary-400">
             <span v-if="config.lastDownloadAt">last download {{ formatDateTime(config.lastDownloadAt) }}</span>
             <span v-else>never downloaded</span>
           </p>
           <div class="mt-3 flex gap-2 border-t border-primary-100 pt-3 dark:border-primary-800">
-            <button type="button" class="btn-primary flex-1" :disabled="!supported || !!activeRun" @click="startRun(config, false)">
-              <ArrowDownTrayIcon class="h-4 w-4" />
-              Full
+            <button type="button" class="btn-primary flex-1" :disabled="!supported || !!activeRun || previewLoading" @click="openPreview(config)">
+              <EyeIcon class="h-4 w-4" />
+              {{ previewLoading === config.id ? "Scanning…" : "Preview" }}
             </button>
             <button type="button" class="btn-secondary flex-1" :disabled="!supported || !!activeRun" @click="startRun(config, true)">
               <ArrowPathIcon class="h-4 w-4" />
               Delta
+            </button>
+            <button type="button" class="btn-secondary flex-1" :disabled="!supported || !!activeRun" @click="startRun(config, false)">
+              <ArrowDownTrayIcon class="h-4 w-4" />
+              Full
             </button>
           </div>
         </div>
@@ -117,7 +200,7 @@
 </template>
 
 <script setup lang="ts">
-import { ArrowDownTrayIcon, ArrowPathIcon, PencilIcon, PlusIcon } from "@heroicons/vue/24/outline";
+import { ArrowDownTrayIcon, ArrowPathIcon, EyeIcon, FolderIcon, PencilIcon, PlusIcon } from "@heroicons/vue/24/outline";
 import { DateTime } from "luxon";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, ref, watch } from "vue";
@@ -128,7 +211,18 @@ import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
 import { DownloadConfigCreate, DownloadConfigUpdate } from "src/api/downloadConfigs";
 import { useUserStore } from "src/stores/user-store";
 import { DownloadConfig, Image, ImageTag } from "src/types/api";
-import { isDirectoryPickerSupported, pickDirectory, runDownload, RunProgress, RETRY_COUNT } from "src/util/downloadRunner";
+import { ensurePermission, getStoredDirHandle, storeDirHandle } from "src/util/dirHandleStore";
+import {
+  collectExistingFiles,
+  DownloadPlan,
+  ImageStatus,
+  isDirectoryPickerSupported,
+  pickDirectory,
+  planDownload,
+  RETRY_COUNT,
+  RunProgress,
+  runDownload,
+} from "src/util/downloadRunner";
 
 const userStore = useUserStore();
 const { activeProjectId } = storeToRefs(userStore);
@@ -136,6 +230,8 @@ const { activeProjectId } = storeToRefs(userStore);
 const supported = isDirectoryPickerSupported();
 const configs = ref<DownloadConfig[]>([]);
 const projectTags = ref<ImageTag[]>([]);
+const matchCounts = ref<Record<string, number>>({});
+const folderNames = ref<Record<string, string>>({});
 const loaded = ref(false);
 
 const unexpectedError = ref<any>(null);
@@ -155,6 +251,7 @@ async function loadData() {
     configs.value = configList.items;
     projectTags.value = tagList.items;
     loaded.value = true;
+    void loadCardMeta(configList.items);
   } catch (error: any) {
     fail(error);
   }
@@ -162,10 +259,46 @@ async function loadData() {
 onMounted(loadData);
 watch(activeProjectId, loadData);
 
+// Per-card metadata: how many images match the filter (limit=1, total only)
+// and the name of the remembered target folder.
+async function loadCardMeta(list: DownloadConfig[]) {
+  await Promise.all(
+    list.map(async (config) => {
+      try {
+        const page = await api.images.list({
+          projectId: activeProjectId.value,
+          tagId: config.whitelistTagIds.length ? config.whitelistTagIds : undefined,
+          limit: 1,
+        });
+        matchCounts.value[config.id] = page.total;
+      } catch {
+        // count stays "counting…" — non-fatal
+      }
+      const handle = await getStoredDirHandle(config.id);
+      if (handle) folderNames.value[config.id] = handle.name;
+    }),
+  );
+}
+
 function tagName(id: string): string {
   return projectTags.value.find((t) => t.id === id)?.name ?? id;
 }
 const formatDateTime = (iso: string) => DateTime.fromISO(iso).toLocaleString(DateTime.DATETIME_SHORT);
+const formatBytes = (n: number) => (n > 1048576 ? `${(n / 1048576).toFixed(1)} MB` : `${Math.round(n / 1024)} kB`);
+
+const statusLabel = (s?: ImageStatus) => ({ new: "new", changed: "changed", present: "present", excluded: "excluded" })[s ?? "present"];
+function statusBadgeClass(s?: ImageStatus): string {
+  switch (s) {
+    case "new":
+      return "bg-accent-600 text-white";
+    case "changed":
+      return "bg-amber-500 text-white";
+    case "excluded":
+      return "bg-red-600/90 text-white";
+    default:
+      return "bg-primary-900/70 text-white";
+  }
+}
 
 // ---- config CRUD ----
 const dialogOpen = ref(false);
@@ -193,6 +326,7 @@ async function saveConfig(payload: DownloadConfigCreate | DownloadConfigUpdate) 
       showNotificationToast({ headline: "Download config saved", type: "success" });
     }
     dialogOpen.value = false;
+    preview.value = null; // filters may have changed — a stale preview lies
     await loadData();
   } catch (error: any) {
     fail(error);
@@ -211,16 +345,27 @@ async function deleteConfig() {
   }
 }
 
-// ---- download run ----
-interface RunState {
-  configName: string;
-  delta: boolean;
-  progress: RunProgress;
-  finished: boolean;
-  aborted: boolean;
+// ---- directory persistence ----
+// The picked folder is remembered per config (IndexedDB) — runs reuse it
+// silently; "change" on the card re-picks.
+async function getDirectory(config: DownloadConfig, forcePick = false): Promise<FileSystemDirectoryHandle | null> {
+  if (!forcePick) {
+    const stored = await getStoredDirHandle(config.id);
+    if (stored && (await ensurePermission(stored))) return stored;
+  }
+  try {
+    const handle = await pickDirectory();
+    await storeDirHandle(config.id, handle);
+    folderNames.value[config.id] = handle.name;
+    return handle;
+  } catch {
+    return null; // user dismissed the picker
+  }
 }
-const run = ref<RunState | null>(null);
-const activeRun = computed(() => run.value && !run.value.finished);
+
+async function changeFolder(config: DownloadConfig) {
+  await getDirectory(config, true);
+}
 
 // fetchAllImages pages through /images with the config's AND whitelist —
 // the same server-side filter the CLI used.
@@ -241,26 +386,60 @@ async function fetchAllImages(config: DownloadConfig): Promise<Image[]> {
   }
 }
 
-async function startRun(config: DownloadConfig, delta: boolean) {
-  let directory: FileSystemDirectoryHandle;
+// ---- preview ----
+interface PreviewState {
+  config: DownloadConfig;
+  images: Image[];
+  plan: DownloadPlan; // delta-mode plan: new/changed/present/excluded counts
+  directory: FileSystemDirectoryHandle;
+}
+const preview = ref<PreviewState | null>(null);
+const previewLoading = ref<string | null>(null);
+
+async function openPreview(config: DownloadConfig) {
+  previewLoading.value = config.id;
   try {
-    directory = await pickDirectory();
-  } catch {
-    return; // user dismissed the picker
+    const directory = await getDirectory(config);
+    if (!directory) return;
+    const [images, existing] = await Promise.all([fetchAllImages(config), collectExistingFiles(directory)]);
+    preview.value = { config, images, plan: planDownload(images, config, existing, { delta: true }), directory };
+  } catch (error: any) {
+    fail(error);
+  } finally {
+    previewLoading.value = null;
   }
+}
+
+// ---- download run ----
+interface RunState {
+  configName: string;
+  delta: boolean;
+  progress: RunProgress;
+  finished: boolean;
+  aborted: boolean;
+}
+const run = ref<RunState | null>(null);
+const activeRun = computed(() => run.value && !run.value.finished);
+
+async function startRun(config: DownloadConfig, delta: boolean) {
+  const directory = preview.value?.config.id === config.id ? preview.value.directory : await getDirectory(config);
+  if (!directory) return;
   const runStart = new Date();
   const state: RunState = {
     configName: config.name,
     delta,
-    progress: { total: 0, done: 0, failed: [], skipped: 0 },
+    progress: { total: 0, done: 0, failed: [], skipped: 0, workers: [] },
     finished: false,
     aborted: false,
   };
   run.value = state;
+  preview.value = null; // the run invalidates the preview's counts
   try {
-    const images = await fetchAllImages(config);
+    // Re-plan at run time — the preview may be minutes old.
+    const [images, existing] = await Promise.all([fetchAllImages(config), collectExistingFiles(directory)]);
+    const plan = planDownload(images, config, existing, { delta });
     const result = await runDownload(
-      images,
+      plan,
       config,
       directory,
       { delta, runDate: runStart },

--- a/ui/src/util/dirHandleStore.ts
+++ b/ui/src/util/dirHandleStore.ts
@@ -1,0 +1,62 @@
+// Per-config persistence of the picked download directory. Directory handles
+// are structured-cloneable, so IndexedDB can store them across sessions —
+// localStorage cannot. Permissions do not survive a browser restart; the
+// caller re-requests them via ensurePermission (needs a user gesture).
+const DB_NAME = "shutterbase-download";
+const STORE = "dirHandles";
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => request.result.createObjectStore(STORE);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function tx<T>(mode: IDBTransactionMode, run: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+  return openDb().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const request = run(db.transaction(STORE, mode).objectStore(STORE));
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      }),
+  );
+}
+
+export async function getStoredDirHandle(configId: string): Promise<FileSystemDirectoryHandle | undefined> {
+  try {
+    return await tx("readonly", (store) => store.get(configId) as IDBRequest<FileSystemDirectoryHandle | undefined>);
+  } catch {
+    return undefined;
+  }
+}
+
+export async function storeDirHandle(configId: string, handle: FileSystemDirectoryHandle): Promise<void> {
+  try {
+    await tx("readwrite", (store) => store.put(handle, configId));
+  } catch {
+    // best effort — worst case the user re-picks the folder next run
+  }
+}
+
+export async function removeDirHandle(configId: string): Promise<void> {
+  try {
+    await tx("readwrite", (store) => store.delete(configId));
+  } catch {
+    // ignore
+  }
+}
+
+// ensurePermission re-acquires readwrite access on a stored handle. Returns
+// false when the user denies or the handle is stale (folder deleted/moved).
+export async function ensurePermission(handle: FileSystemDirectoryHandle): Promise<boolean> {
+  const h = handle as any;
+  try {
+    if ((await h.queryPermission({ mode: "readwrite" })) === "granted") return true;
+    return (await h.requestPermission({ mode: "readwrite" })) === "granted";
+  } catch {
+    return false;
+  }
+}

--- a/ui/src/util/downloadRunner.ts
+++ b/ui/src/util/downloadRunner.ts
@@ -33,20 +33,51 @@ export function isExcluded(image: Pick<Image, "id" | "computedFileName" | "image
   return config.blacklistTagIds.some((tagId) => (image.imageTags ?? []).includes(tagId));
 }
 
-// needsDownload: CLI delta semantics. existingFiles holds basenames found
-// anywhere under the target directory (recursive), so files from earlier
-// full runs, date folders or delta subfolders all count as present.
-export function needsDownload(
-  image: Pick<Image, "computedFileName" | "updatedAt">,
-  config: Pick<DownloadConfig, "lastDownloadAt">,
+// ImageStatus drives both the preview grid and the run plan:
+//   excluded — blacklist tag or blocklist entry
+//   new      — no local file yet, will be downloaded
+//   changed  — local file exists but the image was updated after the delta
+//              window start, will be re-downloaded
+//   present  — local file exists and is up to date
+export type ImageStatus = "excluded" | "new" | "changed" | "present";
+
+export function classifyImage(
+  image: Pick<Image, "id" | "computedFileName" | "imageTags" | "updatedAt">,
+  config: Pick<DownloadConfig, "blacklistTagIds" | "blockedImageIds" | "lastDownloadAt">,
   existingFiles: Set<string>,
-  options: Pick<RunOptions, "delta">,
-): boolean {
-  if (!options.delta) return true;
-  if (!existingFiles.has(downloadFileName(image))) return true;
-  if (!config.lastDownloadAt) return false;
-  const windowStart = new Date(config.lastDownloadAt).getTime() - DELTA_SAFETY_MARGIN_MS;
-  return new Date(image.updatedAt).getTime() > windowStart;
+): ImageStatus {
+  if (isExcluded(image, config)) return "excluded";
+  if (!existingFiles.has(downloadFileName(image))) return "new";
+  if (config.lastDownloadAt) {
+    const windowStart = new Date(config.lastDownloadAt).getTime() - DELTA_SAFETY_MARGIN_MS;
+    if (new Date(image.updatedAt).getTime() > windowStart) return "changed";
+  }
+  return "present";
+}
+
+export interface DownloadPlan {
+  statuses: Map<string, ImageStatus>; // by image id
+  counts: Record<ImageStatus, number>;
+  // download order for the given mode: full = everything not excluded,
+  // delta = new + changed only
+  wanted: Image[];
+}
+
+// planDownload is the single source of truth shared by the preview panel and
+// the actual run — what the preview shows is exactly what a run would do.
+export function planDownload(images: Image[], config: DownloadConfig, existingFiles: Set<string>, options: Pick<RunOptions, "delta">): DownloadPlan {
+  const statuses = new Map<string, ImageStatus>();
+  const counts: Record<ImageStatus, number> = { excluded: 0, new: 0, changed: 0, present: 0 };
+  const wanted: Image[] = [];
+  for (const image of images) {
+    const status = classifyImage(image, config, existingFiles);
+    statuses.set(image.id, status);
+    counts[status]++;
+    if (status === "new" || status === "changed" || (!options.delta && status === "present")) {
+      wanted.push(image);
+    }
+  }
+  return { statuses, counts, wanted };
 }
 
 // targetSegments: folder path (without the file name) inside the picked
@@ -72,11 +103,18 @@ function isoDate(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
+export interface FileProgress {
+  fileName: string;
+  received: number;
+  total: number; // 0 when the server sends no content-length
+}
+
 export interface RunProgress {
   total: number;
   done: number;
   failed: string[]; // computedFileNames that exhausted retries
-  skipped: number; // images filtered out (delta up-to-date, blacklist, blocked)
+  skipped: number; // images not part of this run (excluded / already present)
+  workers: (FileProgress | null)[]; // per-parallel-slot file progress
 }
 
 // ---- File System Access API glue (Chromium desktop only) ----
@@ -115,9 +153,9 @@ async function ensureDirectory(root: FileSystemDirectoryHandle, segments: string
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // downloadImageToDirectory streams one original into the target folder,
-// retrying on failure. The writable is aborted on error, so a broken stream
-// never leaves a partial file behind.
-export async function downloadImageToDirectory(image: Image, root: FileSystemDirectoryHandle, segments: string[]): Promise<void> {
+// retrying on failure and reporting byte progress. The writable is aborted on
+// error, so a broken stream never leaves a partial file behind.
+export async function downloadImageToDirectory(image: Image, root: FileSystemDirectoryHandle, segments: string[], onProgress?: (p: FileProgress) => void): Promise<void> {
   let lastError: unknown = null;
   for (let attempt = 0; attempt <= RETRY_COUNT; attempt++) {
     if (attempt > 0) await sleep(RETRY_WAIT_MS);
@@ -126,11 +164,21 @@ export async function downloadImageToDirectory(image: Image, root: FileSystemDir
       if (!response.ok || !response.body) {
         throw new Error(`download of ${image.computedFileName} failed: status ${response.status}`);
       }
+      const total = Number(response.headers.get("content-length") ?? 0);
       const dir = await ensureDirectory(root, segments);
       const fileHandle = await dir.getFileHandle(downloadFileName(image), { create: true });
       const writable = await fileHandle.createWritable();
+      const reader = response.body.getReader();
+      let received = 0;
       try {
-        await response.body.pipeTo(writable);
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          await writable.write(value);
+          received += value.byteLength;
+          onProgress?.({ fileName: image.computedFileName, received, total });
+        }
+        await writable.close();
       } catch (streamError) {
         await writable.abort().catch(() => undefined);
         throw streamError;
@@ -143,35 +191,51 @@ export async function downloadImageToDirectory(image: Image, root: FileSystemDir
   throw lastError;
 }
 
-// runDownload executes the plan with a small worker pool. Returns the final
-// progress; the caller persists lastDownloadAt only when nothing failed.
+// runDownload executes a precomputed plan with a small worker pool. Returns
+// the final progress; the caller persists lastDownloadAt only when the run
+// completed (not aborted).
 export async function runDownload(
-  images: Image[],
+  plan: DownloadPlan,
   config: DownloadConfig,
   root: FileSystemDirectoryHandle,
   options: RunOptions,
   onProgress: (p: RunProgress) => void,
   shouldAbort: () => boolean,
 ): Promise<RunProgress> {
-  const existing = await collectExistingFiles(root);
-  const wanted = images.filter((img) => !isExcluded(img, config) && needsDownload(img, config, existing, options));
-  const progress: RunProgress = { total: wanted.length, done: 0, failed: [], skipped: images.length - wanted.length };
-  onProgress({ ...progress });
+  const progress: RunProgress = {
+    total: plan.wanted.length,
+    done: 0,
+    failed: [],
+    skipped: plan.statuses.size - plan.wanted.length,
+    workers: Array.from({ length: PARALLELISM }, () => null),
+  };
+  onProgress({ ...progress, workers: [...progress.workers] });
+  const emit = () => onProgress({ ...progress, workers: [...progress.workers] });
 
-  const queue = [...wanted];
-  const worker = async (): Promise<void> => {
+  const queue = [...plan.wanted];
+  const worker = async (slot: number): Promise<void> => {
     for (;;) {
       const image = queue.shift();
-      if (!image || shouldAbort()) return;
+      if (!image || shouldAbort()) {
+        progress.workers[slot] = null;
+        emit();
+        return;
+      }
+      progress.workers[slot] = { fileName: image.computedFileName, received: 0, total: 0 };
+      emit();
       try {
-        await downloadImageToDirectory(image, root, targetSegments(image, config, options));
+        await downloadImageToDirectory(image, root, targetSegments(image, config, options), (p) => {
+          progress.workers[slot] = p;
+          emit();
+        });
       } catch {
         progress.failed.push(image.computedFileName);
       }
       progress.done++;
-      onProgress({ ...progress });
+      progress.workers[slot] = null;
+      emit();
     }
   };
-  await Promise.all(Array.from({ length: PARALLELISM }, () => worker()));
+  await Promise.all(Array.from({ length: PARALLELISM }, (_, slot) => worker(slot)));
   return progress;
 }

--- a/ui/tests/downloadRunner.spec.ts
+++ b/ui/tests/downloadRunner.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { isExcluded, needsDownload, targetSegments, downloadFileName, DELTA_SAFETY_MARGIN_MS } from "src/util/downloadRunner";
+import { classifyImage, planDownload, isExcluded, targetSegments, downloadFileName, DELTA_SAFETY_MARGIN_MS } from "src/util/downloadRunner";
+import { DownloadConfig, Image } from "src/types/api";
 
 const config = {
   blacklistTagIds: ["internal"],
@@ -7,9 +8,14 @@ const config = {
   lastDownloadAt: "2026-07-28T12:00:00Z",
   deltaSubfolder: false,
   groupByDate: false,
-};
+} as unknown as DownloadConfig;
 
-const image = { id: "img000000000001", computedFileName: "FSG26_001_max", imageTags: ["podium"], updatedAt: "2026-07-28T09:00:00Z" };
+const image = {
+  id: "img000000000001",
+  computedFileName: "FSG26_001_max",
+  imageTags: ["podium"],
+  updatedAt: "2026-07-28T09:00:00Z",
+} as unknown as Image;
 
 describe("downloadFileName", () => {
   it("appends .jpg to the computed name", () => {
@@ -35,26 +41,55 @@ describe("isExcluded", () => {
   });
 });
 
-describe("needsDownload", () => {
+describe("classifyImage", () => {
   const existing = new Set(["FSG26_001_max.jpg"]);
 
-  it("downloads everything on a full run", () => {
-    expect(needsDownload(image, config, existing, { delta: false })).toBe(true);
+  it("marks missing files as new", () => {
+    expect(classifyImage(image, config, new Set())).toBe("new");
   });
-  it("downloads missing files on a delta run", () => {
-    expect(needsDownload(image, config, new Set(), { delta: true })).toBe(true);
+  it("marks existing untouched files as present", () => {
+    expect(classifyImage(image, config, existing)).toBe("present");
   });
-  it("skips existing files older than the delta window", () => {
-    expect(needsDownload(image, config, existing, { delta: true })).toBe(false);
+  it("marks files updated after lastDownloadAt minus the safety margin as changed", () => {
+    expect(classifyImage({ ...image, updatedAt: "2026-07-28T12:30:00Z" }, config, existing)).toBe("changed");
+    const margin = new Date(new Date(config.lastDownloadAt!).getTime() - DELTA_SAFETY_MARGIN_MS / 2).toISOString();
+    expect(classifyImage({ ...image, updatedAt: margin }, config, existing)).toBe("changed");
   });
-  it("re-downloads files updated after lastDownloadAt minus the safety margin", () => {
-    const updated = { ...image, updatedAt: "2026-07-28T12:30:00Z" };
-    expect(needsDownload(updated, config, existing, { delta: true })).toBe(true);
-    const margin = new Date(new Date(config.lastDownloadAt).getTime() - DELTA_SAFETY_MARGIN_MS / 2).toISOString();
-    expect(needsDownload({ ...image, updatedAt: margin }, config, existing, { delta: true })).toBe(true);
+  it("marks blacklisted images as excluded before anything else", () => {
+    expect(classifyImage({ ...image, imageTags: ["internal"] }, config, new Set())).toBe("excluded");
   });
-  it("skips existing files when the config never completed a run", () => {
-    expect(needsDownload(image, { lastDownloadAt: null }, existing, { delta: true })).toBe(false);
+  it("treats existing files as present when the config never completed a run", () => {
+    expect(classifyImage(image, { ...config, lastDownloadAt: null }, existing)).toBe("present");
+  });
+});
+
+describe("planDownload", () => {
+  const images = [
+    image, // present
+    { ...image, id: "img2", computedFileName: "FSG26_002_max" }, // new
+    { ...image, id: "img3", updatedAt: "2026-07-28T13:00:00Z" }, // changed (same file name as img1 — use distinct name)
+    { ...image, id: "img4", computedFileName: "FSG26_004_max", imageTags: ["internal"] }, // excluded
+  ] as Image[];
+  // distinct file for the changed case
+  images[2] = { ...images[2], computedFileName: "FSG26_003_max" } as Image;
+  const existing = new Set(["FSG26_001_max.jpg", "FSG26_003_max.jpg"]);
+
+  it("counts all four statuses", () => {
+    const plan = planDownload(images, config, existing, { delta: true });
+    expect(plan.counts).toEqual({ present: 1, new: 1, changed: 1, excluded: 1 });
+  });
+  it("delta wants only new + changed", () => {
+    const plan = planDownload(images, config, existing, { delta: true });
+    expect(plan.wanted.map((i) => i.id)).toEqual(["img2", "img3"]);
+  });
+  it("full wants everything except excluded", () => {
+    const plan = planDownload(images, config, existing, { delta: false });
+    expect(plan.wanted.map((i) => i.id)).toEqual([image.id, "img2", "img3"]);
+  });
+  it("statuses map is keyed by image id", () => {
+    const plan = planDownload(images, config, existing, { delta: true });
+    expect(plan.statuses.get("img4")).toBe("excluded");
+    expect(plan.statuses.get("img2")).toBe("new");
   });
 });
 


### PR DESCRIPTION
Revision of the download page after first field test: the picked directory
is persisted per config (IndexedDB) and reused unless changed; each config
card shows how many images match its filter; a preview panel scans the
target folder and shows present/new/changed/excluded counts over a full
thumbnail grid (same plan code the run uses); the run panel gains per-file
progress bars for each parallel download alongside the overall bar.

Filter validation against prod confirmed the server-side AND tag filter is
correct; template tags ($DATE, $WEEKDAY) are no longer offered as filter
options since images never carry them — picking one silently matched
nothing.
