### PR TITLE
fix(people): sharp face crops, crops for dimension-less imports, prefetch soft-fail

### DIFF
--- a/ui/src/components/project/FaceCarousel.vue
+++ b/ui/src/components/project/FaceCarousel.vue
@@ -2,10 +2,10 @@
   <div>
     <div class="relative aspect-square w-full overflow-hidden rounded-sm bg-primary-100 dark:bg-primary-900">
       <template v-if="current && crop">
-        <img :src="src(current)" :alt="current.image.computedFileName" :style="crop.img" class="absolute max-w-none" loading="lazy" />
+        <img :src="currentSrc" :alt="current.image.computedFileName" :style="crop.img" class="absolute max-w-none" loading="lazy" />
         <div :style="crop.box" class="absolute rounded-sm border-2 border-accent-400/90 shadow-[0_0_0_1px_rgba(0,0,0,0.4)]"></div>
       </template>
-      <img v-else-if="current" :src="src(current)" :alt="current.image.computedFileName" class="h-full w-full object-cover" loading="lazy" />
+      <img v-else-if="current" :src="currentSrc" :alt="current.image.computedFileName" @load="onImgLoad" class="h-full w-full object-cover" loading="lazy" />
       <div v-else class="flex h-full w-full items-center justify-center">
         <span class="label-mono-sm text-primary-400 dark:text-primary-600">{{ loading ? "…" : "no sample" }}</span>
       </div>
@@ -37,7 +37,7 @@ import { computed, onMounted, ref, watch } from "vue";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/vue/24/solid";
 import { api } from "src/api";
 import { AiPersonImage, AiPersonImagesPage } from "src/api/ai";
-import { faceCropStyle } from "src/util/aiDetection";
+import { faceCropStyle, faceRendition } from "src/util/aiDetection";
 
 // One face of a person cluster, cropped with generous margin, with arrows to
 // flip through the cluster's appearances in place. Seed it with a single
@@ -67,10 +67,34 @@ const loading = ref(false);
 
 const current = computed(() => items.value[index.value]);
 const atEnd = computed(() => !hasMore.value && index.value >= items.value.length - 1);
-const crop = computed(() => (current.value ? faceCropStyle(current.value, current.value.image.width ?? 0, current.value.image.height ?? 0) : null));
 
