### PR TITLE
feat(ai): store and inspect the raw AI detection result per image

### DIFF
--- a/api/ent/image.go
+++ b/api/ent/image.go
@@ -53,6 +53,8 @@ type Image struct {
 	AiQueuedAt *time.Time `json:"-"`
 	// AiScope holds the value of the "aiScope" field.
 	AiScope string `json:"-"`
+	// AiRawResult holds the value of the "aiRawResult" field.
+	AiRawResult json.RawMessage `json:"-"`
 	// AiAttempts holds the value of the "aiAttempts" field.
 	AiAttempts int `json:"-"`
 	// AiError holds the value of the "aiError" field.
@@ -154,7 +156,7 @@ func (*Image) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case image.FieldCreatedBy, image.FieldUpdatedBy:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case image.FieldExifData, image.FieldImageTags:
+		case image.FieldExifData, image.FieldImageTags, image.FieldAiRawResult:
 			values[i] = new([]byte)
 		case image.FieldAiAttempts, image.FieldSize, image.FieldWidth, image.FieldHeight:
 			values[i] = new(sql.NullInt64)
@@ -285,6 +287,14 @@ func (_m *Image) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field aiScope", values[i])
 			} else if value.Valid {
 				_m.AiScope = value.String
+			}
+		case image.FieldAiRawResult:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field aiRawResult", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.AiRawResult); err != nil {
+					return fmt.Errorf("unmarshal field aiRawResult: %w", err)
+				}
 			}
 		case image.FieldAiAttempts:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -461,6 +471,9 @@ func (_m *Image) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("aiScope=")
 	builder.WriteString(_m.AiScope)
+	builder.WriteString(", ")
+	builder.WriteString("aiRawResult=")
+	builder.WriteString(fmt.Sprintf("%v", _m.AiRawResult))
 	builder.WriteString(", ")
 	builder.WriteString("aiAttempts=")
 	builder.WriteString(fmt.Sprintf("%v", _m.AiAttempts))

