### PR TITLE
feat(ai): re-read car numbers — scoped project rerun via the aiserver contract

### DIFF
--- a/api/ent/image.go
+++ b/api/ent/image.go
@@ -51,6 +51,8 @@ type Image struct {
 	AiStatus *image.AiStatus `json:"aiStatus,omitempty"`
 	// AiQueuedAt holds the value of the "aiQueuedAt" field.
 	AiQueuedAt *time.Time `json:"-"`
+	// AiScope holds the value of the "aiScope" field.
+	AiScope string `json:"-"`
 	// AiAttempts holds the value of the "aiAttempts" field.
 	AiAttempts int `json:"-"`
 	// AiError holds the value of the "aiError" field.
@@ -156,7 +158,7 @@ func (*Image) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case image.FieldAiAttempts, image.FieldSize, image.FieldWidth, image.FieldHeight:
 			values[i] = new(sql.NullInt64)
-		case image.FieldID, image.FieldFileName, image.FieldComputedFileName, image.FieldStorageId, image.FieldAiStatus, image.FieldAiError, image.FieldUploadID, image.FieldProjectID, image.FieldCameraID:
+		case image.FieldID, image.FieldFileName, image.FieldComputedFileName, image.FieldStorageId, image.FieldAiStatus, image.FieldAiScope, image.FieldAiError, image.FieldUploadID, image.FieldProjectID, image.FieldCameraID:
 			values[i] = new(sql.NullString)
 		case image.FieldCreatedAt, image.FieldUpdatedAt, image.FieldCapturedAt, image.FieldCapturedAtCorrected, image.FieldInferredAt, image.FieldAiQueuedAt:
 			values[i] = new(sql.NullTime)
@@ -277,6 +279,12 @@ func (_m *Image) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.AiQueuedAt = new(time.Time)
 				*_m.AiQueuedAt = value.Time
+			}
+		case image.FieldAiScope:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field aiScope", values[i])
+			} else if value.Valid {
+				_m.AiScope = value.String
 			}
 		case image.FieldAiAttempts:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -450,6 +458,9 @@ func (_m *Image) String() string {
 		builder.WriteString("aiQueuedAt=")
 		builder.WriteString(v.Format(time.ANSIC))
 	}
+	builder.WriteString(", ")
+	builder.WriteString("aiScope=")
+	builder.WriteString(_m.AiScope)
 	builder.WriteString(", ")
 	builder.WriteString("aiAttempts=")
 	builder.WriteString(fmt.Sprintf("%v", _m.AiAttempts))

--- a/api/ent/image/image.go
+++ b/api/ent/image/image.go
@@ -43,6 +43,8 @@ const (
 	FieldAiStatus = "ai_status"
 	// FieldAiQueuedAt holds the string denoting the aiqueuedat field in the database.
 	FieldAiQueuedAt = "ai_queued_at"
+	// FieldAiScope holds the string denoting the aiscope field in the database.
+	FieldAiScope = "ai_scope"
 	// FieldAiAttempts holds the string denoting the aiattempts field in the database.
 	FieldAiAttempts = "ai_attempts"
 	// FieldAiError holds the string denoting the aierror field in the database.
@@ -127,6 +129,7 @@ var Columns = []string{
 	FieldInferredAt,
 	FieldAiStatus,
 	FieldAiQueuedAt,
+	FieldAiScope,
 	FieldAiAttempts,
 	FieldAiError,
 	FieldSize,
@@ -266,6 +269,11 @@ func ByAiStatus(opts ...sql.OrderTermOption) OrderOption {
 // ByAiQueuedAt orders the results by the aiQueuedAt field.
 func ByAiQueuedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAiQueuedAt, opts...).ToFunc()
+}
+
+// ByAiScope orders the results by the aiScope field.
+func ByAiScope(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldAiScope, opts...).ToFunc()
 }
 
 // ByAiAttempts orders the results by the aiAttempts field.

--- a/api/ent/image/where.go
+++ b/api/ent/image/where.go
@@ -121,6 +121,11 @@ func AiQueuedAt(v time.Time) predicate.Image {
 	return predicate.Image(sql.FieldEQ(FieldAiQueuedAt, v))
 }
 
