### PR TITLE
fix(download): live run progress — reactivity fix, byte-accurate bars, ETA

### DIFF
--- a/ui/src/pages/download/Download.vue
+++ b/ui/src/pages/download/Download.vue
@@ -25,7 +25,9 @@
           <div class="min-w-0">
             <p class="text-sm font-semibold text-primary-900 dark:text-white">{{ run.configName }} — {{ run.delta ? "delta" : "full" }} download</p>
             <p class="mt-0.5 text-xs tabular-nums text-primary-500 dark:text-primary-400">
-              {{ run.progress.done }} / {{ run.progress.total }} downloaded
+              {{ run.progress.done }} / {{ run.progress.total }} images
+              <span v-if="run.progress.bytesTotal"> · {{ formatBytes(overallBytes) }} / {{ formatBytes(run.progress.bytesTotal) }}</span>
+              <span v-if="etaSeconds !== null" class="font-semibold text-primary-700 dark:text-primary-200"> · ~{{ formatDuration(etaSeconds) }} remaining</span>
               <span v-if="run.progress.skipped"> · {{ run.progress.skipped }} skipped</span>
               <span v-if="run.progress.failed.length" class="text-red-600 dark:text-red-400"> · {{ run.progress.failed.length }} failed</span>
             </p>
@@ -34,10 +36,7 @@
           <button v-else type="button" class="btn-secondary" @click="run = null">Dismiss</button>
         </div>
         <div class="mt-3 h-2 overflow-hidden rounded-full bg-primary-100 dark:bg-primary-800">
-          <div
-            class="h-full rounded-full bg-accent-500 transition-all"
-            :style="{ width: run.progress.total ? `${(run.progress.done / run.progress.total) * 100}%` : '100%' }"
-          ></div>
+          <div class="h-full rounded-full bg-accent-500 transition-all" :style="{ width: `${overallPercent}%` }"></div>
         </div>
         <div v-if="!run.finished" class="mt-3 space-y-2">
           <div v-for="(worker, slot) in run.progress.workers" :key="slot" class="flex items-center gap-3">
@@ -49,11 +48,13 @@
                 v-if="worker"
                 class="h-full rounded-full bg-accent-400 transition-all"
                 :class="{ 'animate-pulse': !worker.total }"
-                :style="{ width: worker.total ? `${(worker.received / worker.total) * 100}%` : '100%' }"
+                :style="{ width: worker.total ? `${Math.min(100, (worker.received / worker.total) * 100)}%` : '100%' }"
               ></div>
             </div>
-            <span class="w-20 text-right font-mono text-[11px] tabular-nums text-primary-400">
-              {{ worker ? formatBytes(worker.received) : "" }}
+            <span class="w-32 text-right font-mono text-[11px] tabular-nums text-primary-400">
+              <template v-if="worker"
+                >{{ formatBytes(worker.received) }}<template v-if="worker.total"> / {{ formatBytes(worker.total) }}</template></template
+              >
             </span>
           </div>
         </div>