-function src(item: AiPersonImage) {
-  return item.image.downloadUrls?.["512"] ?? "";
+// Old imports have no stored width/height; the loaded thumbnail's natural
+// dimensions are aspect-correct and the crop math is scale-invariant, so they
+// substitute fully (probed per current image via @load on the fallback img).
+const probed = ref<{ w: number; h: number } | null>(null);
+watch(current, () => (probed.value = null));
+
+const dims = computed(() => {
+  const image = current.value?.image;
+  if (image?.width && image?.height) return { w: image.width, h: image.height };
+  return probed.value;
+});
+
+const crop = computed(() => (current.value && dims.value ? faceCropStyle(current.value, dims.value.w, dims.value.h) : null));
+const currentSrc = computed(() => (current.value ? src(current.value, dims.value) : ""));
+
+function onImgLoad(event: Event) {
+  if (dims.value) return;
+  const el = event.target as HTMLImageElement;
+  if (el.naturalWidth && el.naturalHeight) probed.value = { w: el.naturalWidth, h: el.naturalHeight };
+}
+
+// Deep crops pixelate on the 512 rendition — pick the rendition by crop depth.
+function src(item: AiPersonImage, d?: { w: number; h: number } | null) {
+  const urls = item.image.downloadUrls ?? {};
+  const w = d?.w ?? item.image.width ?? 0;
+  const h = d?.h ?? item.image.height ?? 0;
+  return urls[faceRendition(item, w, h)] ?? urls["512"] ?? "";
 }
 
 // fetchNext loads the next page and leaves `index` on the face the user asked

--- a/ui/src/pages/people/People.vue
+++ b/ui/src/pages/people/People.vue
@@ -280,6 +280,7 @@ import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
 import FaceCarousel from "src/components/project/FaceCarousel.vue";
 import { api } from "src/api";
 import { AiMerge, AiMergeCandidate, AiPersonImage, AiPersonImagesPage, AiRankedPerson } from "src/api/ai";
+import { faceRendition } from "src/util/aiDetection";
 import * as dateTimeUtil from "src/util/dateTimeUtil";
 import { showNotificationToast } from "src/boot/mitt";
 import { useUserStore } from "src/stores/user-store";
@@ -432,7 +433,9 @@ function reviewFail(error: any) {
 }
 
 function preload(item?: AiPersonImage) {
-  const url = item?.image.downloadUrls?.["512"];
+  if (!item) return;
+  const size = faceRendition(item, item.image.width ?? 0, item.image.height ?? 0);
+  const url = item.image.downloadUrls?.[size] ?? item.image.downloadUrls?.["512"];
   if (url) new Image().src = url;
 }
 
@@ -476,7 +479,15 @@ async function refill() {
     }
     if (cursor >= 500) exhausted.value = true;
   } catch (error: any) {
-    if (gen === refillGen) reviewFail(error);
+    if (gen !== refillGen) return;
+    if (!error?.response) {
+      // response-less = transient network blip (pod roll, flaky wifi) — a
+      // background prefetch must self-heal, not raise the error modal. With
+      // an empty queue nothing else re-triggers refill, so retry on a timer.
+      if (!queue.value.length) setTimeout(() => refill(), 5000);
+    } else {
+      reviewFail(error);
+    }
   } finally {
     if (gen === refillGen) refilling = false;
   }

--- a/ui/src/util/aiDetection.ts
+++ b/ui/src/util/aiDetection.ts
@@ -38,18 +38,36 @@ export function faceBoxStyle(box: RelativeBox): Record<string, string> {
   return { left: pct(box.x), top: pct(box.y), width: pct(box.w), height: pct(box.h) };
 }
 
+// cropSide is the edge length (in image px) of the square face crop: margin ×
+// the face's larger edge, clamped to fit the image. 0 when uncomputable.
+function cropSide(box: RelativeBox, imageWidth: number, imageHeight: number, margin: number): number {
+  if (!imageWidth || !imageHeight) return 0;
+  const edge = Math.max(box.w * imageWidth, box.h * imageHeight);
+  if (edge <= 0) return 0;
+  return Math.min(edge * margin, Math.min(imageWidth, imageHeight));
+}
+
+// faceRendition picks the smallest thumbnail rendition whose crop region still
+// fills a tile of tilePx — deep crops need a larger source or they pixelate.
+// The math is scale-invariant, so rendition dimensions work as well as
+// original ones. Falls back to "512" without dimensions.
+export function faceRendition(box: RelativeBox, imageWidth: number, imageHeight: number, tilePx = 512, margin = 2.75): string {
+  const side = cropSide(box, imageWidth, imageHeight, margin);
+  if (!side) return "512";
+  const neededLongEdge = (tilePx * Math.max(imageWidth, imageHeight)) / side;
+  return String([512, 1024, 2048].find((s) => s >= neededLongEdge) ?? 2048);
+}
+
 // faceCropStyle positions an <img> inside a square, overflow-hidden tile so
 // the face bbox sits centered with generous margin — a face crop without