+// AiScope applies equality check predicate on the "aiScope" field. It's identical to AiScopeEQ.
+func AiScope(v string) predicate.Image {
+	return predicate.Image(sql.FieldEQ(FieldAiScope, v))
+}
+
 // AiAttempts applies equality check predicate on the "aiAttempts" field. It's identical to AiAttemptsEQ.
 func AiAttempts(v int) predicate.Image {
 	return predicate.Image(sql.FieldEQ(FieldAiAttempts, v))
@@ -799,6 +804,81 @@ func AiQueuedAtIsNil() predicate.Image {
 // AiQueuedAtNotNil applies the NotNil predicate on the "aiQueuedAt" field.
 func AiQueuedAtNotNil() predicate.Image {
 	return predicate.Image(sql.FieldNotNull(FieldAiQueuedAt))
+}
+
+// AiScopeEQ applies the EQ predicate on the "aiScope" field.
+func AiScopeEQ(v string) predicate.Image {
+	return predicate.Image(sql.FieldEQ(FieldAiScope, v))
+}
+
+// AiScopeNEQ applies the NEQ predicate on the "aiScope" field.
+func AiScopeNEQ(v string) predicate.Image {
+	return predicate.Image(sql.FieldNEQ(FieldAiScope, v))
+}
+
+// AiScopeIn applies the In predicate on the "aiScope" field.
+func AiScopeIn(vs ...string) predicate.Image {
+	return predicate.Image(sql.FieldIn(FieldAiScope, vs...))
+}
+
+// AiScopeNotIn applies the NotIn predicate on the "aiScope" field.
+func AiScopeNotIn(vs ...string) predicate.Image {
+	return predicate.Image(sql.FieldNotIn(FieldAiScope, vs...))
+}
+
+// AiScopeGT applies the GT predicate on the "aiScope" field.
+func AiScopeGT(v string) predicate.Image {
+	return predicate.Image(sql.FieldGT(FieldAiScope, v))
+}
+
+// AiScopeGTE applies the GTE predicate on the "aiScope" field.
+func AiScopeGTE(v string) predicate.Image {
+	return predicate.Image(sql.FieldGTE(FieldAiScope, v))
+}
+
+// AiScopeLT applies the LT predicate on the "aiScope" field.
+func AiScopeLT(v string) predicate.Image {
+	return predicate.Image(sql.FieldLT(FieldAiScope, v))
+}
+
+// AiScopeLTE applies the LTE predicate on the "aiScope" field.
+func AiScopeLTE(v string) predicate.Image {
+	return predicate.Image(sql.FieldLTE(FieldAiScope, v))
+}
+
+// AiScopeContains applies the Contains predicate on the "aiScope" field.
+func AiScopeContains(v string) predicate.Image {
+	return predicate.Image(sql.FieldContains(FieldAiScope, v))
+}
+
+// AiScopeHasPrefix applies the HasPrefix predicate on the "aiScope" field.
+func AiScopeHasPrefix(v string) predicate.Image {
+	return predicate.Image(sql.FieldHasPrefix(FieldAiScope, v))
+}
+
+// AiScopeHasSuffix applies the HasSuffix predicate on the "aiScope" field.
+func AiScopeHasSuffix(v string) predicate.Image {
+	return predicate.Image(sql.FieldHasSuffix(FieldAiScope, v))
+}
+
+// AiScopeIsNil applies the IsNil predicate on the "aiScope" field.
+func AiScopeIsNil() predicate.Image {
+	return predicate.Image(sql.FieldIsNull(FieldAiScope))
+}
+
+// AiScopeNotNil applies the NotNil predicate on the "aiScope" field.
+func AiScopeNotNil() predicate.Image {
+	return predicate.Image(sql.FieldNotNull(FieldAiScope))
+}
+
+// AiScopeEqualFold applies the EqualFold predicate on the "aiScope" field.
+func AiScopeEqualFold(v string) predicate.Image {
+	return predicate.Image(sql.FieldEqualFold(FieldAiScope, v))
+}
+
+// AiScopeContainsFold applies the ContainsFold predicate on the "aiScope" field.
+func AiScopeContainsFold(v string) predicate.Image {
+	return predicate.Image(sql.FieldContainsFold(FieldAiScope, v))
 }
 
 // AiAttemptsEQ applies the EQ predicate on the "aiAttempts" field.

--- a/api/ent/image_create.go
+++ b/api/ent/image_create.go
@@ -190,6 +190,20 @@ func (_c *ImageCreate) SetNillableAiQueuedAt(v *time.Time) *ImageCreate {
 	return _c
 }
 
+// SetAiScope sets the "aiScope" field.
+func (_c *ImageCreate) SetAiScope(v string) *ImageCreate {
+	_c.mutation.SetAiScope(v)
+	return _c
+}
+
+// SetNillableAiScope sets the "aiScope" field if the given value is not nil.
+func (_c *ImageCreate) SetNillableAiScope(v *string) *ImageCreate {
+	if v != nil {
+		_c.SetAiScope(*v)
+	}
+	return _c
+}
+
 // SetAiAttempts sets the "aiAttempts" field.
 func (_c *ImageCreate) SetAiAttempts(v int) *ImageCreate {
 	_c.mutation.SetAiAttempts(v)
@@ -551,6 +565,10 @@ func (_c *ImageCreate) createSpec() (*Image, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.AiQueuedAt(); ok {
 		_spec.SetField(image.FieldAiQueuedAt, field.TypeTime, value)
 		_node.AiQueuedAt = &value
+	}
+	if value, ok := _c.mutation.AiScope(); ok {
+		_spec.SetField(image.FieldAiScope, field.TypeString, value)
+		_node.AiScope = value
 	}
 	if value, ok := _c.mutation.AiAttempts(); ok {
 		_spec.SetField(image.FieldAiAttempts, field.TypeInt, value)

--- a/api/ent/image_update.go
+++ b/api/ent/image_update.go
@@ -239,6 +239,26 @@ func (_u *ImageUpdate) ClearAiQueuedAt() *ImageUpdate {
 	return _u
 }
 
+// SetAiScope sets the "aiScope" field.
+func (_u *ImageUpdate) SetAiScope(v string) *ImageUpdate {
+	_u.mutation.SetAiScope(v)
+	return _u
+}
+
+// SetNillableAiScope sets the "aiScope" field if the given value is not nil.
+func (_u *ImageUpdate) SetNillableAiScope(v *string) *ImageUpdate {
+	if v != nil {
+		_u.SetAiScope(*v)
+	}
+	return _u
+}
+
+// ClearAiScope clears the value of the "aiScope" field.
+func (_u *ImageUpdate) ClearAiScope() *ImageUpdate {
+	_u.mutation.ClearAiScope()
+	return _u
+}
+
 // SetAiAttempts sets the "aiAttempts" field.
 func (_u *ImageUpdate) SetAiAttempts(v int) *ImageUpdate {
 	_u.mutation.ResetAiAttempts()
@@ -662,6 +682,12 @@ func (_u *ImageUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if _u.mutation.AiQueuedAtCleared() {
 		_spec.ClearField(image.FieldAiQueuedAt, field.TypeTime)
 	}
+	if value, ok := _u.mutation.AiScope(); ok {
+		_spec.SetField(image.FieldAiScope, field.TypeString, value)
+	}
+	if _u.mutation.AiScopeCleared() {
+		_spec.ClearField(image.FieldAiScope, field.TypeString)
+	}
 	if value, ok := _u.mutation.AiAttempts(); ok {
 		_spec.SetField(image.FieldAiAttempts, field.TypeInt, value)
 	}
@@ -1080,6 +1106,26 @@ func (_u *ImageUpdateOne) SetNillableAiQueuedAt(v *time.Time) *ImageUpdateOne {
 // ClearAiQueuedAt clears the value of the "aiQueuedAt" field.
 func (_u *ImageUpdateOne) ClearAiQueuedAt() *ImageUpdateOne {
 	_u.mutation.ClearAiQueuedAt()
+	return _u
+}
+
+// SetAiScope sets the "aiScope" field.
+func (_u *ImageUpdateOne) SetAiScope(v string) *ImageUpdateOne {
+	_u.mutation.SetAiScope(v)
+	return _u
+}
+
+// SetNillableAiScope sets the "aiScope" field if the given value is not nil.
+func (_u *ImageUpdateOne) SetNillableAiScope(v *string) *ImageUpdateOne {
+	if v != nil {
+		_u.SetAiScope(*v)
+	}
+	return _u
+}
+
+// ClearAiScope clears the value of the "aiScope" field.
+func (_u *ImageUpdateOne) ClearAiScope() *ImageUpdateOne {
+	_u.mutation.ClearAiScope()
 	return _u
 }
 
@@ -1535,6 +1581,12 @@ func (_u *ImageUpdateOne) sqlSave(ctx context.Context) (_node *Image, err error)
 	}
 	if _u.mutation.AiQueuedAtCleared() {
 		_spec.ClearField(image.FieldAiQueuedAt, field.TypeTime)
+	}
+	if value, ok := _u.mutation.AiScope(); ok {
+		_spec.SetField(image.FieldAiScope, field.TypeString, value)
+	}
+	if _u.mutation.AiScopeCleared() {
+		_spec.ClearField(image.FieldAiScope, field.TypeString)
 	}
 	if value, ok := _u.mutation.AiAttempts(); ok {
 		_spec.SetField(image.FieldAiAttempts, field.TypeInt, value)

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -183,6 +183,7 @@ var (
 		{Name: "inferred_at", Type: field.TypeTime, Nullable: true},
 		{Name: "ai_status", Type: field.TypeEnum, Nullable: true, Enums: []string{"pending", "processing", "done", "error"}},
 		{Name: "ai_queued_at", Type: field.TypeTime, Nullable: true},
+		{Name: "ai_scope", Type: field.TypeString, Nullable: true},
 		{Name: "ai_attempts", Type: field.TypeInt, Default: 0},
 		{Name: "ai_error", Type: field.TypeString, Nullable: true},
 		{Name: "size", Type: field.TypeInt},
@@ -201,25 +202,25 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "images_cameras_images",
-				Columns:    []*schema.Column{ImagesColumns[20]},
+				Columns:    []*schema.Column{ImagesColumns[21]},
 				RefColumns: []*schema.Column{CamerasColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "images_projects_images",
-				Columns:    []*schema.Column{ImagesColumns[21]},
+				Columns:    []*schema.Column{ImagesColumns[22]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "images_uploads_images",
-				Columns:    []*schema.Column{ImagesColumns[22]},
+				Columns:    []*schema.Column{ImagesColumns[23]},
 				RefColumns: []*schema.Column{UploadsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "images_users_images",
-				Columns:    []*schema.Column{ImagesColumns[23]},
+				Columns:    []*schema.Column{ImagesColumns[24]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -228,22 +229,22 @@ var (
 			{
 				Name:    "image_project_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[21]},
+				Columns: []*schema.Column{ImagesColumns[22]},
 			},
 			{
 				Name:    "image_upload_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[22]},
+				Columns: []*schema.Column{ImagesColumns[23]},
 			},
 			{
 				Name:    "image_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[23]},
+				Columns: []*schema.Column{ImagesColumns[24]},
 			},
 			{
 				Name:    "image_camera_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[20]},
+				Columns: []*schema.Column{ImagesColumns[21]},
 			},
 			{
 				Name:    "image_captured_at_corrected",
@@ -253,7 +254,7 @@ var (
 			{
 				Name:    "image_project_id_captured_at_corrected",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[21], ImagesColumns[11]},
+				Columns: []*schema.Column{ImagesColumns[22], ImagesColumns[11]},
 			},
 			{
 				Name:    "image_ai_status_ai_queued_at",

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -4158,6 +4158,7 @@ type ImageMutation struct {
 	inferredAt                 *time.Time
 	aiStatus                   *image.AiStatus
 	aiQueuedAt                 *time.Time
+	aiScope                    *string
 	aiAttempts                 *int
 	addaiAttempts              *int
 	aiError                    *string
@@ -4938,6 +4939,55 @@ func (m *ImageMutation) ResetAiQueuedAt() {
 	delete(m.clearedFields, image.FieldAiQueuedAt)
 }
 
+// SetAiScope sets the "aiScope" field.
+func (m *ImageMutation) SetAiScope(s string) {
+	m.aiScope = &s
+}
+
+// AiScope returns the value of the "aiScope" field in the mutation.
+func (m *ImageMutation) AiScope() (r string, exists bool) {
+	v := m.aiScope
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAiScope returns the old "aiScope" field's value of the Image entity.
+// If the Image object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ImageMutation) OldAiScope(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAiScope is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAiScope requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAiScope: %w", err)
+	}
+	return oldValue.AiScope, nil
+}
+
+// ClearAiScope clears the value of the "aiScope" field.
+func (m *ImageMutation) ClearAiScope() {
+	m.aiScope = nil
+	m.clearedFields[image.FieldAiScope] = struct{}{}
+}
+
+// AiScopeCleared returns if the "aiScope" field was cleared in this mutation.
+func (m *ImageMutation) AiScopeCleared() bool {
+	_, ok := m.clearedFields[image.FieldAiScope]
+	return ok
+}
+
+// ResetAiScope resets all changes to the "aiScope" field.
+func (m *ImageMutation) ResetAiScope() {
+	m.aiScope = nil
+	delete(m.clearedFields, image.FieldAiScope)
+}
+
 // SetAiAttempts sets the "aiAttempts" field.
 func (m *ImageMutation) SetAiAttempts(i int) {
 	m.aiAttempts = &i
@@ -5579,7 +5629,7 @@ func (m *ImageMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ImageMutation) Fields() []string {
-	fields := make([]string, 0, 23)
+	fields := make([]string, 0, 24)
 	if m.createdAt != nil {
 		fields = append(fields, image.FieldCreatedAt)
 	}
@@ -5621,6 +5671,9 @@ func (m *ImageMutation) Fields() []string {
 	}
 	if m.aiQueuedAt != nil {
 		fields = append(fields, image.FieldAiQueuedAt)
+	}
+	if m.aiScope != nil {
+		fields = append(fields, image.FieldAiScope)
 	}
 	if m.aiAttempts != nil {
 		fields = append(fields, image.FieldAiAttempts)
@@ -5685,6 +5738,8 @@ func (m *ImageMutation) Field(name string) (ent.Value, bool) {
 		return m.AiStatus()
 	case image.FieldAiQueuedAt:
 		return m.AiQueuedAt()
+	case image.FieldAiScope:
+		return m.AiScope()
 	case image.FieldAiAttempts:
 		return m.AiAttempts()
 	case image.FieldAiError:
@@ -5740,6 +5795,8 @@ func (m *ImageMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldAiStatus(ctx)
 	case image.FieldAiQueuedAt:
 		return m.OldAiQueuedAt(ctx)
+	case image.FieldAiScope:
+		return m.OldAiScope(ctx)
 	case image.FieldAiAttempts:
 		return m.OldAiAttempts(ctx)
 	case image.FieldAiError:
@@ -5864,6 +5921,13 @@ func (m *ImageMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAiQueuedAt(v)
+		return nil
+	case image.FieldAiScope:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAiScope(v)
 		return nil
 	case image.FieldAiAttempts:
 		v, ok := value.(int)
@@ -6039,6 +6103,9 @@ func (m *ImageMutation) ClearedFields() []string {
 	if m.FieldCleared(image.FieldAiQueuedAt) {
 		fields = append(fields, image.FieldAiQueuedAt)
 	}
+	if m.FieldCleared(image.FieldAiScope) {
+		fields = append(fields, image.FieldAiScope)
+	}
 	if m.FieldCleared(image.FieldAiError) {
 		fields = append(fields, image.FieldAiError)
 	}
@@ -6091,6 +6158,9 @@ func (m *ImageMutation) ClearField(name string) error {
 		return nil
 	case image.FieldAiQueuedAt:
 		m.ClearAiQueuedAt()
+		return nil
+	case image.FieldAiScope:
+		m.ClearAiScope()
 		return nil
 	case image.FieldAiError:
 		m.ClearAiError()
@@ -6150,6 +6220,9 @@ func (m *ImageMutation) ResetField(name string) error {
 		return nil
 	case image.FieldAiQueuedAt:
 		m.ResetAiQueuedAt()
+		return nil
+	case image.FieldAiScope:
+		m.ResetAiScope()
 		return nil
 	case image.FieldAiAttempts:
 		m.ResetAiAttempts()

--- a/api/ent/runtime.go
+++ b/api/ent/runtime.go
@@ -193,19 +193,19 @@ func init() {
 	// image.DefaultImageTags holds the default value on creation for the imageTags field.
 	image.DefaultImageTags = imageDescImageTags.Default.([]string)
 	// imageDescAiAttempts is the schema descriptor for aiAttempts field.
-	imageDescAiAttempts := imageFields[10].Descriptor()
+	imageDescAiAttempts := imageFields[11].Descriptor()
 	// image.DefaultAiAttempts holds the default value on creation for the aiAttempts field.
 	image.DefaultAiAttempts = imageDescAiAttempts.Default.(int)
 	// imageDescSize is the schema descriptor for size field.
-	imageDescSize := imageFields[12].Descriptor()
+	imageDescSize := imageFields[13].Descriptor()
 	// image.SizeValidator is a validator for the "size" field. It is called by the builders before save.
 	image.SizeValidator = imageDescSize.Validators[0].(func(int) error)
 	// imageDescWidth is the schema descriptor for width field.
-	imageDescWidth := imageFields[13].Descriptor()
+	imageDescWidth := imageFields[14].Descriptor()
 	// image.WidthValidator is a validator for the "width" field. It is called by the builders before save.
 	image.WidthValidator = imageDescWidth.Validators[0].(func(int) error)
 	// imageDescHeight is the schema descriptor for height field.
-	imageDescHeight := imageFields[14].Descriptor()
+	imageDescHeight := imageFields[15].Descriptor()
 	// image.HeightValidator is a validator for the "height" field. It is called by the builders before save.
 	image.HeightValidator = imageDescHeight.Validators[0].(func(int) error)
 	// imageDescID is the schema descriptor for id field.

--- a/api/ent/schema/image.go
+++ b/api/ent/schema/image.go
@@ -30,6 +30,10 @@ func (Image) Fields() []ent.Field {
 		// aiQueuedAt — so it survives restarts.
 		field.Enum("aiStatus").Values("pending", "processing", "done", "error").Optional().Nillable().StructTag(`json:"aiStatus,omitempty"`),
 		field.Time("aiQueuedAt").Optional().Nillable().StructTag(`json:"-"`),
+		// Scope of the queued (re)run: "" = full analysis, "numbers" = vision-only
+		// car-number re-read (aiserver.ScopeNumbers). Persisted so a restart
+		// doesn't silently upgrade a cheap numbers backlog into full reruns.
+		field.String("aiScope").Optional().StructTag(`json:"-"`),
 		field.Int("aiAttempts").Default(0).StructTag(`json:"-"`),
 		field.String("aiError").Optional().StructTag(`json:"aiError,omitempty"`),
 		field.Int("size").NonNegative().StructTag(`json:"size"`),

--- a/api/internal/server/ai_controller.go
+++ b/api/internal/server/ai_controller.go
@@ -35,6 +35,7 @@ func (s *Server) registerAIRoutes(api *gin.RouterGroup) {
 	api.POST("/projects/:id/ai/rerun", s.aiRerunBatch)
 	api.POST("/projects/:id/ai/rerun-failed", s.aiRerunFailed)
 	api.POST("/projects/:id/ai/rerun-all", s.aiRerunAll)
+	api.POST("/projects/:id/ai/rerun-numbers", s.aiRerunNumbers)
 	api.POST("/projects/:id/ai/recluster", s.aiRecluster)
 	api.GET("/projects/:id/ai/persons/:personRef/images", s.aiPersonImages)
 	// People overview + merge review are global (persons span projects):
@@ -253,7 +254,31 @@ func (s *Server) aiRerunAll(c *gin.Context) {
 	if !allow(c, authorization.CanEditProject(authUser(c), projectID)) {
 		return
 	}
-	queued, err := s.ai.EnqueueProject(projectID)
+	queued, err := s.ai.EnqueueProject(projectID, "")
+	if err != nil {
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"queued": queued})
+}
+
+// aiRerunNumbers re-queues every image for a vision-only car-number re-read
+// against the AI server's currently configured model. Stored embeddings, faces
+// and descriptions are kept, so it is far cheaper than rerun-all. Scoped runs
+// only exist in the aiserver contract, hence the remote guard. Settings-page
+// action, projectAdmin+.
+func (s *Server) aiRerunNumbers(c *gin.Context) {
+	projectID, ok := getIdParam(c)
+	if !ok {
+		return
+	}
+	if _, ok := s.remote(c); !ok {
+		return
+	}
+	if !allow(c, authorization.CanEditProject(authUser(c), projectID)) {
+		return
+	}
+	queued, err := s.ai.EnqueueProject(projectID, aiserver.ScopeNumbers)
 	if err != nil {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return

--- a/api/internal/service/ai_service.go
+++ b/api/internal/service/ai_service.go
@@ -87,14 +87,17 @@ func NewAIService(repo *repository.Repository, s3Client *s3.S3Client, inference 
 // built later in the server bootstrap than the AI service).
 func (s *AIService) SetBus(bus *event.Bus) { s.bus = bus }
 
-// Enqueue marks an image pending. The DB is the queue, so this is just a
-// status write; the dispatcher picks it up FIFO by aiQueuedAt.
+// Enqueue marks an image pending for a FULL analysis (aiScope cleared — a
+// manual single-image rerun always recomputes everything). The DB is the
+// queue, so this is just a status write; the dispatcher picks it up FIFO by
+// aiQueuedAt.
 func (s *AIService) Enqueue(imageID string) {
 	ctx := context.Background()
 	img, err := s.repo.Client.Image.UpdateOneID(imageID).
 		SetAiStatus(entimage.AiStatusPending).
 		SetAiQueuedAt(time.Now()).
 		SetAiAttempts(0).
+		ClearAiScope().
 		ClearAiError().
 		Save(ctx)
 	if err != nil {
@@ -111,15 +114,22 @@ func (s *AIService) Enqueue(imageID string) {
 // EnqueueProject re-queues every image of the project in one statement — a
 // project can be tens of thousands of images, so per-row Enqueue would hammer
 // the DB and the websocket (no per-image publish here; the grid's queue-status
-// polling picks the change up).
-func (s *AIService) EnqueueProject(projectID string) (int, error) {
-	n, err := s.repo.Client.Image.Update().
+// polling picks the change up). scope "" = full analysis; a non-empty scope
+// (aiserver.ScopeNumbers) is persisted per image and forwarded to the AI
+// server on inference.
+func (s *AIService) EnqueueProject(projectID, scope string) (int, error) {
+	upd := s.repo.Client.Image.Update().
 		Where(entimage.ProjectID(projectID)).
 		SetAiStatus(entimage.AiStatusPending).
 		SetAiQueuedAt(time.Now()).
 		SetAiAttempts(0).
-		ClearAiError().
-		Save(context.Background())
+		ClearAiError()
+	if scope == "" {
+		upd.ClearAiScope()
+	} else {
+		upd.SetAiScope(scope)
+	}
+	n, err := upd.Save(context.Background())
 	if err != nil {
 		return 0, err
 	}
@@ -344,6 +354,7 @@ func (s *AIService) processWith(ctx context.Context, imageID string, inference I
 		Prompt:        project.AiSystemMessage,
 		AvailableTags: s.availableTags(ctx, project.ID),
 		CapturedAt:    image.CapturedAtCorrected,
+		Scope:         image.AiScope,
 	}
 	if req.CapturedAt == nil {
 		req.CapturedAt = image.CapturedAt
@@ -396,6 +407,7 @@ func (s *AIService) processWith(ctx context.Context, imageID string, inference I
 	updated, err := image.Update().
 		SetAiStatus(entimage.AiStatusDone).
 		SetInferredAt(time.Now()).
+		ClearAiScope().
 		ClearAiError().
 		Save(ctx)
 	if err != nil {

--- a/api/internal/service/ai_service_test.go
+++ b/api/internal/service/ai_service_test.go
@@ -335,6 +335,40 @@ func TestClientTimeoutClassifiesAsTimeout(t *testing.T) {
 	assert.True(t, row.AiQueuedAt.After(base), "timed-out image must move to the back of the queue")
 }
 
+// scopeInference records the Scope of each request it serves.
+type scopeInference struct{ scopes []string }
+
+func (s *scopeInference) Infer(_ context.Context, req InferenceRequest) ([]InferredTag, error) {
+	s.scopes = append(s.scopes, req.Scope)
+	return []InferredTag{}, nil
+}
+
+// A scoped project rerun persists aiScope, forwards it to the inference
+// request, and clears it on done; a subsequent single-image Enqueue is a full
+// run again (scope cleared).
+func TestScopedRerunThreadsScope(t *testing.T) {
+	inf := &scopeInference{}
+	svc, m := newSvc(t, inf)
+	ctx := context.Background()
+
+	n, err := svc.EnqueueProject(m.Project, "numbers")
+	require.NoError(t, err)
+	require.Equal(t, len(m.Images), n)
+	assert.Equal(t, "numbers", svc.repo.Client.Image.GetX(ctx, m.Images[0]).AiScope)
+
+	for svc.step(ctx) {
+	}
+	require.Len(t, inf.scopes, len(m.Images))
+	for _, scope := range inf.scopes {
+		assert.Equal(t, "numbers", scope)
+	}
+	assert.Empty(t, svc.repo.Client.Image.GetX(ctx, m.Images[0]).AiScope, "done must clear aiScope")
+
+	svc.Enqueue(m.Images[0])
+	require.True(t, svc.step(ctx))
+	assert.Equal(t, "", inf.scopes[len(inf.scopes)-1], "single-image rerun must be a full run")
+}
+
 // Boot recovery: STALE processing rows are re-queued by Start; fresh ones are
 // left alone (they belong to another replica mid-flight during a rolling deploy).
 func TestBootRecovery(t *testing.T) {

--- a/api/internal/service/inference.go
+++ b/api/internal/service/inference.go
@@ -25,6 +25,9 @@ type InferenceRequest struct {
 	AvailableTags []string
 	CapturedAt    *time.Time
 	Author        string
+	// Scope narrows a rerun (aiserver.ScopeNumbers = vision-only car-number
+	// re-read). Only the http provider forwards it; the others run full.
+	Scope string
 }
 
 // InferredTag is one tag with the provider's confidence (1.0 when the provider
@@ -148,6 +151,7 @@ func (h *HTTPInference) Infer(ctx context.Context, req InferenceRequest) ([]Infe
 		ImageURL:   req.ImageURL,
 		CapturedAt: req.CapturedAt,
 		Author:     req.Author,
+		Scope:      req.Scope,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/aiserver/types.go
+++ b/pkg/aiserver/types.go
@@ -20,6 +20,12 @@ type Project struct {
 	Tags []string `json:"tags"`
 }
 
+// ScopeNumbers narrows a re-ingest to the vision pass (car-number read) using
+// the server's currently configured model. Stored embeddings, faces and
+// descriptions are kept; a server without a stored analysis for the ref runs
+// a full ingest instead.
+const ScopeNumbers = "numbers"
+
 // IngestRequest submits one image for analysis. ImageRef is the caller's
 // stable image id and the idempotency key: re-ingesting the same ref replaces
 // the previous analysis.
@@ -29,6 +35,9 @@ type IngestRequest struct {
 	ImageURL   string     `json:"imageUrl"`
 	CapturedAt *time.Time `json:"capturedAt,omitempty"`
 	Author     string     `json:"author,omitempty"`
+	// Scope narrows the analysis: "" = full, ScopeNumbers = vision-only rerun.
+	// Servers ignore scopes they don't know and run a full ingest.
+	Scope string `json:"scope,omitempty"`
 }
 
 // Tag is one inferred tag; Name is always an element of Project.Tags.

--- a/ui/src/api/ai.ts
+++ b/ui/src/api/ai.ts
@@ -86,6 +86,14 @@ export async function rerunAll(projectId: string): Promise<number> {
   return data.queued;
 }
 
+// Re-queues EVERY image for a vision-only car-number re-read against the AI
+// server's currently configured model. Faces, similarity and descriptions are
+// kept — much cheaper than rerunAll. Confirm before calling.
+export async function rerunNumbers(projectId: string): Promise<number> {
+  const { data } = await http.post<{ queued: number }>(`/projects/${projectId}/ai/rerun-numbers`);
+  return data.queued;
+}
+
 // Rebuilds all person clusters from stored face embeddings (no inference, no
 // credits). Fire-and-forget on the server: 202 means started, not finished.
 // Discards all merge entries — confirm before calling.

--- a/ui/src/pages/project/ProjectGeneral.vue
+++ b/ui/src/pages/project/ProjectGeneral.vue
@@ -38,7 +38,7 @@
           <button
             type="button"
             class="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-primary-200 bg-surface px-3.5 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:text-white"
-            :disabled="rerunningFailed || rerunningAll"
+            :disabled="rerunningFailed || rerunningAll || rerunningNumbers"
             @click="rerunFailed"
           >
             <ArrowPathIcon class="h-4 w-4" />
@@ -47,7 +47,7 @@
           <button
             type="button"
             class="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-primary-200 bg-surface px-3.5 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:text-white"
-            :disabled="rerunningFailed || rerunningAll"
+            :disabled="rerunningFailed || rerunningAll || rerunningNumbers"
             @click="showRecomputeConfirm = true"
           >
             <ArrowPathIcon class="h-4 w-4" />
@@ -56,7 +56,16 @@
           <button
             type="button"
             class="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-primary-200 bg-surface px-3.5 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:text-white"
-            :disabled="rerunningFailed || rerunningAll"
+            :disabled="rerunningFailed || rerunningAll || rerunningNumbers"
+            @click="showRerunNumbersConfirm = true"
+          >
+            <ArrowPathIcon class="h-4 w-4" />
+            Re-read car numbers
+          </button>
+          <button
+            type="button"
+            class="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-primary-200 bg-surface px-3.5 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 disabled:cursor-not-allowed disabled:opacity-50 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:text-white"
+            :disabled="rerunningFailed || rerunningAll || rerunningNumbers"
             @click="showReclusterConfirm = true"
           >
             <ArrowPathIcon class="h-4 w-4" />
@@ -83,6 +92,16 @@
     cancelText="Cancel"
     @confirmed="rerunAll"
     @closed="showRecomputeConfirm = false"
+  />
+  <ModalMessage
+    :show="showRerunNumbersConfirm"
+    :type="MessageType.CONFIRM_WARNING"
+    headline="Re-read car numbers?"
+    message="Every image of this project is re-queued for a car-number re-read with the currently configured AI model. Number and scene tags are recomputed; faces, similarity data and descriptions are kept. Cheaper than a full recompute, but the run still costs AI credits."
+    confirmText="Re-read numbers"
+    cancelText="Cancel"
+    @confirmed="rerunNumbers"
+    @closed="showRerunNumbersConfirm = false"
   />
   <ModalMessage
     :show="showReclusterConfirm"
@@ -195,6 +214,26 @@ async function rerunAll() {
     showUnexpectedErrorMessage.value = true;
   } finally {
     rerunningAll.value = false;
+  }
+}
+
+const rerunningNumbers = ref(false);
+const showRerunNumbersConfirm = ref(false);
+async function rerunNumbers() {
+  if (!item.value) return;
+  showRerunNumbersConfirm.value = false;
+  rerunningNumbers.value = true;
+  try {
+    const queued = await api.ai.rerunNumbers(item.value.id);
+    showNotificationToast({
+      headline: queued === 0 ? "No images to re-read" : `Car-number re-read queued for ${queued} image${queued === 1 ? "" : "s"}`,
+      type: "success",
+    });
+  } catch (error: any) {
+    unexpectedError.value = error;
+    showUnexpectedErrorMessage.value = true;
+  } finally {
+    rerunningNumbers.value = false;
   }
 }
 


### PR DESCRIPTION
Adds a **Re-read car numbers** action to the project AI options: every image is re-queued for a vision-only car-number re-read against the AI server's currently configured model — no re-embedding, no face detection, no descriptions, so it is far cheaper than a full recompute.

- **aiserver contract**: optional `IngestRequest.Scope` (`ScopeNumbers`). Compatible both ways: servers ignore unknown scopes and run a full ingest.
- **Queue**: `aiScope` is persisted on the image row so a restart doesn't silently upgrade a cheap numbers backlog into full reruns; any full enqueue or completion clears it.
- **API**: `POST /projects/:id/ai/rerun-numbers` — projectAdmin+, guarded to the aiserver (`AI_PROVIDER=http`) provider.
- **SPA**: button + confirm dialog beside the existing rerun actions on the project settings page.

The fsai side (scoped ingest that reuses stored embeddings/face rows, hard-retry on vision failure, machine-confirmation refresh) is implemented in the fsai repo and verified by its docker e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)