### PR TITLE
fix(spa): survive rolling updates — stale-chunk recovery, version-aware navigation, correct cache headers

### DIFF
--- a/api/internal/server/server.go
+++ b/api/internal/server/server.go
@@ -259,13 +259,32 @@ func (s *Server) registerSPA() {
 			return
 		}
 		// Serve the requested asset if it exists; otherwise fall back to the SPA
-		// shell so the client router can handle the route.
+		// shell so the client router can handle the route. A missing FILE (path
+		// with an extension — e.g. a hashed chunk from a previous deploy) must
+		// 404 instead: serving the HTML shell for it breaks dynamic imports with
+		// an opaque "failed to fetch module" and hides the real cause from the
+		// client's stale-chunk recovery.
 		clean := strings.TrimPrefix(path.Clean(reqPath), "/")
 		if clean == "" {
 			clean = "index.html"
 		}
 		if _, statErr := fs.Stat(sub, clean); statErr != nil {
+			if path.Ext(clean) != "" {
+				c.Header("Cache-Control", "no-store")
+				c.AbortWithStatus(http.StatusNotFound)
+				return
+			}
+			clean = "index.html"
 			c.Request.URL.Path = "/"
+		}
+		// Vite content-hashes everything under assets/ — cache those forever.
+		// index.html (and any other unhashed file) must revalidate on every
+		// load, or a plain reload keeps the stale shell and only a hard reload
+		// recovers after a deploy.
+		if strings.HasPrefix(clean, "assets/") {
+			c.Header("Cache-Control", "public, max-age=31536000, immutable")
+		} else {
+			c.Header("Cache-Control", "no-cache")
 		}
 		fileServer.ServeHTTP(c.Writer, c.Request)
 	})

--- a/api/internal/server/spa_test.go
+++ b/api/internal/server/spa_test.go
@@ -35,6 +35,29 @@ func TestSPA_ServesIndexAtRoot(t *testing.T) {
 	assert.True(t, strings.Contains(w.Header().Get("Content-Type"), "text/html"))
 }
 
+// Regression: a hashed chunk from a previous deploy must 404 (no-store), not
+// serve the HTML shell — the shell response broke dynamic imports opaquely and
+// defeated client-side stale-chunk recovery after rolling updates.
+func TestSPA_MissingAssetIs404NotShell(t *testing.T) {
+	w := httptest.NewRecorder()
+	spaServer().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/assets/index-OLDHASH.js", nil))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+	assert.NotContains(t, w.Body.String(), "<html")
+}
+
+// index.html (root and deep-link fallback) must revalidate on every load —
+// heuristic caching of the shell was why only a HARD reload picked up a new
+// deploy.
+func TestSPA_ShellIsNoCache(t *testing.T) {
+	for _, target := range []string{"/", "/projects/abc"} {
+		w := httptest.NewRecorder()
+		spaServer().ServeHTTP(w, httptest.NewRequest(http.MethodGet, target, nil))
+		assert.Equal(t, http.StatusOK, w.Code, target)
+		assert.Equal(t, "no-cache", w.Header().Get("Cache-Control"), target)
+	}
+}
+
 func TestSPA_UnknownAPIRouteIs404JSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	spaServer().ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/nope", nil))