--- a/api/ent/image/image.go
+++ b/api/ent/image/image.go
@@ -45,6 +45,8 @@ const (
 	FieldAiQueuedAt = "ai_queued_at"
 	// FieldAiScope holds the string denoting the aiscope field in the database.
 	FieldAiScope = "ai_scope"
+	// FieldAiRawResult holds the string denoting the airawresult field in the database.
+	FieldAiRawResult = "ai_raw_result"
 	// FieldAiAttempts holds the string denoting the aiattempts field in the database.
 	FieldAiAttempts = "ai_attempts"
 	// FieldAiError holds the string denoting the aierror field in the database.
@@ -130,6 +132,7 @@ var Columns = []string{
 	FieldAiStatus,
 	FieldAiQueuedAt,
 	FieldAiScope,
+	FieldAiRawResult,
 	FieldAiAttempts,
 	FieldAiError,
 	FieldSize,

--- a/api/ent/image/where.go
+++ b/api/ent/image/where.go
@@ -881,6 +881,16 @@ func AiScopeContainsFold(v string) predicate.Image {
 	return predicate.Image(sql.FieldContainsFold(FieldAiScope, v))
 }
 
+// AiRawResultIsNil applies the IsNil predicate on the "aiRawResult" field.
+func AiRawResultIsNil() predicate.Image {
+	return predicate.Image(sql.FieldIsNull(FieldAiRawResult))
+}
+
+// AiRawResultNotNil applies the NotNil predicate on the "aiRawResult" field.
+func AiRawResultNotNil() predicate.Image {
+	return predicate.Image(sql.FieldNotNull(FieldAiRawResult))
+}
+
 // AiAttemptsEQ applies the EQ predicate on the "aiAttempts" field.
 func AiAttemptsEQ(v int) predicate.Image {
 	return predicate.Image(sql.FieldEQ(FieldAiAttempts, v))

--- a/api/ent/image_create.go
+++ b/api/ent/image_create.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -201,6 +202,12 @@ func (_c *ImageCreate) SetNillableAiScope(v *string) *ImageCreate {
 	if v != nil {
 		_c.SetAiScope(*v)
 	}
+	return _c
+}
+
+// SetAiRawResult sets the "aiRawResult" field.
+func (_c *ImageCreate) SetAiRawResult(v json.RawMessage) *ImageCreate {
+	_c.mutation.SetAiRawResult(v)
 	return _c
 }
 
@@ -569,6 +576,10 @@ func (_c *ImageCreate) createSpec() (*Image, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.AiScope(); ok {
 		_spec.SetField(image.FieldAiScope, field.TypeString, value)
 		_node.AiScope = value
+	}
+	if value, ok := _c.mutation.AiRawResult(); ok {
+		_spec.SetField(image.FieldAiRawResult, field.TypeJSON, value)
+		_node.AiRawResult = value
 	}
 	if value, ok := _c.mutation.AiAttempts(); ok {
 		_spec.SetField(image.FieldAiAttempts, field.TypeInt, value)

--- a/api/ent/image_update.go
+++ b/api/ent/image_update.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -256,6 +257,24 @@ func (_u *ImageUpdate) SetNillableAiScope(v *string) *ImageUpdate {
 // ClearAiScope clears the value of the "aiScope" field.
 func (_u *ImageUpdate) ClearAiScope() *ImageUpdate {
 	_u.mutation.ClearAiScope()
+	return _u
+}
+
+// SetAiRawResult sets the "aiRawResult" field.
+func (_u *ImageUpdate) SetAiRawResult(v json.RawMessage) *ImageUpdate {
+	_u.mutation.SetAiRawResult(v)
+	return _u
+}
+
+// AppendAiRawResult appends value to the "aiRawResult" field.
+func (_u *ImageUpdate) AppendAiRawResult(v json.RawMessage) *ImageUpdate {
+	_u.mutation.AppendAiRawResult(v)
+	return _u
+}
+
+// ClearAiRawResult clears the value of the "aiRawResult" field.
+func (_u *ImageUpdate) ClearAiRawResult() *ImageUpdate {
+	_u.mutation.ClearAiRawResult()
 	return _u
 }
 
@@ -687,6 +706,17 @@ func (_u *ImageUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if _u.mutation.AiScopeCleared() {
 		_spec.ClearField(image.FieldAiScope, field.TypeString)
+	}
+	if value, ok := _u.mutation.AiRawResult(); ok {
+		_spec.SetField(image.FieldAiRawResult, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedAiRawResult(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, image.FieldAiRawResult, value)
+		})
+	}
+	if _u.mutation.AiRawResultCleared() {
+		_spec.ClearField(image.FieldAiRawResult, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.AiAttempts(); ok {
 		_spec.SetField(image.FieldAiAttempts, field.TypeInt, value)
@@ -1126,6 +1156,24 @@ func (_u *ImageUpdateOne) SetNillableAiScope(v *string) *ImageUpdateOne {
 // ClearAiScope clears the value of the "aiScope" field.
 func (_u *ImageUpdateOne) ClearAiScope() *ImageUpdateOne {
 	_u.mutation.ClearAiScope()
+	return _u
+}
+
+// SetAiRawResult sets the "aiRawResult" field.
+func (_u *ImageUpdateOne) SetAiRawResult(v json.RawMessage) *ImageUpdateOne {
+	_u.mutation.SetAiRawResult(v)
+	return _u
+}
+
+// AppendAiRawResult appends value to the "aiRawResult" field.
+func (_u *ImageUpdateOne) AppendAiRawResult(v json.RawMessage) *ImageUpdateOne {
+	_u.mutation.AppendAiRawResult(v)
+	return _u
+}
+
+// ClearAiRawResult clears the value of the "aiRawResult" field.
+func (_u *ImageUpdateOne) ClearAiRawResult() *ImageUpdateOne {
+	_u.mutation.ClearAiRawResult()
 	return _u
 }
 
@@ -1587,6 +1635,17 @@ func (_u *ImageUpdateOne) sqlSave(ctx context.Context) (_node *Image, err error)
 	}
 	if _u.mutation.AiScopeCleared() {
 		_spec.ClearField(image.FieldAiScope, field.TypeString)
+	}
+	if value, ok := _u.mutation.AiRawResult(); ok {
+		_spec.SetField(image.FieldAiRawResult, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AppendedAiRawResult(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, image.FieldAiRawResult, value)
+		})
+	}
+	if _u.mutation.AiRawResultCleared() {
+		_spec.ClearField(image.FieldAiRawResult, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.AiAttempts(); ok {
 		_spec.SetField(image.FieldAiAttempts, field.TypeInt, value)

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -184,6 +184,7 @@ var (
 		{Name: "ai_status", Type: field.TypeEnum, Nullable: true, Enums: []string{"pending", "processing", "done", "error"}},
 		{Name: "ai_queued_at", Type: field.TypeTime, Nullable: true},
 		{Name: "ai_scope", Type: field.TypeString, Nullable: true},
+		{Name: "ai_raw_result", Type: field.TypeJSON, Nullable: true},
 		{Name: "ai_attempts", Type: field.TypeInt, Default: 0},
 		{Name: "ai_error", Type: field.TypeString, Nullable: true},
 		{Name: "size", Type: field.TypeInt},
@@ -202,25 +203,25 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "images_cameras_images",
-				Columns:    []*schema.Column{ImagesColumns[21]},
+				Columns:    []*schema.Column{ImagesColumns[22]},
 				RefColumns: []*schema.Column{CamerasColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "images_projects_images",
-				Columns:    []*schema.Column{ImagesColumns[22]},
+				Columns:    []*schema.Column{ImagesColumns[23]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "images_uploads_images",
-				Columns:    []*schema.Column{ImagesColumns[23]},
+				Columns:    []*schema.Column{ImagesColumns[24]},
 				RefColumns: []*schema.Column{UploadsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "images_users_images",
-				Columns:    []*schema.Column{ImagesColumns[24]},
+				Columns:    []*schema.Column{ImagesColumns[25]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -229,22 +230,22 @@ var (
 			{
 				Name:    "image_project_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[22]},
+				Columns: []*schema.Column{ImagesColumns[23]},
 			},
 			{
 				Name:    "image_upload_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[23]},
+				Columns: []*schema.Column{ImagesColumns[24]},
 			},
 			{
 				Name:    "image_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[24]},
+				Columns: []*schema.Column{ImagesColumns[25]},
 			},
 			{
 				Name:    "image_camera_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[21]},
+				Columns: []*schema.Column{ImagesColumns[22]},
 			},
 			{
 				Name:    "image_captured_at_corrected",
@@ -254,7 +255,7 @@ var (
 			{
 				Name:    "image_project_id_captured_at_corrected",
 				Unique:  false,
-				Columns: []*schema.Column{ImagesColumns[22], ImagesColumns[11]},
+				Columns: []*schema.Column{ImagesColumns[23], ImagesColumns[11]},
 			},
 			{
 				Name:    "image_ai_status_ai_queued_at",

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -4,6 +4,7 @@ package ent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -4159,6 +4160,8 @@ type ImageMutation struct {
 	aiStatus                   *image.AiStatus
 	aiQueuedAt                 *time.Time
 	aiScope                    *string
+	aiRawResult                *json.RawMessage
+	appendaiRawResult          json.RawMessage
 	aiAttempts                 *int
 	addaiAttempts              *int
 	aiError                    *string
@@ -4988,6 +4991,71 @@ func (m *ImageMutation) ResetAiScope() {
 	delete(m.clearedFields, image.FieldAiScope)
 }
 
+// SetAiRawResult sets the "aiRawResult" field.
+func (m *ImageMutation) SetAiRawResult(jm json.RawMessage) {
+	m.aiRawResult = &jm
+	m.appendaiRawResult = nil
+}
+
+// AiRawResult returns the value of the "aiRawResult" field in the mutation.
+func (m *ImageMutation) AiRawResult() (r json.RawMessage, exists bool) {
+	v := m.aiRawResult
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAiRawResult returns the old "aiRawResult" field's value of the Image entity.
+// If the Image object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ImageMutation) OldAiRawResult(ctx context.Context) (v json.RawMessage, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAiRawResult is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAiRawResult requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAiRawResult: %w", err)
+	}
+	return oldValue.AiRawResult, nil
+}
+
+// AppendAiRawResult adds jm to the "aiRawResult" field.
+func (m *ImageMutation) AppendAiRawResult(jm json.RawMessage) {
+	m.appendaiRawResult = append(m.appendaiRawResult, jm...)
+}
+
+// AppendedAiRawResult returns the list of values that were appended to the "aiRawResult" field in this mutation.
+func (m *ImageMutation) AppendedAiRawResult() (json.RawMessage, bool) {
+	if len(m.appendaiRawResult) == 0 {
+		return nil, false
+	}
+	return m.appendaiRawResult, true
+}
+
+// ClearAiRawResult clears the value of the "aiRawResult" field.
+func (m *ImageMutation) ClearAiRawResult() {
+	m.aiRawResult = nil
+	m.appendaiRawResult = nil
+	m.clearedFields[image.FieldAiRawResult] = struct{}{}
+}
+
+// AiRawResultCleared returns if the "aiRawResult" field was cleared in this mutation.
+func (m *ImageMutation) AiRawResultCleared() bool {
+	_, ok := m.clearedFields[image.FieldAiRawResult]
+	return ok
+}
+
+// ResetAiRawResult resets all changes to the "aiRawResult" field.
+func (m *ImageMutation) ResetAiRawResult() {
+	m.aiRawResult = nil
+	m.appendaiRawResult = nil
+	delete(m.clearedFields, image.FieldAiRawResult)
+}
+
 // SetAiAttempts sets the "aiAttempts" field.
 func (m *ImageMutation) SetAiAttempts(i int) {
 	m.aiAttempts = &i
@@ -5629,7 +5697,7 @@ func (m *ImageMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ImageMutation) Fields() []string {
-	fields := make([]string, 0, 24)
+	fields := make([]string, 0, 25)
 	if m.createdAt != nil {
 		fields = append(fields, image.FieldCreatedAt)
 	}
@@ -5674,6 +5742,9 @@ func (m *ImageMutation) Fields() []string {
 	}
 	if m.aiScope != nil {
 		fields = append(fields, image.FieldAiScope)
+	}
+	if m.aiRawResult != nil {
+		fields = append(fields, image.FieldAiRawResult)
 	}
 	if m.aiAttempts != nil {
 		fields = append(fields, image.FieldAiAttempts)
@@ -5740,6 +5811,8 @@ func (m *ImageMutation) Field(name string) (ent.Value, bool) {
 		return m.AiQueuedAt()
 	case image.FieldAiScope:
 		return m.AiScope()
+	case image.FieldAiRawResult:
+		return m.AiRawResult()
 	case image.FieldAiAttempts:
 		return m.AiAttempts()
 	case image.FieldAiError:
@@ -5797,6 +5870,8 @@ func (m *ImageMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldAiQueuedAt(ctx)
 	case image.FieldAiScope:
 		return m.OldAiScope(ctx)
+	case image.FieldAiRawResult:
+		return m.OldAiRawResult(ctx)
 	case image.FieldAiAttempts:
 		return m.OldAiAttempts(ctx)
 	case image.FieldAiError:
@@ -5928,6 +6003,13 @@ func (m *ImageMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAiScope(v)
+		return nil
+	case image.FieldAiRawResult:
+		v, ok := value.(json.RawMessage)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAiRawResult(v)
 		return nil
 	case image.FieldAiAttempts:
 		v, ok := value.(int)
@@ -6106,6 +6188,9 @@ func (m *ImageMutation) ClearedFields() []string {
 	if m.FieldCleared(image.FieldAiScope) {
 		fields = append(fields, image.FieldAiScope)
 	}
+	if m.FieldCleared(image.FieldAiRawResult) {
+		fields = append(fields, image.FieldAiRawResult)
+	}
 	if m.FieldCleared(image.FieldAiError) {
 		fields = append(fields, image.FieldAiError)
 	}
@@ -6161,6 +6246,9 @@ func (m *ImageMutation) ClearField(name string) error {
 		return nil
 	case image.FieldAiScope:
 		m.ClearAiScope()
+		return nil
+	case image.FieldAiRawResult:
+		m.ClearAiRawResult()
 		return nil
 	case image.FieldAiError:
 		m.ClearAiError()
@@ -6223,6 +6311,9 @@ func (m *ImageMutation) ResetField(name string) error {
 		return nil
 	case image.FieldAiScope:
 		m.ResetAiScope()
+		return nil
+	case image.FieldAiRawResult:
+		m.ResetAiRawResult()
 		return nil
 	case image.FieldAiAttempts:
 		m.ResetAiAttempts()

--- a/api/ent/runtime.go
+++ b/api/ent/runtime.go
@@ -193,19 +193,19 @@ func init() {
 	// image.DefaultImageTags holds the default value on creation for the imageTags field.
 	image.DefaultImageTags = imageDescImageTags.Default.([]string)
 	// imageDescAiAttempts is the schema descriptor for aiAttempts field.
-	imageDescAiAttempts := imageFields[11].Descriptor()
+	imageDescAiAttempts := imageFields[12].Descriptor()
 	// image.DefaultAiAttempts holds the default value on creation for the aiAttempts field.
 	image.DefaultAiAttempts = imageDescAiAttempts.Default.(int)
 	// imageDescSize is the schema descriptor for size field.
-	imageDescSize := imageFields[13].Descriptor()
+	imageDescSize := imageFields[14].Descriptor()
 	// image.SizeValidator is a validator for the "size" field. It is called by the builders before save.
 	image.SizeValidator = imageDescSize.Validators[0].(func(int) error)
 	// imageDescWidth is the schema descriptor for width field.
-	imageDescWidth := imageFields[14].Descriptor()
+	imageDescWidth := imageFields[15].Descriptor()
 	// image.WidthValidator is a validator for the "width" field. It is called by the builders before save.
 	image.WidthValidator = imageDescWidth.Validators[0].(func(int) error)
 	// imageDescHeight is the schema descriptor for height field.
-	imageDescHeight := imageFields[15].Descriptor()
+	imageDescHeight := imageFields[16].Descriptor()
 	// image.HeightValidator is a validator for the "height" field. It is called by the builders before save.
 	image.HeightValidator = imageDescHeight.Validators[0].(func(int) error)
 	// imageDescID is the schema descriptor for id field.

--- a/api/ent/schema/image.go
+++ b/api/ent/schema/image.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"encoding/json"
+
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
@@ -34,6 +36,10 @@ func (Image) Fields() []ent.Field {
 		// car-number re-read (aiserver.ScopeNumbers). Persisted so a restart
 		// doesn't silently upgrade a cheap numbers backlog into full reruns.
 		field.String("aiScope").Optional().StructTag(`json:"-"`),
+		// Raw detection payload of the last AI run (aiserver IngestResponse.Raw),
+		// stored verbatim for the SPA's inspection dialog; excluded from image
+		// DTOs (served by GET /images/:id/ai/result only).
+		field.JSON("aiRawResult", json.RawMessage{}).Optional().StructTag(`json:"-"`),
 		field.Int("aiAttempts").Default(0).StructTag(`json:"-"`),
 		field.String("aiError").Optional().StructTag(`json:"aiError,omitempty"`),
 		field.Int("size").NonNegative().StructTag(`json:"size"`),

--- a/api/internal/server/ai_controller.go
+++ b/api/internal/server/ai_controller.go
@@ -49,6 +49,7 @@ func (s *Server) registerAIRoutes(api *gin.RouterGroup) {
 	api.GET("/uploads/:id/ai", s.aiUploadStatus)
 	api.POST("/uploads/:id/ai/rerun", s.aiRerunUpload)
 	api.POST("/images/:id/ai/rerun", s.aiRerunImage)
+	api.GET("/images/:id/ai/result", s.aiImageResult)
 	api.GET("/images/:id/ai/faces", s.aiImageFaces)
 	api.GET("/images/:id/ai/similar", s.aiImageSimilar)
 }
@@ -318,6 +319,29 @@ func (s *Server) aiRerunBatch(c *gin.Context) {
 		s.ai.Enqueue(imageID)
 	}
 	c.JSON(http.StatusOK, gin.H{"queued": len(ids)})
+}
+
+// aiImageResult serves the stored raw detection payload of the image's last
+// AI run — the AI server's full detail (model reads, evidence axes, notes),
+// stored verbatim at inference time for the SPA's inspection dialog. No AI
+// server round trip; 404 when no run stored a payload yet.
+func (s *Server) aiImageResult(c *gin.Context) {
+	id, ok := getIdParam(c)
+	if !ok {
+		return
+	}
+	img, err := s.Repository.GetImage(c.Request.Context(), id)
+	if abortGetError(c, err) {
+		return
+	}
+	if !allow(c, authorization.CanViewImage(authUser(c), img)) {
+		return
+	}
+	if len(img.AiRawResult) == 0 {
+		apiError(c, http.StatusNotFound, "no_ai_result", "no stored AI detection result for this image")
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"raw": img.AiRawResult, "inferredAt": img.InferredAt})
 }
 
 // --- AI server proxies ---

--- a/api/internal/service/ai_service.go
+++ b/api/internal/service/ai_service.go
@@ -365,7 +365,7 @@ func (s *AIService) processWith(ctx context.Context, imageID string, inference I
 
 	inferCtx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
-	inferred, err := inference.Infer(inferCtx, req)
+	result, err := inference.Infer(inferCtx, req)
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func (s *AIService) processWith(ctx context.Context, imageID string, inference I
 		return err
 	}
 
-	for _, t := range inferred {
+	for _, t := range result.Tags {
 		name := strings.TrimSpace(t.Name)
 		if name == "" || name == "none" {
 			continue
@@ -404,12 +404,19 @@ func (s *AIService) processWith(ctx context.Context, imageID string, inference I
 		return err
 	}
 
-	updated, err := image.Update().
+	done := image.Update().
 		SetAiStatus(entimage.AiStatusDone).
 		SetInferredAt(time.Now()).
 		ClearAiScope().
-		ClearAiError().
-		Save(ctx)
+		ClearAiError()
+	// keep the provider's raw payload for the SPA's inspection dialog; a
+	// provider without one clears any stale payload from an earlier run.
+	if len(result.Raw) > 0 {
+		done.SetAiRawResult(result.Raw)
+	} else {
+		done.ClearAiRawResult()
+	}
+	updated, err := done.Save(ctx)
 	if err != nil {
 		return err
 	}

--- a/api/internal/service/ai_service_test.go
+++ b/api/internal/service/ai_service_test.go
@@ -70,7 +70,7 @@ type recordInference struct {
 	seen []string
 }
 
-func (r *recordInference) Infer(_ context.Context, req InferenceRequest) ([]InferredTag, error) {
+func (r *recordInference) Infer(_ context.Context, req InferenceRequest) (InferenceResult, error) {
 	// object name looks like "se/seedimg00000001-512.jpg"; capture the storage id.
 	for _, part := range strings.Split(req.ImageURL, "/") {
 		if strings.HasPrefix(part, "seedimg") {
@@ -81,13 +81,13 @@ func (r *recordInference) Infer(_ context.Context, req InferenceRequest) ([]Infe
 	for _, name := range r.tags {
 		tags = append(tags, InferredTag{Name: name, Confidence: 1})
 	}
-	return tags, nil
+	return InferenceResult{Tags: tags}, nil
 }
 
 type failInference struct{}
 
-func (failInference) Infer(_ context.Context, _ InferenceRequest) ([]InferredTag, error) {
-	return nil, errors.New("boom")
+func (failInference) Infer(_ context.Context, _ InferenceRequest) (InferenceResult, error) {
+	return InferenceResult{}, errors.New("boom")
 }
 
 // Provider selection by config.
@@ -255,12 +255,12 @@ type deadlineInference struct {
 	seen    []string
 }
 
-func (d *deadlineInference) Infer(_ context.Context, req InferenceRequest) ([]InferredTag, error) {
+func (d *deadlineInference) Infer(_ context.Context, req InferenceRequest) (InferenceResult, error) {
 	d.seen = append(d.seen, req.ImageID)
 	if req.ImageID == d.failFor {
-		return nil, fmt.Errorf("infer: %w", context.DeadlineExceeded)
+		return InferenceResult{}, fmt.Errorf("infer: %w", context.DeadlineExceeded)
 	}
-	return []InferredTag{}, nil
+	return InferenceResult{}, nil
 }
 
 // A deadline-exceeded inference retries at the BACK of the FIFO without arming
@@ -312,8 +312,8 @@ func (netTimeoutErr) Temporary() bool { return true }
 
 type netTimeoutInference struct{}
 
-func (netTimeoutInference) Infer(_ context.Context, _ InferenceRequest) ([]InferredTag, error) {
-	return nil, fmt.Errorf("infer: %w", netTimeoutErr{})
+func (netTimeoutInference) Infer(_ context.Context, _ InferenceRequest) (InferenceResult, error) {
+	return InferenceResult{}, fmt.Errorf("infer: %w", netTimeoutErr{})
 }
 
 // An http-client-level timeout (net.Error, not DeadlineExceeded) classifies as
@@ -338,9 +338,9 @@ func TestClientTimeoutClassifiesAsTimeout(t *testing.T) {
 // scopeInference records the Scope of each request it serves.
 type scopeInference struct{ scopes []string }
 
-func (s *scopeInference) Infer(_ context.Context, req InferenceRequest) ([]InferredTag, error) {
+func (s *scopeInference) Infer(_ context.Context, req InferenceRequest) (InferenceResult, error) {
 	s.scopes = append(s.scopes, req.Scope)
-	return []InferredTag{}, nil
+	return InferenceResult{}, nil
 }
 
 // A scoped project rerun persists aiScope, forwards it to the inference
@@ -367,6 +367,32 @@ func TestScopedRerunThreadsScope(t *testing.T) {
 	svc.Enqueue(m.Images[0])
 	require.True(t, svc.step(ctx))
 	assert.Equal(t, "", inf.scopes[len(inf.scopes)-1], "single-image rerun must be a full run")
+}
+
+// rawInference returns a fixed raw payload alongside no tags.
+type rawInference struct{ raw string }
+
+func (r *rawInference) Infer(_ context.Context, _ InferenceRequest) (InferenceResult, error) {
+	if r.raw == "" {
+		return InferenceResult{}, nil
+	}
+	return InferenceResult{Raw: []byte(r.raw)}, nil
+}
+
+// The provider's raw payload is stored on done and cleared again when a later
+// run returns none.
+func TestRawResultStoredAndCleared(t *testing.T) {
+	inf := &rawInference{raw: `{"carNumber":"E7"}`}
+	svc, m := newSvc(t, inf)
+	ctx := context.Background()
+	img := m.Images[0]
+
+	require.NoError(t, svc.process(ctx, img))
+	assert.JSONEq(t, `{"carNumber":"E7"}`, string(svc.repo.Client.Image.GetX(ctx, img).AiRawResult))
+
+	inf.raw = ""
+	require.NoError(t, svc.process(ctx, img))
+	assert.Empty(t, svc.repo.Client.Image.GetX(ctx, img).AiRawResult, "a run without raw must clear the stale payload")
 }
 
 // Boot recovery: STALE processing rows are re-queued by Start; fresh ones are

--- a/api/internal/service/inference.go
+++ b/api/internal/service/inference.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -37,11 +38,19 @@ type InferredTag struct {
 	Confidence float64
 }
 
+// InferenceResult is one provider run: the tags plus the provider's raw
+// detection payload (aiserver Raw — stored verbatim for human inspection;
+// nil for providers without one).
+type InferenceResult struct {
+	Tags []InferredTag
+	Raw  json.RawMessage
+}
+
 // ImageInference is the single seam the AI tagging service talks to.
 // Provider-specific transport (OpenAI, OpenRouter, the aiserver contract)
 // lives behind this; the service stays provider-agnostic.
 type ImageInference interface {
-	Infer(ctx context.Context, req InferenceRequest) ([]InferredTag, error)
+	Infer(ctx context.Context, req InferenceRequest) (InferenceResult, error)
 }
 
 // NewInference selects an implementation from AI_PROVIDER. Unknown providers are
@@ -74,7 +83,7 @@ type StubInference struct {
 	Tags []string
 }
 
-func (s *StubInference) Infer(_ context.Context, req InferenceRequest) ([]InferredTag, error) {
+func (s *StubInference) Infer(_ context.Context, req InferenceRequest) (InferenceResult, error) {
 	names := s.Tags
 	if names == nil {
 		names = []string{req.Prompt}
@@ -83,7 +92,7 @@ func (s *StubInference) Infer(_ context.Context, req InferenceRequest) ([]Inferr
 	for _, n := range names {
 		tags = append(tags, InferredTag{Name: n, Confidence: 1})
 	}
-	return tags, nil
+	return InferenceResult{Tags: tags}, nil
 }
 
 // openAIInference ports the old hook's go-openai usage: system prompt + the
@@ -103,7 +112,7 @@ func newOpenAIInference(baseURL string) *openAIInference {
 	}
 }
 
-func (o *openAIInference) Infer(ctx context.Context, req InferenceRequest) ([]InferredTag, error) {
+func (o *openAIInference) Infer(ctx context.Context, req InferenceRequest) (InferenceResult, error) {
 	cfg := openai.DefaultConfig(o.apiKey)
 	if o.baseURL != "" {
 		cfg.BaseURL = o.baseURL
@@ -121,7 +130,7 @@ func (o *openAIInference) Infer(ctx context.Context, req InferenceRequest) ([]In
 		},
 	})
 	if err != nil {
-		return nil, err
+		return InferenceResult{}, err
 	}
 	tags := make([]InferredTag, 0, len(resp.Choices))
 	for _, choice := range resp.Choices {
@@ -129,7 +138,7 @@ func (o *openAIInference) Infer(ctx context.Context, req InferenceRequest) ([]In
 			tags = append(tags, InferredTag{Name: t, Confidence: 1})
 		}
 	}
-	return tags, nil
+	return InferenceResult{Tags: tags}, nil
 }
 
 // HTTPInference speaks the shutterbase AI-server contract. The full request
@@ -139,7 +148,7 @@ type HTTPInference struct {
 	Client *aiserver.Client
 }
 
-func (h *HTTPInference) Infer(ctx context.Context, req InferenceRequest) ([]InferredTag, error) {
+func (h *HTTPInference) Infer(ctx context.Context, req InferenceRequest) (InferenceResult, error) {
 	resp, err := h.Client.Ingest(ctx, req.ProjectID, aiserver.IngestRequest{
 		Project: aiserver.Project{
 			ID:     req.ProjectID,
@@ -154,11 +163,11 @@ func (h *HTTPInference) Infer(ctx context.Context, req InferenceRequest) ([]Infe
 		Scope:      req.Scope,
 	})
 	if err != nil {
-		return nil, err
+		return InferenceResult{}, err
 	}
 	tags := make([]InferredTag, 0, len(resp.Tags))
 	for _, t := range resp.Tags {
 		tags = append(tags, InferredTag{Name: t.Name, Confidence: t.Confidence})
 	}
-	return tags, nil
+	return InferenceResult{Tags: tags, Raw: resp.Raw}, nil
 }

--- a/pkg/aiserver/aiserver_test.go
+++ b/pkg/aiserver/aiserver_test.go
@@ -1,6 +1,7 @@
 package aiserver
 
 import (
+	"encoding/json"
 	"context"
 	"errors"
 	"net/http/httptest"
@@ -32,7 +33,8 @@ func (f *fakeServer) Prime(_ context.Context, projectID string, p Project) error
 
 func (f *fakeServer) Ingest(_ context.Context, projectID string, req IngestRequest) (IngestResponse, error) {
 	f.lastIn = req
-	return IngestResponse{ImageRef: req.ImageRef, Tags: []Tag{{Name: "alpha", Confidence: 0.91}}}, nil
+	return IngestResponse{ImageRef: req.ImageRef, Tags: []Tag{{Name: "alpha", Confidence: 0.91}},
+		Raw: json.RawMessage(`{"carNumber":"E7"}`)}, nil
 }
 
 func (f *fakeServer) Faces(_ context.Context, projectID, imageRef string) (FacesResponse, error) {
@@ -130,6 +132,9 @@ func TestClientHandlerRoundtrip(t *testing.T) {
 	}
 	if ingest.ImageRef != "img1" || len(ingest.Tags) != 1 || ingest.Tags[0].Name != "alpha" {
 		t.Fatalf("ingest response mangled: %+v", ingest)
+	}
+	if string(ingest.Raw) != `{"carNumber":"E7"}` {
+		t.Fatalf("raw payload mangled: %s", ingest.Raw)
 	}
 	if fake.lastIn.Author != "MP" || !fake.lastIn.CapturedAt.Equal(captured) {
 		t.Fatalf("ingest request mangled: %+v", fake.lastIn)

--- a/pkg/aiserver/types.go
+++ b/pkg/aiserver/types.go
@@ -6,7 +6,10 @@
 // tags from that vocabulary — nothing else about the domain leaks through.
 package aiserver
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // Project is the priming payload: everything the AI server needs to know about
 // a shutterbase project. It is sent both via Prime and inline with every
@@ -49,6 +52,10 @@ type Tag struct {
 type IngestResponse struct {
 	ImageRef string `json:"imageRef"`
 	Tags     []Tag  `json:"tags"`
+	// Raw is the server's full detection detail (model reads, evidence axes,
+	// notes …) as an opaque JSON document for human inspection. The caller
+	// stores and displays it verbatim — no semantics leak into the contract.
+	Raw json.RawMessage `json:"raw,omitempty"`
 }
 
 // Face is a detected face. Coordinates are relative (0..1) to the image, so

--- a/ui/src/api/ai.ts
+++ b/ui/src/api/ai.ts
@@ -101,6 +101,13 @@ export async function recluster(projectId: string): Promise<void> {
   await http.post(`/projects/${projectId}/ai/recluster`);
 }
 
+// Stored raw detection payload of the image's last AI run (the AI server's
+// full detail — model reads, evidence axes, notes). 404 when none is stored.
+export async function result(imageId: string): Promise<{ raw: unknown; inferredAt?: string }> {
+  const { data } = await http.get<{ raw: unknown; inferredAt?: string }>(`/images/${imageId}/ai/result`);
+  return data;
+}
+
 export async function faces(imageId: string): Promise<AiFace[]> {
   const { data } = await http.get<{ faces: AiFace[] }>(`/images/${imageId}/ai/faces`);
   return data.faces;

--- a/ui/src/components/image/Sidebar.vue
+++ b/ui/src/components/image/Sidebar.vue
@@ -88,6 +88,7 @@
           <p @click="() => emitter.emit('ai-show-similar')" class="text-sm font-medium text-accent-600 hover:text-accent-500 dark:text-accent-400 underline cursor-pointer">
             similar images
           </p>
+          <p @click="showDetectionResult" class="text-sm font-medium text-accent-600 hover:text-accent-500 dark:text-accent-400 underline cursor-pointer">detection result</p>
           <p
             v-if="userStore.isProjectEditorOrHigher()"
             @click="rerunAi"
@@ -161,6 +162,15 @@
         </div>
       </div>
     </div>
+    <div v-if="showAiResult" class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" @click.self="showAiResult = false">
+      <div class="flex max-h-[80vh] w-full max-w-2xl flex-col rounded-lg border border-primary-200 bg-surface shadow-xl dark:border-primary-700 dark:bg-surface-dark">
+        <div class="flex items-center justify-between border-b border-primary-200 px-4 py-3 dark:border-primary-800">
+          <h3 class="label-mono text-primary-500 dark:text-primary-400">AI Detection Result</h3>
+          <button type="button" class="cursor-pointer text-sm font-medium text-accent-600 hover:text-accent-500 dark:text-accent-400" @click="showAiResult = false">close</button>
+        </div>
+        <pre class="overflow-auto whitespace-pre-wrap break-all px-4 py-3 font-data text-xs leading-relaxed text-primary-800 dark:text-primary-100">{{ aiResultText }}</pre>
+      </div>
+    </div>
     <UnexpectedErrorMessage :show="showUnexpectedErrorMessage" :error="unexpectedError" @closed="showUnexpectedErrorMessage = false" />
     <ModalMessage
       :show="showDeleteDialog"
@@ -226,6 +236,24 @@ const aiStatusText = computed(() => {
       return "not run";
   }
 });
+
+const showAiResult = ref(false);
+const aiResultText = ref("");
+async function showDetectionResult() {
+  if (!props.item) return;
+  try {
+    const res = await api.ai.result(props.item.id);
+    aiResultText.value = JSON.stringify(res.raw, null, 2);
+    showAiResult.value = true;
+  } catch (error: any) {
+    if (error?.response?.status === 404) {
+      showNotificationToast({ headline: "No detection result stored for this image", type: "info" });
+      return;
+    }
+    unexpectedError.value = error;
+    showUnexpectedErrorMessage.value = true;
+  }
+}
 
 async function rerunAi() {
   if (!props.item) return;


### PR DESCRIPTION
Adds visibility into what the FSAI server actually detected: the aiserver contract gains an opaque `IngestResponse.Raw` JSON document with the server's full detection detail — the vision model's reads (car number, colors, sponsors, discipline…), the ranked identity scores, the per-axis evidence votes, and the analysis notes.

- Shutterbase stores the payload verbatim on the image row at inference time (`aiRawResult`, excluded from image DTOs) and serves it via `GET /images/:id/ai/result` (viewer+, 404 when none stored).
- The image sidebar's AI Detection section gets a **detection result** link opening a raw-JSON dialog.
- `ImageInference` now returns `InferenceResult{Tags, Raw}`; only the http provider carries a raw payload, and a run without one clears any stale payload from an earlier run.
- fsai side (in the fsai repo): the ingest response and the stored `result` jsonb now share one enriched payload built by `rawDetail`, including the rerun scope — verified by the docker e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)