@@ -215,6 +216,9 @@ import { ensurePermission, getStoredDirHandle, storeDirHandle } from "src/util/d
 import {
   collectExistingFiles,
   DownloadPlan,
+  estimateEtaSeconds,
+  formatBytes,
+  formatDuration,
   ImageStatus,
   isDirectoryPickerSupported,
   pickDirectory,
@@ -284,7 +288,24 @@ function tagName(id: string): string {
   return projectTags.value.find((t) => t.id === id)?.name ?? id;
 }
 const formatDateTime = (iso: string) => DateTime.fromISO(iso).toLocaleString(DateTime.DATETIME_SHORT);
-const formatBytes = (n: number) => (n > 1048576 ? `${(n / 1048576).toFixed(1)} MB` : `${Math.round(n / 1024)} kB`);
+// Overall data progress = completed files + everything the workers have
+// streamed so far, so the bar moves smoothly instead of jumping per file.
+const overallBytes = computed(() => {
+  const p = run.value?.progress;
+  if (!p) return 0;
+  return p.bytesDone + p.workers.reduce((sum, w) => sum + (w?.received ?? 0), 0);
+});
+const overallPercent = computed(() => {
+  const p = run.value?.progress;
+  if (!p) return 0;
+  if (p.bytesTotal) return Math.min(100, (overallBytes.value / p.bytesTotal) * 100);
+  return p.total ? (p.done / p.total) * 100 : 0;
+});
+const etaSeconds = computed(() => {
+  const p = run.value?.progress;
+  if (!p || run.value?.finished) return null;
+  return estimateEtaSeconds(overallBytes.value, p.bytesTotal, Date.now() - p.startedAt);
+});
 
 const statusLabel = (s?: ImageStatus) => ({ new: "new", changed: "changed", present: "present", excluded: "excluded" })[s ?? "present"];
 function statusBadgeClass(s?: ImageStatus): string {
@@ -425,14 +446,17 @@ async function startRun(config: DownloadConfig, delta: boolean) {
   const directory = preview.value?.config.id === config.id ? preview.value.directory : await getDirectory(config);
   if (!directory) return;
   const runStart = new Date();
-  const state: RunState = {
+  run.value = {
     configName: config.name,
     delta,
-    progress: { total: 0, done: 0, failed: [], skipped: 0, workers: [] },
+    progress: { total: 0, done: 0, failed: [], skipped: 0, bytesTotal: 0, bytesDone: 0, startedAt: Date.now(), workers: [] },
     finished: false,
     aborted: false,
   };
-  run.value = state;
+  // Work through the ref's reactive proxy — mutating the raw object the ref
+  // was created from bypasses Vue's tracking and freezes the panel at 0/0
+  // (the original bug this rewrite fixes).
+  const state = run.value;
   preview.value = null; // the run invalidates the preview's counts
   try {
     // Re-plan at run time — the preview may be minutes old.

--- a/ui/src/util/downloadRunner.ts
+++ b/ui/src/util/downloadRunner.ts
@@ -106,7 +106,7 @@ function isoDate(d: Date): string {
 export interface FileProgress {
   fileName: string;
   received: number;
-  total: number; // 0 when the server sends no content-length
+  total: number; // content-length, falling back to image.size; 0 = unknown
 }
 
 export interface RunProgress {
@@ -114,7 +114,31 @@ export interface RunProgress {
   done: number;
   failed: string[]; // computedFileNames that exhausted retries
   skipped: number; // images not part of this run (excluded / already present)
+  bytesTotal: number; // sum of known image sizes in the plan (0 = unknown)
+  bytesDone: number; // bytes of completed files
+  startedAt: number; // epoch ms — ETA baseline
   workers: (FileProgress | null)[]; // per-parallel-slot file progress
+}
+
+// estimateEtaSeconds: simple average-rate ETA over the whole run. Returns null
+// until there is enough signal (3s elapsed, some bytes moved) — a flickering
+// wild guess is worse than none.
+export function estimateEtaSeconds(bytesDone: number, bytesTotal: number, elapsedMs: number): number | null {
+  if (bytesDone <= 0 || bytesTotal <= bytesDone || elapsedMs < 3000) return null;
+  const bytesPerSecond = bytesDone / (elapsedMs / 1000);
+  return Math.round((bytesTotal - bytesDone) / bytesPerSecond);
+}
+
+export function formatBytes(n: number): string {
+  if (n >= 1073741824) return `${(n / 1073741824).toFixed(2)} GB`;
+  if (n >= 1048576) return `${(n / 1048576).toFixed(1)} MB`;
+  return `${Math.round(n / 1024)} kB`;
+}
+
+export function formatDuration(seconds: number): string {
+  if (seconds >= 3600) return `${Math.floor(seconds / 3600)}h ${Math.round((seconds % 3600) / 60)}m`;
+  if (seconds >= 60) return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`;
+  return `${Math.max(1, Math.round(seconds))}s`;
 }
 
 // ---- File System Access API glue (Chromium desktop only) ----
@@ -164,21 +188,30 @@ export async function downloadImageToDirectory(image: Image, root: FileSystemDir
       if (!response.ok || !response.body) {
         throw new Error(`download of ${image.computedFileName} failed: status ${response.status}`);
       }
-      const total = Number(response.headers.get("content-length") ?? 0);
+      // content-length can be absent (chunked EXIF-injected stream) — fall
+      // back to the catalog size so the file bar still has a denominator.
+      const total = Number(response.headers.get("content-length") ?? 0) || image.size || 0;
       const dir = await ensureDirectory(root, segments);
       const fileHandle = await dir.getFileHandle(downloadFileName(image), { create: true });
       const writable = await fileHandle.createWritable();
       const reader = response.body.getReader();
       let received = 0;
+      let lastEmitted = 0;
       try {
         for (;;) {
           const { done, value } = await reader.read();
           if (done) break;
           await writable.write(value);
           received += value.byteLength;
-          onProgress?.({ fileName: image.computedFileName, received, total });
+          // throttle UI updates to every 256 kB — per-chunk emits at 4
+          // parallel streams would re-render the panel hundreds of times/s
+          if (received - lastEmitted >= 262144) {
+            lastEmitted = received;
+            onProgress?.({ fileName: image.computedFileName, received, total });
+          }
         }
         await writable.close();
+        onProgress?.({ fileName: image.computedFileName, received, total });
       } catch (streamError) {
         await writable.abort().catch(() => undefined);
         throw streamError;
@@ -207,6 +240,9 @@ export async function runDownload(
     done: 0,
     failed: [],
     skipped: plan.statuses.size - plan.wanted.length,
+    bytesTotal: plan.wanted.reduce((sum, image) => sum + (image.size || 0), 0),
+    bytesDone: 0,
+    startedAt: Date.now(),
     workers: Array.from({ length: PARALLELISM }, () => null),
   };
   onProgress({ ...progress, workers: [...progress.workers] });
@@ -221,13 +257,16 @@ export async function runDownload(
         emit();
         return;
       }
-      progress.workers[slot] = { fileName: image.computedFileName, received: 0, total: 0 };
+      progress.workers[slot] = { fileName: image.computedFileName, received: 0, total: image.size || 0 };
       emit();
+      let fileBytes = 0;
       try {
         await downloadImageToDirectory(image, root, targetSegments(image, config, options), (p) => {
+          fileBytes = p.received;
           progress.workers[slot] = p;
           emit();
         });
+        progress.bytesDone += fileBytes || image.size || 0;
       } catch {
         progress.failed.push(image.computedFileName);
       }

--- a/ui/tests/downloadRunner.spec.ts
+++ b/ui/tests/downloadRunner.spec.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { classifyImage, planDownload, isExcluded, targetSegments, downloadFileName, DELTA_SAFETY_MARGIN_MS } from "src/util/downloadRunner";
+import {
+  classifyImage,
+  planDownload,
+  isExcluded,
+  targetSegments,
+  downloadFileName,
+  estimateEtaSeconds,
+  formatBytes,
+  formatDuration,
+  DELTA_SAFETY_MARGIN_MS,
+} from "src/util/downloadRunner";
 import { DownloadConfig, Image } from "src/types/api";
 
 const config = {
@@ -90,6 +100,32 @@ describe("planDownload", () => {
     const plan = planDownload(images, config, existing, { delta: true });
     expect(plan.statuses.get("img4")).toBe("excluded");
     expect(plan.statuses.get("img2")).toBe("new");
+  });
+});
+
+describe("estimateEtaSeconds", () => {
+  it("computes remaining seconds from the average rate", () => {
+    // 100 MB done in 10s -> 10 MB/s; 300 MB remaining -> 30s
+    expect(estimateEtaSeconds(100e6, 400e6, 10_000)).toBe(30);
+  });
+  it("returns null until there is signal", () => {
+    expect(estimateEtaSeconds(0, 400e6, 10_000)).toBeNull(); // nothing moved
+    expect(estimateEtaSeconds(1e6, 400e6, 1000)).toBeNull(); // too early
+    expect(estimateEtaSeconds(400e6, 400e6, 10_000)).toBeNull(); // finished
+    expect(estimateEtaSeconds(1e6, 0, 10_000)).toBeNull(); // unknown total
+  });
+});
+
+describe("formatters", () => {
+  it("formatBytes picks a sensible unit", () => {
+    expect(formatBytes(512_000)).toBe("500 kB");
+    expect(formatBytes(8_400_000)).toBe("8.0 MB");
+    expect(formatBytes(2_500_000_000)).toBe("2.33 GB");
+  });
+  it("formatDuration scales from seconds to hours", () => {
+    expect(formatDuration(42)).toBe("42s");
+    expect(formatDuration(130)).toBe("2m 10s");
+    expect(formatDuration(3790)).toBe("1h 3m");
   });
 });
 


### PR DESCRIPTION
The run panel froze at '0 / 0' because the progress callbacks mutated the
raw state object instead of the ref's reactive proxy — updates landed in
memory without ever triggering a re-render. State is now mutated through
the proxy only.

Display reworked to what the feature promised: the overall bar is driven
by bytes (completed files + in-flight worker streams) with images, data
and an average-rate ETA; each of the four worker rows shows filename,
percent bar and received/total data (content-length, falling back to the
catalog image size for chunked responses). Progress emits are throttled
to every 256 kB per stream.