--- a/ui/quasar.config.ts
+++ b/ui/quasar.config.ts
@@ -15,7 +15,7 @@ export default configure((/* ctx */) => {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli-vite/boot-files
-    boot: ["axios", "mitt"],
+    boot: ["axios", "mitt", "updateGuard"],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
     css: ["app.sass", "tailwind.css"],

--- a/ui/src/boot/updateGuard.ts
+++ b/ui/src/boot/updateGuard.ts
@@ -1,0 +1,62 @@
+// Keeps stale browser tabs working across deploys. See util/updateGuard.ts
+// for the decision logic and the reasoning; this file is the wiring only.
+import { boot } from "quasar/wrappers";
+import { API_BASE } from "src/boot/axios";
+import { isVersionChange, RELOAD_COOLDOWN_MS, shouldReloadOnChunkError, VERSION_CHECK_INTERVAL_MS } from "src/util/updateGuard";
+
+const RELOAD_KEY = "shutterbase-chunk-reload-at";
+
+async function fetchServerVersion(): Promise<string | null> {
+  try {
+    const response = await fetch(`${API_BASE}/health`, { credentials: "include" });
+    if (!response.ok) return null;
+    return ((await response.json()) as { version?: string }).version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default boot(({ router }) => {
+  // --- reactive: stale chunk failed to load ---------------------------------
+  window.addEventListener("vite:preloadError", (event) => {
+    const last = Number(sessionStorage.getItem(RELOAD_KEY)) || null;
+    if (!shouldReloadOnChunkError(last, Date.now())) return; // let it surface
+    event.preventDefault(); // suppress the error — we recover instead
+    sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+    window.location.reload();
+  });
+
+  // --- proactive: server runs a newer build than this tab -------------------
+  let baseline: string | null = null;
+  let updatePending = false;
+
+  const check = async () => {
+    if (updatePending) return;
+    const version = await fetchServerVersion();
+    if (baseline === null) {
+      baseline = version;
+    } else if (isVersionChange(baseline, version)) {
+      updatePending = true;
+    }
+  };
+
+  void check(); // capture the baseline at app start
+  setInterval(() => void check(), VERSION_CHECK_INTERVAL_MS);
+  let lastFocusCheck = 0;
+  document.addEventListener("visibilitychange", () => {
+    // returning to the tab is the moment stale tabs resurface — re-check, but
+    // no more often than the reload cooldown
+    if (document.visibilityState === "visible" && Date.now() - lastFocusCheck > RELOAD_COOLDOWN_MS) {
+      lastFocusCheck = Date.now();
+      void check();
+    }
+  });
+
+  router.beforeEach((to) => {
+    if (!updatePending) return true;
+    // Full document load to the target route: the user sees an ordinary page
+    // transition and lands in the new build.
+    window.location.href = router.resolve(to).href;
+    return false;
+  });
+});

--- a/ui/src/util/updateGuard.ts
+++ b/ui/src/util/updateGuard.ts
@@ -1,0 +1,25 @@
+// Pure decision logic for the SPA update guard (boot/updateGuard.ts wires it
+// to the router and window events). Two recovery paths after a deploy:
+//
+//  1. Proactive: the app remembers the server version from its first /health
+//     call; when a later check sees a different version, the NEXT router
+//     navigation becomes a full document load — the user gets the new build
+//     disguised as an ordinary page transition.
+//  2. Reactive: if a lazy chunk still fails (vite:preloadError), reload the
+//     page — rate-limited so a genuinely broken asset can't reload-loop.
+
+export const RELOAD_COOLDOWN_MS = 30_000;
+export const VERSION_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+// isVersionChange: true only when both sides are known and differ — an
+// unreachable health endpoint (empty/undefined) must never trigger reloads.
+export function isVersionChange(baseline: string | null, current: string | null | undefined): boolean {
+  return !!baseline && !!current && baseline !== current;
+}
+
+// shouldReloadOnChunkError: allow at most one automatic reload per cooldown
+// window. lastReloadAt is the persisted (sessionStorage) timestamp of the
+// previous automatic reload, as epoch ms.
+export function shouldReloadOnChunkError(lastReloadAt: number | null, now: number): boolean {
+  return lastReloadAt === null || now - lastReloadAt > RELOAD_COOLDOWN_MS;
+}

--- a/ui/tests/updateGuard.spec.ts
+++ b/ui/tests/updateGuard.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { isVersionChange, shouldReloadOnChunkError, RELOAD_COOLDOWN_MS } from "src/util/updateGuard";
+
+describe("isVersionChange", () => {
+  it("detects a real version flip", () => {
+    expect(isVersionChange("v1.12.0", "v1.12.1")).toBe(true);
+  });
+  it("is false for the same version", () => {
+    expect(isVersionChange("v1.12.0", "v1.12.0")).toBe(false);
+  });
+  it("never fires on unknown versions (health unreachable)", () => {
+    expect(isVersionChange(null, "v1.12.1")).toBe(false);
+    expect(isVersionChange("v1.12.0", null)).toBe(false);
+    expect(isVersionChange("v1.12.0", undefined)).toBe(false);
+    expect(isVersionChange("", "v1.12.1")).toBe(false);
+  });
+});
+
+describe("shouldReloadOnChunkError", () => {
+  const now = 1_000_000_000;
+  it("allows the first reload", () => {
+    expect(shouldReloadOnChunkError(null, now)).toBe(true);
+  });
+  it("suppresses a second reload within the cooldown", () => {
+    expect(shouldReloadOnChunkError(now - RELOAD_COOLDOWN_MS / 2, now)).toBe(false);
+  });
+  it("allows a reload after the cooldown", () => {
+    expect(shouldReloadOnChunkError(now - RELOAD_COOLDOWN_MS - 1, now)).toBe(true);
+  });
+});


### PR DESCRIPTION
After a deploy, tabs holding the old index.html failed on lazy-loaded
routes until a HARD reload. Three compounding causes, three fixes:

- Server served the HTML shell (200) for missing hashed chunks of previous
  builds — dynamic imports got text/html and failed opaquely. Missing files
  now 404 no-store; the shell fallback only applies to extensionless
  client routes.
- No Cache-Control headers: browsers heuristically cached index.html, so a
  normal reload kept the stale shell. index.html is now no-cache; the
  content-hashed assets/ are immutable for a year.
- No client-side recovery: a new updateGuard boot file (1) polls /health
  and, once the server version differs from the tab's baseline, turns the
  next router navigation into a full document load — the update disguises
  itself as an ordinary page transition; (2) on vite:preloadError reloads
  the page automatically, rate-limited to one reload per 30s so a broken
  asset cannot loop.