-// server-side cropping. The crop is a square of `margin` × the face's larger
-// edge, clamped into the image. Returns percentage styles for the img and for
-// the face box drawn inside the crop, or null when the image dimensions are
+// server-side cropping. Returns percentage styles for the img and for the
+// face box drawn inside the crop, or null when the image dimensions are
 // unknown (caller falls back to object-cover).
 export function faceCropStyle(box: RelativeBox, imageWidth: number, imageHeight: number, margin = 2.75): { img: Record<string, string>; box: Record<string, string> } | null {
-  if (!imageWidth || !imageHeight) return null;
+  const side = cropSide(box, imageWidth, imageHeight, margin);
+  if (!side) return null;
   const faceW = box.w * imageWidth;
   const faceH = box.h * imageHeight;
-  if (faceW <= 0 || faceH <= 0) return null;
-  const side = Math.min(Math.max(faceW, faceH) * margin, Math.min(imageWidth, imageHeight));
   const clamp = (v: number, max: number) => Math.max(0, Math.min(v, max));
   const left = clamp((box.x + box.w / 2) * imageWidth - side / 2, imageWidth - side);
   const top = clamp((box.y + box.h / 2) * imageHeight - side / 2, imageHeight - side);

--- a/ui/tests/aiDetection.spec.ts
+++ b/ui/tests/aiDetection.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { aiBadgeLabel, aiBadgeTitle, aiUploadSummary, faceBoxStyle, faceCropStyle } from "src/util/aiDetection";
+import { aiBadgeLabel, aiBadgeTitle, aiUploadSummary, faceBoxStyle, faceCropStyle, faceRendition } from "src/util/aiDetection";
 
 describe("aiBadgeLabel", () => {
   it("shows the queue position only while pending", () => {
@@ -59,6 +59,24 @@ describe("faceCropStyle", () => {
   });
   it("returns null without image dimensions", () => {
     expect(faceCropStyle({ x: 0.1, y: 0.1, w: 0.2, h: 0.2 }, 0, 0)).toBeNull();
+  });
+});
+
+describe("faceRendition", () => {
+  it("scales the rendition with crop depth", () => {
+    // huge face on a square image: crop covers the full image → 512 suffices
+    expect(faceRendition({ x: 0.25, y: 0.25, w: 0.5, h: 0.5 }, 4000, 4000, 512, 2.75)).toBe("512");
+    // same face on a 3:2 image: crop = short edge = 2/3 of the long edge → 1024
+    expect(faceRendition({ x: 0.2, y: 0.1, w: 0.3, h: 0.8 }, 6000, 4000, 512, 2.75)).toBe("1024");
+    // small face: crop side = 600px of a 6000px edge → needs 512/0.1 = 5120 → capped at 2048
+    expect(faceRendition({ x: 0.45, y: 0.45, w: 0.05, h: 0.05 }, 6000, 4000, 512, 2)).toBe("2048");
+    // medium face: crop side = 2062px of 6000 → needs ~1490 → 2048
+    expect(faceRendition({ x: 0.4, y: 0.3, w: 0.125, h: 0.1 }, 6000, 4000, 512, 2.75)).toBe("2048");
+    // shallow-ish crop on a smaller image: side 1650 of 3000 → needs ~931 → 1024
+    expect(faceRendition({ x: 0.3, y: 0.3, w: 0.2, h: 0.2 }, 3000, 2000, 512, 2.75)).toBe("1024");
+  });
+  it("falls back to 512 without dimensions", () => {
+    expect(faceRendition({ x: 0.1, y: 0.1, w: 0.2, h: 0.2 }, 0, 0)).toBe("512");
   });
 });
 


### PR DESCRIPTION
- Deep face crops pixelated: the carousel always used the 512 rendition.
  faceRendition now picks 512/1024/2048 from the crop depth (scale-
  invariant, so probed rendition dimensions work too).
- Imported images (pre-dimension era, e.g. FSG25) have no stored
  width/height, so the merge review fell back to uncropped tiles without
  a bounding box. The carousel now probes naturalWidth/Height from the
  loaded thumbnail and crops with those.
- A transient network blip during the background candidate prefetch
  (e.g. a pod rolling mid-request) raised the unexpected-error modal.
  Response-less errors now self-heal: retry on a timer when the queue is
  empty, silently rely on the next user action otherwise.
