### PR TITLE
feat(images): upload-batch filter and ranked tag category rows

### DIFF
--- a/api/ent/imagetag.go
+++ b/api/ent/imagetag.go
@@ -33,6 +33,8 @@ type ImageTag struct {
 	Description string `json:"description"`
 	// IsAlbum holds the value of the "isAlbum" field.
 	IsAlbum bool `json:"isAlbum"`
+	// Order holds the value of the "order" field.
+	Order *int `json:"order,omitempty"`
 	// Type holds the value of the "type" field.
 	Type imagetag.Type `json:"type"`
 	// ProjectID holds the value of the "project_id" field.
@@ -94,6 +96,8 @@ func (*ImageTag) scanValues(columns []string) ([]any, error) {
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		case imagetag.FieldIsAlbum:
 			values[i] = new(sql.NullBool)
+		case imagetag.FieldOrder:
+			values[i] = new(sql.NullInt64)
 		case imagetag.FieldID, imagetag.FieldName, imagetag.FieldDescription, imagetag.FieldType, imagetag.FieldProjectID:
 			values[i] = new(sql.NullString)
 		case imagetag.FieldCreatedAt, imagetag.FieldUpdatedAt:
@@ -162,6 +166,13 @@ func (_m *ImageTag) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field isAlbum", values[i])
 			} else if value.Valid {
 				_m.IsAlbum = value.Bool
+			}
+		case imagetag.FieldOrder:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field order", values[i])
+			} else if value.Valid {
+				_m.Order = new(int)
+				*_m.Order = int(value.Int64)
 			}
 		case imagetag.FieldType:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -250,6 +261,11 @@ func (_m *ImageTag) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("isAlbum=")
 	builder.WriteString(fmt.Sprintf("%v", _m.IsAlbum))
+	builder.WriteString(", ")
+	if v := _m.Order; v != nil {
+		builder.WriteString("order=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
 	builder.WriteString(", ")
 	builder.WriteString("type=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Type))

--- a/api/ent/imagetag/imagetag.go
+++ b/api/ent/imagetag/imagetag.go
@@ -29,6 +29,8 @@ const (
 	FieldDescription = "description"
 	// FieldIsAlbum holds the string denoting the isalbum field in the database.
 	FieldIsAlbum = "is_album"
+	// FieldOrder holds the string denoting the order field in the database.
+	FieldOrder = "order"
 	// FieldType holds the string denoting the type field in the database.
 	FieldType = "type"
 	// FieldProjectID holds the string denoting the project_id field in the database.
@@ -72,6 +74,7 @@ var Columns = []string{
 	FieldName,
 	FieldDescription,
 	FieldIsAlbum,
+	FieldOrder,
 	FieldType,
 	FieldProjectID,
 }
@@ -105,6 +108,8 @@ var (
 	DescriptionValidator func(string) error
 	// DefaultIsAlbum holds the default value on creation for the "isAlbum" field.
 	DefaultIsAlbum bool
+	// OrderValidator is a validator for the "order" field. It is called by the builders before save.
+	OrderValidator func(int) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
@@ -177,6 +182,11 @@ func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 // ByIsAlbum orders the results by the isAlbum field.
 func ByIsAlbum(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIsAlbum, opts...).ToFunc()
+}
+
+// ByOrder orders the results by the order field.
+func ByOrder(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOrder, opts...).ToFunc()
 }
 
 // ByType orders the results by the type field.

--- a/api/ent/imagetag/where.go
+++ b/api/ent/imagetag/where.go
@@ -101,6 +101,11 @@ func IsAlbum(v bool) predicate.ImageTag {
 	return predicate.ImageTag(sql.FieldEQ(FieldIsAlbum, v))
 }
 
+// Order applies equality check predicate on the "order" field. It's identical to OrderEQ.
+func Order(v int) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldEQ(FieldOrder, v))
+}
+
 // ProjectID applies equality check predicate on the "project_id" field. It's identical to ProjectIDEQ.
 func ProjectID(v string) predicate.ImageTag {
 	return predicate.ImageTag(sql.FieldEQ(FieldProjectID, v))
@@ -424,6 +429,56 @@ func IsAlbumEQ(v bool) predicate.ImageTag {
 // IsAlbumNEQ applies the NEQ predicate on the "isAlbum" field.
 func IsAlbumNEQ(v bool) predicate.ImageTag {
 	return predicate.ImageTag(sql.FieldNEQ(FieldIsAlbum, v))
+}
+
+// OrderEQ applies the EQ predicate on the "order" field.
+func OrderEQ(v int) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldEQ(FieldOrder, v))
+}
+
+// OrderNEQ applies the NEQ predicate on the "order" field.
+func OrderNEQ(v int) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldNEQ(FieldOrder, v))
+}
+
+// OrderIn applies the In predicate on the "order" field.
+func OrderIn(vs ...int) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldIn(FieldOrder, vs...))
+}
+
+// OrderNotIn applies the NotIn predicate on the "order" field.
+func OrderNotIn(vs ...int) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldNotIn(FieldOrder, vs...))
+}
+
+// OrderGT applies the GT predicate on the "order" field.
+func OrderGT(v int) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldGT(FieldOrder, v))
+}
+
+// OrderGTE applies the GTE predicate on the "order" field.
+func OrderGTE(v int) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldGTE(FieldOrder, v))
+}
+
+// OrderLT applies the LT predicate on the "order" field.
+func OrderLT(v int) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldLT(FieldOrder, v))
+}
+
+// OrderLTE applies the LTE predicate on the "order" field.
+func OrderLTE(v int) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldLTE(FieldOrder, v))
+}
+
+// OrderIsNil applies the IsNil predicate on the "order" field.
+func OrderIsNil() predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldIsNull(FieldOrder))
+}
+
+// OrderNotNil applies the NotNil predicate on the "order" field.
+func OrderNotNil() predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldNotNull(FieldOrder))
 }
 
 // TypeEQ applies the EQ predicate on the "type" field.

--- a/api/ent/imagetag_create.go
+++ b/api/ent/imagetag_create.go
@@ -106,6 +106,20 @@ func (_c *ImageTagCreate) SetNillableIsAlbum(v *bool) *ImageTagCreate {
 	return _c
 }
 
+// SetOrder sets the "order" field.
+func (_c *ImageTagCreate) SetOrder(v int) *ImageTagCreate {
+	_c.mutation.SetOrder(v)
+	return _c
+}
+
+// SetNillableOrder sets the "order" field if the given value is not nil.
+func (_c *ImageTagCreate) SetNillableOrder(v *int) *ImageTagCreate {
+	if v != nil {
+		_c.SetOrder(*v)
+	}
+	return _c
+}
+
 // SetType sets the "type" field.
 func (_c *ImageTagCreate) SetType(v imagetag.Type) *ImageTagCreate {
 	_c.mutation.SetType(v)
@@ -247,6 +261,11 @@ func (_c *ImageTagCreate) check() error {
 	if _, ok := _c.mutation.IsAlbum(); !ok {
 		return &ValidationError{Name: "isAlbum", err: errors.New(`ent: missing required field "ImageTag.isAlbum"`)}
 	}
+	if v, ok := _c.mutation.Order(); ok {
+		if err := imagetag.OrderValidator(v); err != nil {
+			return &ValidationError{Name: "order", err: fmt.Errorf(`ent: validator failed for field "ImageTag.order": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.GetType(); !ok {
 		return &ValidationError{Name: "type", err: errors.New(`ent: missing required field "ImageTag.type"`)}
 	}
@@ -328,6 +347,10 @@ func (_c *ImageTagCreate) createSpec() (*ImageTag, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.IsAlbum(); ok {
 		_spec.SetField(imagetag.FieldIsAlbum, field.TypeBool, value)
 		_node.IsAlbum = value
+	}
+	if value, ok := _c.mutation.Order(); ok {
+		_spec.SetField(imagetag.FieldOrder, field.TypeInt, value)
+		_node.Order = &value
 	}
 	if value, ok := _c.mutation.GetType(); ok {
 		_spec.SetField(imagetag.FieldType, field.TypeEnum, value)

--- a/api/ent/imagetag_update.go
+++ b/api/ent/imagetag_update.go
@@ -100,6 +100,33 @@ func (_u *ImageTagUpdate) SetNillableIsAlbum(v *bool) *ImageTagUpdate {
 	return _u
 }
 
+// SetOrder sets the "order" field.
+func (_u *ImageTagUpdate) SetOrder(v int) *ImageTagUpdate {
+	_u.mutation.ResetOrder()
+	_u.mutation.SetOrder(v)
+	return _u
+}
+
+// SetNillableOrder sets the "order" field if the given value is not nil.
+func (_u *ImageTagUpdate) SetNillableOrder(v *int) *ImageTagUpdate {
+	if v != nil {
+		_u.SetOrder(*v)
+	}
+	return _u
+}
+
+// AddOrder adds value to the "order" field.
+func (_u *ImageTagUpdate) AddOrder(v int) *ImageTagUpdate {
+	_u.mutation.AddOrder(v)
+	return _u
+}
+
+// ClearOrder clears the value of the "order" field.
+func (_u *ImageTagUpdate) ClearOrder() *ImageTagUpdate {
+	_u.mutation.ClearOrder()
+	return _u
+}
+
 // SetType sets the "type" field.
 func (_u *ImageTagUpdate) SetType(v imagetag.Type) *ImageTagUpdate {
 	_u.mutation.SetType(v)
@@ -264,6 +291,11 @@ func (_u *ImageTagUpdate) check() error {
 			return &ValidationError{Name: "description", err: fmt.Errorf(`ent: validator failed for field "ImageTag.description": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.Order(); ok {
+		if err := imagetag.OrderValidator(v); err != nil {
+			return &ValidationError{Name: "order", err: fmt.Errorf(`ent: validator failed for field "ImageTag.order": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.GetType(); ok {
 		if err := imagetag.TypeValidator(v); err != nil {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`ent: validator failed for field "ImageTag.type": %w`, err)}
@@ -307,6 +339,15 @@ func (_u *ImageTagUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.IsAlbum(); ok {
 		_spec.SetField(imagetag.FieldIsAlbum, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.Order(); ok {
+		_spec.SetField(imagetag.FieldOrder, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedOrder(); ok {
+		_spec.AddField(imagetag.FieldOrder, field.TypeInt, value)
+	}
+	if _u.mutation.OrderCleared() {
+		_spec.ClearField(imagetag.FieldOrder, field.TypeInt)
 	}
 	if value, ok := _u.mutation.GetType(); ok {
 		_spec.SetField(imagetag.FieldType, field.TypeEnum, value)
@@ -518,6 +559,33 @@ func (_u *ImageTagUpdateOne) SetNillableIsAlbum(v *bool) *ImageTagUpdateOne {
 	return _u
 }
 
+// SetOrder sets the "order" field.
+func (_u *ImageTagUpdateOne) SetOrder(v int) *ImageTagUpdateOne {
+	_u.mutation.ResetOrder()
+	_u.mutation.SetOrder(v)
+	return _u
+}
+
+// SetNillableOrder sets the "order" field if the given value is not nil.
+func (_u *ImageTagUpdateOne) SetNillableOrder(v *int) *ImageTagUpdateOne {
+	if v != nil {
+		_u.SetOrder(*v)
+	}
+	return _u
+}
+
+// AddOrder adds value to the "order" field.
+func (_u *ImageTagUpdateOne) AddOrder(v int) *ImageTagUpdateOne {
+	_u.mutation.AddOrder(v)
+	return _u
+}
+
+// ClearOrder clears the value of the "order" field.
+func (_u *ImageTagUpdateOne) ClearOrder() *ImageTagUpdateOne {
+	_u.mutation.ClearOrder()
+	return _u
+}
+
 // SetType sets the "type" field.
 func (_u *ImageTagUpdateOne) SetType(v imagetag.Type) *ImageTagUpdateOne {
 	_u.mutation.SetType(v)
@@ -695,6 +763,11 @@ func (_u *ImageTagUpdateOne) check() error {
 			return &ValidationError{Name: "description", err: fmt.Errorf(`ent: validator failed for field "ImageTag.description": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.Order(); ok {
+		if err := imagetag.OrderValidator(v); err != nil {
+			return &ValidationError{Name: "order", err: fmt.Errorf(`ent: validator failed for field "ImageTag.order": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.GetType(); ok {
 		if err := imagetag.TypeValidator(v); err != nil {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`ent: validator failed for field "ImageTag.type": %w`, err)}
@@ -755,6 +828,15 @@ func (_u *ImageTagUpdateOne) sqlSave(ctx context.Context) (_node *ImageTag, err 
 	}
 	if value, ok := _u.mutation.IsAlbum(); ok {
 		_spec.SetField(imagetag.FieldIsAlbum, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.Order(); ok {
+		_spec.SetField(imagetag.FieldOrder, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedOrder(); ok {
+		_spec.AddField(imagetag.FieldOrder, field.TypeInt, value)
+	}
+	if _u.mutation.OrderCleared() {
+		_spec.ClearField(imagetag.FieldOrder, field.TypeInt)
 	}
 	if value, ok := _u.mutation.GetType(); ok {
 		_spec.SetField(imagetag.FieldType, field.TypeEnum, value)

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -283,6 +283,7 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString},
 		{Name: "is_album", Type: field.TypeBool, Default: false},
+		{Name: "order", Type: field.TypeInt, Nullable: true},
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"template", "default", "manual", "custom"}},
 		{Name: "project_id", Type: field.TypeString, Size: 15},
 	}
@@ -294,7 +295,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "image_tags_projects_imageTags",
-				Columns:    []*schema.Column{ImageTagsColumns[9]},
+				Columns:    []*schema.Column{ImageTagsColumns[10]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -303,12 +304,12 @@ var (
 			{
 				Name:    "imagetag_project_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImageTagsColumns[9]},
+				Columns: []*schema.Column{ImageTagsColumns[10]},
 			},
 			{
 				Name:    "imagetag_name_project_id",
 				Unique:  true,
-				Columns: []*schema.Column{ImageTagsColumns[5], ImageTagsColumns[9]},
+				Columns: []*schema.Column{ImageTagsColumns[5], ImageTagsColumns[10]},
 			},
 		},
 	}

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -6517,6 +6517,8 @@ type ImageTagMutation struct {
 	name                  *string
 	description           *string
 	isAlbum               *bool
+	_order                *int
+	add_order             *int
 	_type                 *imagetag.Type
 	clearedFields         map[string]struct{}
 	project               *string
@@ -6914,6 +6916,76 @@ func (m *ImageTagMutation) ResetIsAlbum() {
 	m.isAlbum = nil
 }
 
+// SetOrder sets the "order" field.
+func (m *ImageTagMutation) SetOrder(i int) {
+	m._order = &i
+	m.add_order = nil
+}
+
+// Order returns the value of the "order" field in the mutation.
+func (m *ImageTagMutation) Order() (r int, exists bool) {
+	v := m._order
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOrder returns the old "order" field's value of the ImageTag entity.
+// If the ImageTag object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ImageTagMutation) OldOrder(ctx context.Context) (v *int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOrder is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOrder requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOrder: %w", err)
+	}
+	return oldValue.Order, nil
+}
+
+// AddOrder adds i to the "order" field.
+func (m *ImageTagMutation) AddOrder(i int) {
+	if m.add_order != nil {
+		*m.add_order += i
+	} else {
+		m.add_order = &i
+	}
+}
+
+// AddedOrder returns the value that was added to the "order" field in this mutation.
+func (m *ImageTagMutation) AddedOrder() (r int, exists bool) {
+	v := m.add_order
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearOrder clears the value of the "order" field.
+func (m *ImageTagMutation) ClearOrder() {
+	m._order = nil
+	m.add_order = nil
+	m.clearedFields[imagetag.FieldOrder] = struct{}{}
+}
+
+// OrderCleared returns if the "order" field was cleared in this mutation.
+func (m *ImageTagMutation) OrderCleared() bool {
+	_, ok := m.clearedFields[imagetag.FieldOrder]
+	return ok
+}
+
+// ResetOrder resets all changes to the "order" field.
+func (m *ImageTagMutation) ResetOrder() {
+	m._order = nil
+	m.add_order = nil
+	delete(m.clearedFields, imagetag.FieldOrder)
+}
+
 // SetType sets the "type" field.
 func (m *ImageTagMutation) SetType(i imagetag.Type) {
 	m._type = &i
@@ -7155,7 +7227,7 @@ func (m *ImageTagMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ImageTagMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.createdAt != nil {
 		fields = append(fields, imagetag.FieldCreatedAt)
 	}
@@ -7176,6 +7248,9 @@ func (m *ImageTagMutation) Fields() []string {
 	}
 	if m.isAlbum != nil {
 		fields = append(fields, imagetag.FieldIsAlbum)
+	}
+	if m._order != nil {
+		fields = append(fields, imagetag.FieldOrder)
 	}
 	if m._type != nil {
 		fields = append(fields, imagetag.FieldType)
@@ -7205,6 +7280,8 @@ func (m *ImageTagMutation) Field(name string) (ent.Value, bool) {
 		return m.Description()
 	case imagetag.FieldIsAlbum:
 		return m.IsAlbum()
+	case imagetag.FieldOrder:
+		return m.Order()
 	case imagetag.FieldType:
 		return m.GetType()
 	case imagetag.FieldProjectID:
@@ -7232,6 +7309,8 @@ func (m *ImageTagMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldDescription(ctx)
 	case imagetag.FieldIsAlbum:
 		return m.OldIsAlbum(ctx)
+	case imagetag.FieldOrder:
+		return m.OldOrder(ctx)
 	case imagetag.FieldType:
 		return m.OldType(ctx)
 	case imagetag.FieldProjectID:
@@ -7294,6 +7373,13 @@ func (m *ImageTagMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetIsAlbum(v)
 		return nil
+	case imagetag.FieldOrder:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOrder(v)
+		return nil
 	case imagetag.FieldType:
 		v, ok := value.(imagetag.Type)
 		if !ok {
@@ -7315,13 +7401,21 @@ func (m *ImageTagMutation) SetField(name string, value ent.Value) error {
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *ImageTagMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.add_order != nil {
+		fields = append(fields, imagetag.FieldOrder)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *ImageTagMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case imagetag.FieldOrder:
+		return m.AddedOrder()
+	}
 	return nil, false
 }
 
@@ -7330,6 +7424,13 @@ func (m *ImageTagMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *ImageTagMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case imagetag.FieldOrder:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddOrder(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ImageTag numeric field %s", name)
 }
@@ -7343,6 +7444,9 @@ func (m *ImageTagMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(imagetag.FieldUpdatedBy) {
 		fields = append(fields, imagetag.FieldUpdatedBy)
+	}
+	if m.FieldCleared(imagetag.FieldOrder) {
+		fields = append(fields, imagetag.FieldOrder)
 	}
 	return fields
 }
@@ -7363,6 +7467,9 @@ func (m *ImageTagMutation) ClearField(name string) error {
 		return nil
 	case imagetag.FieldUpdatedBy:
 		m.ClearUpdatedBy()
+		return nil
+	case imagetag.FieldOrder:
+		m.ClearOrder()
 		return nil
 	}
 	return fmt.Errorf("unknown ImageTag nullable field %s", name)
@@ -7392,6 +7499,9 @@ func (m *ImageTagMutation) ResetField(name string) error {
 		return nil
 	case imagetag.FieldIsAlbum:
 		m.ResetIsAlbum()
+		return nil
+	case imagetag.FieldOrder:
+		m.ResetOrder()
 		return nil
 	case imagetag.FieldType:
 		m.ResetType()

--- a/api/ent/runtime.go
+++ b/api/ent/runtime.go
@@ -244,6 +244,10 @@ func init() {
 	imagetagDescIsAlbum := imagetagFields[2].Descriptor()
 	// imagetag.DefaultIsAlbum holds the default value on creation for the isAlbum field.
 	imagetag.DefaultIsAlbum = imagetagDescIsAlbum.Default.(bool)
+	// imagetagDescOrder is the schema descriptor for order field.
+	imagetagDescOrder := imagetagFields[3].Descriptor()
+	// imagetag.OrderValidator is a validator for the "order" field. It is called by the builders before save.
+	imagetag.OrderValidator = imagetagDescOrder.Validators[0].(func(int) error)
 	// imagetagDescID is the schema descriptor for id field.
 	imagetagDescID := imagetagMixinFields0[0].Descriptor()
 	// imagetag.DefaultID holds the default value on creation for the id field.

--- a/api/ent/schema/image_tag.go
+++ b/api/ent/schema/image_tag.go
@@ -18,6 +18,9 @@ func (ImageTag) Fields() []ent.Field {
 		field.String("name").NotEmpty().StructTag(`json:"name"`),
 		field.String("description").NotEmpty().StructTag(`json:"description"`),
 		field.Bool("isAlbum").Default(false).StructTag(`json:"isAlbum"`),
+		// Sort rank for tag application/display: lower first, ties and unset
+		// tags alphabetical, unset after all ranked tags.
+		field.Int("order").Optional().Nillable().Positive().StructTag(`json:"order,omitempty"`),
 		field.Enum("type").Values("template", "default", "manual", "custom").StructTag(`json:"type"`),
 		field.String("project_id").StructTag(`json:"-"`),
 	}

--- a/api/internal/exif/inject.go
+++ b/api/internal/exif/inject.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"sync"
 
 	"github.com/shutterbase/shutterbase/ent"
@@ -99,7 +101,7 @@ func buildMetadata(image *ent.Image) map[string]any {
 	}
 
 	// Keywords: only default/manual tags, never the internal management tag.
-	keywords := []string{}
+	tags := []*ent.ImageTag{}
 	for _, a := range image.Edges.ImageTagAssignments {
 		tag := a.Edges.ImageTag
 		if tag == nil {
@@ -112,6 +114,10 @@ func buildMetadata(image *ent.Image) map[string]any {
 		if tag.Name == "internal" {
 			continue
 		}
+		tags = append(tags, tag)
+	}
+	keywords := make([]string, 0, len(tags))
+	for _, tag := range sortTagsByOrder(tags) {
 		keywords = append(keywords, tag.Name)
 	}
 	m["EXIF:XPKeywords"] = keywords
@@ -139,4 +145,23 @@ func buildMetadata(image *ent.Image) map[string]any {
 
 	m["IPTC:OriginatingProgram"] = "Shutterbase by Max Partenfeder"
 	return m
+}
+
+// sortTagsByOrder ranks tags for keyword injection: lower order first, ties
+// alphabetical; tags without an order come after all ranked ones, alphabetical.
+func sortTagsByOrder(tags []*ent.ImageTag) []*ent.ImageTag {
+	rank := func(t *ent.ImageTag) int {
+		if t.Order == nil {
+			return math.MaxInt
+		}
+		return *t.Order
+	}
+	sort.SliceStable(tags, func(i, j int) bool {
+		ri, rj := rank(tags[i]), rank(tags[j])
+		if ri != rj {
+			return ri < rj
+		}
+		return tags[i].Name < tags[j].Name
+	})
+	return tags
 }

--- a/api/internal/exif/inject_test.go
+++ b/api/internal/exif/inject_test.go
@@ -1,0 +1,56 @@
+package exif
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/shutterbase/shutterbase/ent"
+	"github.com/shutterbase/shutterbase/ent/imagetag"
+)
+
+func tag(name string, tagType imagetag.Type, order *int) *ent.ImageTag {
+	return &ent.ImageTag{Name: name, Type: tagType, Order: order}
+}
+
+func intPtr(v int) *int { return &v }
+
+func TestSortTagsByOrder(t *testing.T) {
+	tags := []*ent.ImageTag{
+		tag("zebra", imagetag.TypeManual, nil),
+		tag("bravo", imagetag.TypeManual, intPtr(2)),
+		tag("delta", imagetag.TypeManual, intPtr(1)),
+		tag("alpha", imagetag.TypeManual, nil),
+		tag("charlie", imagetag.TypeManual, intPtr(2)),
+	}
+	got := []string{}
+	for _, tg := range sortTagsByOrder(tags) {
+		got = append(got, tg.Name)
+	}
+	// ranked ascending, order ties alphabetical, unset last alphabetical
+	want := []string{"delta", "bravo", "charlie", "alpha", "zebra"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildMetadataKeywordsRespectOrder(t *testing.T) {
+	image := &ent.Image{
+		Edges: ent.ImageEdges{
+			ImageTagAssignments: []*ent.ImageTagAssignment{
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("manual-late", imagetag.TypeManual, nil)}},
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("default-first", imagetag.TypeDefault, intPtr(1))}},
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("custom-hidden", imagetag.TypeCustom, intPtr(1))}},
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("internal", imagetag.TypeDefault, intPtr(1))}},
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("manual-second", imagetag.TypeManual, intPtr(5))}},
+			},
+		},
+	}
+	m := buildMetadata(image)
+	want := []string{"default-first", "manual-second", "manual-late"}
+	if !reflect.DeepEqual(m["EXIF:XPKeywords"], want) {
+		t.Fatalf("XPKeywords = %v, want %v", m["EXIF:XPKeywords"], want)
+	}
+	if !reflect.DeepEqual(m["IPTC:Keywords"], want) {
+		t.Fatalf("IPTC:Keywords = %v, want %v", m["IPTC:Keywords"], want)
+	}
+}

--- a/api/internal/repository/image_tag.go
+++ b/api/internal/repository/image_tag.go
@@ -85,6 +85,7 @@ type CreateImageTagParameters struct {
 	Name        string
 	Description string
 	IsAlbum     *bool
+	Order       *int
 	Type        imagetag.Type
 	ProjectID   string
 }
@@ -96,7 +97,8 @@ func (r *Repository) CreateImageTag(ctx context.Context, parameters *CreateImage
 		SetType(parameters.Type).
 		SetProjectID(parameters.ProjectID).
 		SetCreatedBy(util.GetActorID(ctx)).
-		SetUpdatedBy(util.GetActorID(ctx))
+		SetUpdatedBy(util.GetActorID(ctx)).
+		SetNillableOrder(parameters.Order)
 	if parameters.IsAlbum != nil {
 		create = create.SetIsAlbum(*parameters.IsAlbum)
 	}
@@ -118,7 +120,9 @@ type UpdateImageTagParameters struct {
 	Name        *string
 	Description *string
 	IsAlbum     *bool
-	Type        *imagetag.Type
+	// Order: nil = untouched; pointer to 0 = clear (0 is not a valid rank).
+	Order *int
+	Type  *imagetag.Type
 }
 
 func (r *Repository) UpdateImageTag(ctx context.Context, id string, parameters *UpdateImageTagParameters) (*ent.ImageTag, error) {
@@ -148,6 +152,20 @@ func (r *Repository) UpdateImageTag(ctx context.Context, id string, parameters *
 	if parameters.IsAlbum != nil && item.IsAlbum != *parameters.IsAlbum {
 		update.SetIsAlbum(*parameters.IsAlbum)
 		st.SetFieldChanged(imagetag.FieldIsAlbum, item.IsAlbum, *parameters.IsAlbum)
+	}
+	if parameters.Order != nil {
+		current := 0
+		if item.Order != nil {
+			current = *item.Order
+		}
+		if *parameters.Order != current {
+			if *parameters.Order == 0 {
+				update.ClearOrder()
+			} else {
+				update.SetOrder(*parameters.Order)
+			}
+			st.SetFieldChanged(imagetag.FieldOrder, current, *parameters.Order)
+		}
 	}
 	if parameters.Type != nil && item.Type != *parameters.Type {
 		update.SetType(*parameters.Type)

--- a/api/internal/server/image_response.go
+++ b/api/internal/server/image_response.go
@@ -60,6 +60,7 @@ type tagRef struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	IsAlbum     bool   `json:"isAlbum"`
+	Order       *int   `json:"order,omitempty"`
 	Type        string `json:"type"`
 }
 
@@ -171,7 +172,7 @@ func ToImageResponse(ctx context.Context, img *ent.Image, signer DownloadURLSign
 	for _, a := range img.Edges.ImageTagAssignments {
 		ref := assignmentRef{ID: a.ID, Type: a.Type.String()}
 		if t := a.Edges.ImageTag; t != nil {
-			ref.Tag = &tagRef{ID: t.ID, Name: t.Name, Description: t.Description, IsAlbum: t.IsAlbum, Type: t.Type.String()}
+			ref.Tag = &tagRef{ID: t.ID, Name: t.Name, Description: t.Description, IsAlbum: t.IsAlbum, Order: t.Order, Type: t.Type.String()}
 		}
 		resp.Tags = append(resp.Tags, ref)
 	}

--- a/api/internal/server/image_tag_assignments_controller.go
+++ b/api/internal/server/image_tag_assignments_controller.go
@@ -24,7 +24,7 @@ func (s *Server) imageTagAssignmentResponse(ctx context.Context, a *ent.ImageTag
 		"updatedAt": a.UpdatedAt,
 	}
 	if t, err := s.Repository.GetImageTag(ctx, a.ImageTagID); err == nil {
-		out["tag"] = gin.H{"id": t.ID, "name": t.Name, "type": t.Type, "isAlbum": t.IsAlbum}
+		out["tag"] = gin.H{"id": t.ID, "name": t.Name, "type": t.Type, "isAlbum": t.IsAlbum, "order": t.Order}
 	}
 	return out
 }

--- a/api/internal/server/image_tags_controller.go
+++ b/api/internal/server/image_tags_controller.go
@@ -20,6 +20,7 @@ func (s *Server) imageTagResponse(ctx context.Context, t *ent.ImageTag) gin.H {
 		"name":        t.Name,
 		"description": t.Description,
 		"isAlbum":     t.IsAlbum,
+		"order":       t.Order,
 		"type":        t.Type,
 		"project":     projectRefByID(ctx, s.Repository, t.ProjectID),
 		"createdAt":   t.CreatedAt,
@@ -102,8 +103,19 @@ type createImageTagPayload struct {
 	Name        string `json:"name" binding:"required"`
 	Description string `json:"description"`
 	IsAlbum     *bool  `json:"isAlbum"`
+	Order       *int   `json:"order"`
 	Type        string `json:"type" binding:"required"`
 	ProjectID   string `json:"projectId" binding:"required"`
+}
+
+// validTagOrder: the rank is a positive integer; 0 means "clear" on update and
+// is rejected on create (send no order instead).
+func validTagOrder(c *gin.Context, order *int, allowZero bool) bool {
+	if order == nil || *order > 0 || (allowZero && *order == 0) {
+		return true
+	}
+	apiError(c, http.StatusBadRequest, "invalid_order", "order must be a positive integer")
+	return false
 }
 
 func (s *Server) createImageTag(c *gin.Context) {
@@ -131,10 +143,14 @@ func (s *Server) createImageTag(c *gin.Context) {
 		!allow(c, authorization.CanDeleteImageTag(authUser(c), payload.ProjectID)) {
 		return
 	}
+	if !validTagOrder(c, payload.Order, false) {
+		return
+	}
 	item, err := s.Repository.CreateImageTag(c.Request.Context(), &repository.CreateImageTagParameters{
 		Name:        payload.Name,
 		Description: payload.Description,
 		IsAlbum:     payload.IsAlbum,
+		Order:       payload.Order,
 		Type:        t,
 		ProjectID:   payload.ProjectID,
 	})
@@ -154,17 +170,21 @@ func (s *Server) updateImageTag(c *gin.Context) {
 		Name        *string `json:"name"`
 		Description *string `json:"description"`
 		IsAlbum     *bool   `json:"isAlbum"`
+		Order       *int    `json:"order"`
 		Type        *string `json:"type"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		c.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
+	if !validTagOrder(c, payload.Order, true) {
+		return
+	}
 	existing, err := s.Repository.GetImageTag(c.Request.Context(), id)
 	if abortGetError(c, err) {
 		return
 	}
-	params := &repository.UpdateImageTagParameters{Name: payload.Name, Description: payload.Description, IsAlbum: payload.IsAlbum}
+	params := &repository.UpdateImageTagParameters{Name: payload.Name, Description: payload.Description, IsAlbum: payload.IsAlbum, Order: payload.Order}
 	resultingType := string(existing.Type)
 	if payload.Type != nil {
 		t := imagetag.Type(*payload.Type)

--- a/ui/src/api/imageTags.ts
+++ b/ui/src/api/imageTags.ts
@@ -15,6 +15,7 @@ export interface ImageTagCreate {
   name: string;
   description?: string;
   isAlbum?: boolean;
+  order?: number; // positive rank; omit for unranked
   type: string;
   projectId: string;
 }
@@ -23,6 +24,7 @@ export interface ImageTagUpdate {
   name?: string;
   description?: string;
   isAlbum?: boolean;
+  order?: number; // positive rank; 0 clears, omit leaves untouched
   type?: string;
 }
 

--- a/ui/src/components/image/ImagesHeader.vue
+++ b/ui/src/components/image/ImagesHeader.vue
@@ -145,6 +145,35 @@
         </transition>
       </Popover>
 
+      <!-- upload batch -->
+      <Listbox :model-value="uploadFilter" @update:model-value="onUploadSelect">
+        <div class="relative">
+          <ListboxButton :class="[triggerBase, uploadFilter ? triggerActive : triggerIdle]">
+            <ArrowUpTrayIcon class="h-[18px] w-[18px]" />
+            <span class="max-w-36 truncate">{{ currentUploadLabel }}</span>
+            <ChevronDownIcon class="h-4 w-4 opacity-60" />
+          </ListboxButton>
+          <transition leave-active-class="transition duration-100 ease-in" leave-from-class="opacity-100" leave-to-class="opacity-0">
+            <ListboxOptions
+              class="scrollbar-tool absolute right-0 z-30 mt-2 max-h-72 w-64 overflow-y-auto rounded-lg border border-primary-200 bg-surface p-1 shadow-xl focus:outline-none dark:border-primary-700 dark:bg-surface-dark"
+            >
+              <ListboxOption v-for="opt in uploadOptions" :key="opt.value ?? 'all'" :value="opt.value" v-slot="{ active, selected }">
+                <li
+                  :class="[
+                    'flex cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-sm',
+                    active ? 'bg-primary-100 dark:bg-primary-800' : '',
+                    selected ? 'text-accent-700 dark:text-accent-200' : 'text-primary-700 dark:text-primary-200',
+                  ]"
+                >
+                  <span class="flex-1 truncate">{{ opt.label }}</span>
+                  <CheckIcon v-if="selected" class="h-4 w-4 shrink-0" />
+                </li>
+              </ListboxOption>
+            </ListboxOptions>
+          </transition>
+        </div>
+      </Listbox>
+
       <!-- orientation -->
       <Listbox v-model="orientation">
         <div class="relative">
@@ -221,13 +250,15 @@ import {
   TableCellsIcon,
   RectangleStackIcon,
   SparklesIcon,
+  ArrowUpTrayIcon,
 } from "@heroicons/vue/24/outline";
 import { Popover, PopoverButton, PopoverPanel, Listbox, ListboxButton, ListboxOptions, ListboxOption } from "@headlessui/vue";
 import { storeToRefs } from "pinia";
 import { useUserStore } from "src/stores/user-store";
 import { emitter } from "src/boot/mitt";
 import { computed, h, ref, watch } from "vue";
-import { ImageTag } from "src/types/api";
+import { ImageTag, Upload } from "src/types/api";
+import { api } from "src/api";
 
 type Density = "gallery" | "comfortable" | "dense";
 
@@ -237,11 +268,14 @@ interface Props {
   density?: Density;
   // multi-selected image count — enables the "Rerun AI" toolbar action
   selectionCount?: number;
+  // active upload-batch filter — route-driven, Images.vue owns the query sync
+  uploadFilter?: string | null;
 }
 const props = withDefaults(defineProps<Props>(), {
   totalImageCount: 0,
   density: "comfortable",
   selectionCount: 0,
+  uploadFilter: null,
 });
 
 const emit = defineEmits<{
@@ -250,6 +284,7 @@ const emit = defineEmits<{
   aspectRatioFilter: [string];
   "update:density": [Density];
   rerunAi: [];
+  uploadFilter: [string | null];
 }>();
 
 const { activeProject, preferredImageSortOrder, projectTags } = storeToRefs(useUserStore());
@@ -310,6 +345,30 @@ function toggleTag(tag: ImageTag) {
 }
 function clearTags() {
   selectedTags.value = [];
+}
+
+// upload batch — the picker renders and emits; Images.vue maps the selection
+// onto the route query (?upload=), mirroring the person filter.
+// ponytail: one unpaginated fetch — revisit if a project ever exceeds 500 uploads
+const uploads = ref<Upload[]>([]);
+watch(
+  () => activeProject.value?.id,
+  async (projectId) => {
+    uploads.value = [];
+    if (!projectId) return;
+    try {
+      const items = (await api.uploads.list({ projectId, limit: 500 })).items;
+      uploads.value = items.sort((a, b) => new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime());
+    } catch {
+      // picker degrades to "All uploads"; deep links keep working without it
+    }
+  },
+  { immediate: true },
+);
+const uploadOptions = computed(() => [{ value: null as string | null, label: "All uploads" }, ...uploads.value.map((u) => ({ value: u.id, label: u.name }))]);
+const currentUploadLabel = computed(() => uploads.value.find((u) => u.id === props.uploadFilter)?.name ?? (props.uploadFilter ? "1 upload" : "Upload"));
+function onUploadSelect(id: string | null) {
+  emit("uploadFilter", id);
 }
 
 // kept for Images.vue: re-sync selected tags when toggling grid/detail

--- a/ui/src/components/image/Sidebar.vue
+++ b/ui/src/components/image/Sidebar.vue
@@ -60,8 +60,19 @@
           <LockClosedIcon class="mt-px h-4 w-4 shrink-0" />
           <span>This upload is submitted for review — official tags are frozen. Custom tags can still be changed.</span>
         </p>
-        <div class="flex flex-wrap gap-2">
-          <ImageTagBadge v-for="tagAssignment in tagAssignments" :key="tagAssignment.id" :tagAssignment="tagAssignment" :removable="removable(tagAssignment)" @remove="removeTag" />
+        <div class="space-y-3">
+          <div v-for="group in tagGroups" :key="group.category">
+            <p class="label-mono text-[0.6rem] text-primary-400 dark:text-primary-500">{{ group.category }}</p>
+            <div class="mt-1 flex flex-wrap gap-2">
+              <ImageTagBadge
+                v-for="tagAssignment in group.assignments"
+                :key="tagAssignment.id"
+                :tagAssignment="tagAssignment"
+                :removable="removable(tagAssignment)"
+                @remove="removeTag"
+              />
+            </div>
+          </div>
         </div>
         <p
           v-if="tagsCanBeAdded()"
@@ -199,6 +210,7 @@ import Clipboard from "src/components/Clipboard.vue";
 import { LockClosedIcon } from "@heroicons/vue/24/outline";
 import { ArrowPathIcon, ClockIcon, ExclamationTriangleIcon, SparklesIcon } from "@heroicons/vue/24/solid";
 import { canEditImageTag, officialTagsFrozen } from "src/pages/upload/uploadUtil";
+import { groupTagAssignments } from "src/util/tagOrder";
 import { aiPositions, aiQueueTotal } from "src/pages/image/imageQueryLogic";
 
 const userStore = useUserStore();
@@ -217,6 +229,10 @@ const props = withDefaults(defineProps<Props>(), {});
 const tagAssignments = computed(() => {
   return props.item?.tags || [];
 });
+
+// One row per tag category (template, manual, custom, ai), each row ordered by
+// the tags' rank — same ordering the EXIF export applies.
+const tagGroups = computed(() => groupTagAssignments(tagAssignments.value));
 
 const aiStatusText = computed(() => {
   const item = props.item;

--- a/ui/src/components/project/TagDialog.vue
+++ b/ui/src/components/project/TagDialog.vue
@@ -149,12 +149,14 @@ function saveTag() {
 const createTagFields: CreateField<ImageTagsResponse>[] = [
   { key: "name", label: "Name", type: CreateFieldType.TEXT },
   { key: "description", label: "Description", type: CreateFieldType.TEXT },
+  { key: "order", label: "Order (lower first, empty = last)", type: CreateFieldType.TEXT },
   { key: "type", label: "Type", type: CreateFieldType.SELECT, options: ["template", "default", "manual", "custom"], optionsDefault: "manual" },
 ];
 
 const editTagFields: EditField<ImageTagsResponse>[] = [
   { key: "name", label: "Name", type: EditFieldType.TEXT },
   { key: "description", label: "Description", type: EditFieldType.TEXT },
+  { key: "order", label: "Order (lower first, empty = last)", type: EditFieldType.TEXT },
   { key: "type", label: "Type", type: EditFieldType.SELECT, options: ["template", "default", "manual", "custom"] },
 ];
 </script>

--- a/ui/src/components/upload/UploadKanban.vue
+++ b/ui/src/components/upload/UploadKanban.vue
@@ -59,9 +59,22 @@
             dragged?.id === upload.id ? 'opacity-50' : '',
           ]"
         >
-          <a href="#" @click.prevent="emit('open', upload)" class="block truncate font-medium text-primary-900 hover:text-accent-600 dark:text-white dark:hover:text-accent-400">{{
-            upload.name
-          }}</a>
+          <div class="flex items-center justify-between gap-2">
+            <a
+              href="#"
+              @click.prevent="emit('open', upload)"
+              class="block truncate font-medium text-primary-900 hover:text-accent-600 dark:text-white dark:hover:text-accent-400"
+              >{{ upload.name }}</a
+            >
+            <router-link
+              :to="{ name: 'images', query: { upload: upload.id } }"
+              title="Show this upload's images"
+              class="shrink-0 text-primary-400 transition-colors hover:text-accent-600 dark:text-primary-500 dark:hover:text-accent-400"
+            >
+              <PhotoIcon class="h-4 w-4" />
+              <span class="sr-only">Show this upload's images</span>
+            </router-link>
+          </div>
           <p class="mt-0.5 truncate text-sm text-primary-500 dark:text-primary-400">{{ upload.user?.firstName }} {{ upload.user?.lastName }}</p>
 
           <dl class="mt-3 grid grid-cols-2 gap-x-3 gap-y-1.5">
@@ -91,7 +104,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { Upload, UploadState } from "src/types/api";
-import { PlusIcon } from "@heroicons/vue/24/outline";
+import { PhotoIcon, PlusIcon } from "@heroicons/vue/24/outline";
 import { UPLOAD_STATES, UPLOAD_STATE_LABEL, UPLOAD_STATE_HINT, TRANSITION_LABEL, allowedTransitions, formatDuration, formatTaggingRate } from "src/util/uploadReview";
 
 interface Props {

--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -7,10 +7,12 @@
         :total-image-count="totalImageCount"
         :show-filter="displayMode === DisplayMode.GRID"
         :selection-count="imageIndices.length"
+        :upload-filter="uploadFilter"
         @search="updateSearchText"
         @filter-tags="updateFilterTags"
         @aspect-ratio-filter="updateAspectRatioFilter"
         @rerun-ai="rerunSelection"
+        @upload-filter="setUploadFilter"
       />
       <div v-if="displayMode === DisplayMode.GRID">
         <div v-if="personFilter" class="mt-6 flex flex-wrap items-center gap-3">
@@ -137,6 +139,7 @@ import {
   filtered,
   personFilter,
   personCrossProject,
+  uploadFilter,
   snapshotGrid,
   restoreGridSnapshot,
   invalidateGridSnapshot,
@@ -177,6 +180,11 @@ const clearPersonFilter = () =>
     delete q.person;
     delete q.personScope;
   });
+const setUploadFilter = (id: string | null) =>
+  pushQuery((q) => {
+    if (id) q.upload = id;
+    else delete q.upload;
+  });
 const togglePersonScope = () =>
   pushQuery((q) => {
     if (q.personScope === "all") delete q.personScope;
@@ -187,14 +195,16 @@ async function applyRoute(initial = false) {
   if (route.name !== "images") return;
   const person = (route.query.person as string) || null;
   const crossProject = route.query.personScope === "all";
+  const uploadId = (route.query.upload as string) || null;
   const imageId = (route.query.image as string) || null;
 
-  if (initial || person !== personFilter.value || crossProject !== personCrossProject.value) {
-    if (person) {
-      // entering a person filter from the unfiltered grid: remember where we were
-      if (!initial && !personFilter.value) snapshotGrid();
+  if (initial || person !== personFilter.value || crossProject !== personCrossProject.value || uploadId !== uploadFilter.value) {
+    if (person || uploadId) {
+      // entering an implicit filter from the unfiltered grid: remember where we were
+      if (!initial && !personFilter.value && !uploadFilter.value) snapshotGrid();
       personFilter.value = person;
       personCrossProject.value = crossProject;
+      uploadFilter.value = uploadId;
       imageIndex.value = -1;
       imageIndices.value = [];
       multiselectStart.value = null;
@@ -203,6 +213,7 @@ async function applyRoute(initial = false) {
     } else {
       personFilter.value = null;
       personCrossProject.value = false;
+      uploadFilter.value = null;
       const scrollY = initial ? null : restoreGridSnapshot();
       if (scrollY === null) {
         await loadImages(true);

--- a/ui/src/pages/image/imageListParams.ts
+++ b/ui/src/pages/image/imageListParams.ts
@@ -9,6 +9,7 @@ export function buildImageListParams(input: {
   tags?: { id: string }[];
   personRef?: string;
   crossProject?: boolean;
+  uploadId?: string;
   orientation?: string;
   sortOrder?: SORT_ORDER;
   limit?: number;
@@ -28,6 +29,9 @@ export function buildImageListParams(input: {
     if (input.crossProject) {
       params.crossProject = "true";
     }
+  }
+  if (input.uploadId) {
+    params.uploadId = input.uploadId;
   }
   if (input.orientation && input.orientation !== "neutral") {
     params.orientation = input.orientation as "portrait" | "landscape";

--- a/ui/src/pages/image/imageQueryLogic.ts
+++ b/ui/src/pages/image/imageQueryLogic.ts
@@ -64,6 +64,11 @@ export const personFilter = ref<string | null>(null);
 // hard project filter. Route-driven like the filter itself (?personScope=all).
 export const personCrossProject = ref(false);
 
+// Implicit upload-batch filter: set by "view images" links on an upload or its
+// kanban card, cleared via the chip above the grid. Route-driven (?upload=)
+// like the person filter; Images.vue owns the sync.
+export const uploadFilter = ref<string | null>(null);
+
 // --- grid snapshot -----------------------------------------------------------
 // Applying the person filter replaces the loaded (possibly deeply scrolled)
 // grid. A snapshot of that state lets "clear filter" / browser-back land on
@@ -127,7 +132,7 @@ export async function loadImages(reload: boolean) {
   try {
     if (reload) page.value = 1;
 
-    filtered.value = !!searchText.value || filterTags.value.length > 0 || aspectRatioFilter.value !== "neutral" || !!personFilter.value;
+    filtered.value = !!searchText.value || filterTags.value.length > 0 || aspectRatioFilter.value !== "neutral" || !!personFilter.value || !!uploadFilter.value;
 
     const params = buildImageListParams({
       projectId: activeProject.value.id,
@@ -135,6 +140,7 @@ export async function loadImages(reload: boolean) {
       tags: filterTags.value,
       personRef: personFilter.value ?? undefined,
       crossProject: personCrossProject.value,
+      uploadId: uploadFilter.value ?? undefined,
       orientation: aspectRatioFilter.value,
       sortOrder: preferredImageSortOrder.value,
       limit: PAGE_SIZE,

--- a/ui/src/pages/project/ProjectTags.vue
+++ b/ui/src/pages/project/ProjectTags.vue
@@ -13,6 +13,7 @@ import { useRoute } from "vue-router";
 import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
 import Table, { TableColumn, TableRowActionType } from "src/components/Table.vue";
 import { ImageTagsResponse, ProjectsResponse } from "src/types/pocketbase";
+import { toTagOrder } from "src/util/tagOrder";
 import { api } from "src/api";
 import { showNotificationToast } from "src/boot/mitt";
 import { ProjectWithTagsType } from "src/types/custom";
@@ -75,6 +76,7 @@ async function addTag(input: ImageTagsResponse) {
       name: input.name,
       description: input.description,
       isAlbum: input.isAlbum,
+      order: toTagOrder(input.order) || undefined,
       type: input.type,
       projectId: item.value.id,
     });
@@ -151,6 +153,7 @@ async function editTag(input: ImageTagsResponse) {
       name: input.name,
       description: input.description,
       isAlbum: input.isAlbum,
+      order: toTagOrder(input.order),
       type: input.type,
     });
     showTagDialog.value = false;
@@ -197,6 +200,7 @@ function showTagEdit() {
 const imageTagColumns: TableColumn<ImageTagsResponse>[] = [
   { key: "name", label: "Name" },
   { key: "description", label: "Description" },
+  { key: "order", label: "Order" },
   { key: "type", label: "Type" },
   {
     key: "actions",

--- a/ui/src/pages/upload/UploadEdit.vue
+++ b/ui/src/pages/upload/UploadEdit.vue
@@ -2,9 +2,15 @@
   <div class="mx-auto max-w-7xl w-full lg:px-8">
     <main class="px-4 py-4 sm:px-6 lg:px-0">
       <div v-if="upload" class="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
-        <h2 class="display text-2xl text-primary-900 dark:text-white">
-          Upload <b class="font-semibold">{{ upload.name }}</b>
-        </h2>
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <h2 class="display text-2xl text-primary-900 dark:text-white">
+            Upload <b class="font-semibold">{{ upload.name }}</b>
+          </h2>
+          <router-link :to="{ name: 'images', query: { upload: upload.id } }" :class="[transitionBase, transitionQuiet]">
+            <PhotoIcon class="h-4 w-4" />
+            View in images
+          </router-link>
+        </div>
 
         <!-- Review state: the same flow the uploads kanban drives, on the page
              where the photographer actually works through the upload. -->
@@ -79,7 +85,7 @@ import * as dateTimeUtil from "src/util/dateTimeUtil";
 import { FileProcessor, Image, newImage, newImageFromBackendImage } from "src/util/fileProcessor";
 import { error } from "src/util/logger";
 import { showUploadEdit } from "./uploadUtil";
-import { CheckCircleIcon, ClockIcon, LockClosedIcon, PencilSquareIcon, SparklesIcon } from "@heroicons/vue/24/outline";
+import { CheckCircleIcon, ClockIcon, LockClosedIcon, PencilSquareIcon, PhotoIcon, SparklesIcon } from "@heroicons/vue/24/outline";
 import { UPLOAD_STATE_LABEL, UPLOAD_STATE_HINT, TRANSITION_LABEL, allowedTransitions, canAddImages } from "src/util/uploadReview";
 import { AiUploadStatus } from "src/api/ai";
 import { aiUploadSummary } from "src/util/aiDetection";

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -59,6 +59,7 @@ export interface EmbeddedTag {
   name: string;
   type: string;
   isAlbum?: boolean;
+  order?: number | null;
   description?: string;
 }
 
@@ -112,6 +113,7 @@ export interface ImageTag {
   name: string;
   description: string;
   isAlbum: boolean;
+  order?: number | null; // positive rank; lower = applied/shown first, unset = last
   type: string; // template | default | manual | custom
   project: EmbeddedProject;
   createdAt: string;

--- a/ui/src/util/tagOrder.ts
+++ b/ui/src/util/tagOrder.ts
@@ -1,0 +1,44 @@
+import { EmbeddedTag, ImageTagAssignment } from "src/types/api";
+
+// Tag category rows for the image detail sidebar. "template" covers the
+// official template-driven tags (tag type default/template), "ai" is any
+// inferred assignment regardless of the tag it points at.
+export type TagCategory = "template" | "manual" | "custom" | "ai";
+export const TAG_CATEGORIES: TagCategory[] = ["template", "manual", "custom", "ai"];
+
+export function tagCategory(assignment: ImageTagAssignment): TagCategory {
+  if (assignment.type === "inferred") return "ai";
+  switch (assignment.tag.type) {
+    case "custom":
+      return "custom";
+    case "manual":
+      return "manual";
+    default:
+      return "template";
+  }
+}
+
+// compareTagOrder ranks tags: lower order first, ties alphabetical; tags
+// without an order come after all ranked ones, alphabetical. Mirrors the
+// server-side EXIF keyword ordering (api/internal/exif/inject.go).
+export function compareTagOrder(a: EmbeddedTag, b: EmbeddedTag): number {
+  const ra = a.order ?? Number.POSITIVE_INFINITY;
+  const rb = b.order ?? Number.POSITIVE_INFINITY;
+  if (ra !== rb) return ra - rb;
+  return a.name.localeCompare(b.name);
+}
+
+// toTagOrder coerces a form value (free-text input) into an order rank: a
+// positive integer, or 0 for empty/invalid input (= "clear" on update, to be
+// dropped on create).
+export function toTagOrder(value: unknown): number {
+  const n = typeof value === "string" ? parseInt(value, 10) : typeof value === "number" ? value : NaN;
+  return Number.isInteger(n) && n > 0 ? n : 0;
+}
+
+export function groupTagAssignments(assignments: ImageTagAssignment[]): { category: TagCategory; assignments: ImageTagAssignment[] }[] {
+  return TAG_CATEGORIES.map((category) => ({
+    category,
+    assignments: assignments.filter((a) => tagCategory(a) === category).sort((a, b) => compareTagOrder(a.tag, b.tag)),
+  })).filter((group) => group.assignments.length > 0);
+}

--- a/ui/tests/e2e/gallery.spec.ts
+++ b/ui/tests/e2e/gallery.spec.ts
@@ -47,6 +47,15 @@ test.describe("gallery toolbar", () => {
     await expect(page.getByText(/Clear 1 selected/)).toBeVisible();
   });
 
+  test("image detail groups tags into category rows", async ({ page }) => {
+    await page.locator('[id^="grid-tile-"]').first().click();
+    await expect(page.getByText("Image Tags")).toBeVisible();
+    // seeded images carry the Default tag (type default) → it renders under the
+    // "template" category row with its caption
+    await expect(page.getByText("template", { exact: true })).toBeVisible();
+    await expect(page.getByText("Default", { exact: true })).toBeVisible();
+  });
+
   test("sort listbox opens with ordering options", async ({ page }) => {
     await page.getByRole("button", { name: /Latest first/ }).click();
     await expect(page.getByRole("option", { name: /Oldest first/ })).toBeVisible();

--- a/ui/tests/e2e/project-tags.spec.ts
+++ b/ui/tests/e2e/project-tags.spec.ts
@@ -23,6 +23,7 @@ test.describe.serial("project tags CRUD", () => {
     await expect(dialog.getByText("Add tag")).toBeVisible();
     await dialog.getByLabel("Name", { exact: true }).fill(TAG);
     await dialog.getByLabel("Description", { exact: true }).fill("created by e2e");
+    await dialog.getByLabel(/^Order/).fill("7");
     await dialog.getByRole("button", { name: "Save tag" }).click();
     await expect(dialog).toBeHidden();
 
@@ -32,6 +33,7 @@ test.describe.serial("project tags CRUD", () => {
     await page.reload();
     const row = page.getByRole("row").filter({ hasText: TAG });
     await expect(row, "created tag must persist after reload").toBeVisible();
+    await expect(row, "and keep its order rank").toContainText("7");
 
     // --- delete ---
     await row.getByRole("button", { name: "Delete" }).click();

--- a/ui/tests/e2e/upload-filter.spec.ts
+++ b/ui/tests/e2e/upload-filter.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, Page } from "@playwright/test";
+import { loginAs, collectJsErrors } from "./helpers";
+
+// The upload-batch filter on the gallery (?upload=) and its two entry points:
+// the "View in images" button on the upload edit page and the photo icon on a
+// kanban card. All three funnel into the same route query, which Images.vue
+// maps onto the images list request.
+
+async function seedUploadId(page: Page, projectId: string): Promise<string | null> {
+  return page.evaluate(async (pid) => {
+    const r = await fetch(`/api/v1/uploads?projectId=${pid}&limit=50`, { credentials: "include" });
+    const b = await r.json().catch(() => ({}));
+    return (b?.items || []).find((u: any) => u.name === "seed upload")?.id ?? null;
+  }, projectId);
+}
+
+test.describe("upload batch filter", () => {
+  let errors: string[];
+  test.beforeEach(async ({ page }) => {
+    errors = collectJsErrors(page);
+  });
+  test.afterEach(() => {
+    expect(errors, errors.join("\n")).toHaveLength(0);
+  });
+
+  test("gallery picker filters by upload and clears again", async ({ page }) => {
+    await loginAs(page, "admin");
+    await page.goto("/images");
+    await expect(page.getByPlaceholder("Search images")).toBeVisible();
+
+    await page.getByRole("button", { name: "Upload", exact: true }).click();
+    await expect(page.getByRole("option", { name: "All uploads" })).toBeVisible();
+    await page.getByRole("option", { name: "seed upload" }).click();
+
+    await expect(page).toHaveURL(/[?&]upload=/);
+    // button now carries the selected batch name and the filtered grid has rows
+    await expect(page.getByRole("button", { name: "seed upload" })).toBeVisible();
+    await expect(page.locator('[id^="grid-tile-"]').first()).toBeVisible();
+
+    await page.getByRole("button", { name: "seed upload" }).click();
+    await page.getByRole("option", { name: "All uploads" }).click();
+    await expect.poll(() => page.url()).not.toMatch(/[?&]upload=/);
+  });
+
+  test("upload edit page links into the filtered gallery", async ({ page }) => {
+    const project = await loginAs(page, "admin");
+    expect(project).not.toBeNull();
+    const uploadId = await seedUploadId(page, project!.id);
+    expect(uploadId, "seeded upload must exist").not.toBeNull();
+
+    await page.goto(`/uploads/${uploadId}/edit`);
+    await page.getByRole("link", { name: "View in images" }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/images\\?.*upload=${uploadId}`));
+    await expect(page.getByRole("button", { name: "seed upload" })).toBeVisible();
+    await expect(page.locator('[id^="grid-tile-"]').first()).toBeVisible();
+  });
+
+  test("kanban card links into the filtered gallery", async ({ page }) => {
+    const project = await loginAs(page, "admin");
+    expect(project).not.toBeNull();
+    const uploadId = await seedUploadId(page, project!.id);
+
+    const setReview = (enabled: boolean) =>
+      page.evaluate(
+        async ({ pid, enabled }) => {
+          const r = await fetch(`/api/v1/projects/${pid}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({ uploadReviewEnabled: enabled }),
+          });
+          if (!r.ok) throw new Error(`project update: ${r.status}`);
+          // the store reads uploadReviewEnabled off the persisted active project,
+          // so pin the fresh full object — {id,name} alone hides the kanban
+          localStorage.setItem("activeProject", JSON.stringify(await r.json()));
+        },
+        { pid: project!.id, enabled },
+      );
+
+    await setReview(true);
+    try {
+      await page.goto("/uploads");
+      const card = page.locator("article").filter({ hasText: "seed upload" }).first();
+      await expect(card).toBeVisible();
+      await card.getByRole("link", { name: "Show this upload's images" }).click();
+
+      await expect(page).toHaveURL(new RegExp(`/images\\?.*upload=${uploadId}`));
+      await expect(page.locator('[id^="grid-tile-"]').first()).toBeVisible();
+    } finally {
+      await setReview(false);
+    }
+  });
+});

--- a/ui/tests/imageListParams.spec.ts
+++ b/ui/tests/imageListParams.spec.ts
@@ -45,6 +45,11 @@ describe("buildImageListParams (UI state -> §4.3 list params)", () => {
     expect(buildImageListParams({ projectId: "p1" }).personRef).toBeUndefined();
   });
 
+  it("maps the implicit upload filter and drops it when unset", () => {
+    expect(buildImageListParams({ projectId: "p1", uploadId: "u-1" }).uploadId).toBe("u-1");
+    expect(buildImageListParams({ projectId: "p1" }).uploadId).toBeUndefined();
+  });
+
   it("sends crossProject only together with a person filter", () => {
     expect(buildImageListParams({ projectId: "p1", personRef: "person-7", crossProject: true }).crossProject).toBe("true");
     expect(buildImageListParams({ projectId: "p1", personRef: "person-7" }).crossProject).toBeUndefined();

--- a/ui/tests/tagOrder.spec.ts
+++ b/ui/tests/tagOrder.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { compareTagOrder, groupTagAssignments, tagCategory, toTagOrder } from "src/util/tagOrder";
+import { ImageTagAssignment } from "src/types/api";
+
+function assignment(id: string, assignmentType: string, tagType: string, name: string, order?: number | null): ImageTagAssignment {
+  return { id, type: assignmentType, tag: { id: `tag-${id}`, name, type: tagType, order } };
+}
+
+describe("tagCategory", () => {
+  it("maps inferred assignments to ai regardless of tag type", () => {
+    expect(tagCategory(assignment("1", "inferred", "manual", "podium"))).toBe("ai");
+  });
+  it("maps default/template tags to template, others by tag type", () => {
+    expect(tagCategory(assignment("1", "default", "default", "20240817"))).toBe("template");
+    expect(tagCategory(assignment("2", "scheduled", "default", "quali"))).toBe("template");
+    expect(tagCategory(assignment("3", "manual", "manual", "podium"))).toBe("manual");
+    expect(tagCategory(assignment("4", "manual", "custom", "review"))).toBe("custom");
+  });
+});
+
+describe("compareTagOrder", () => {
+  it("sorts by order asc, ties and unset alphabetical, unset last", () => {
+    const tags = [
+      { id: "a", name: "zebra", type: "manual" },
+      { id: "b", name: "bravo", type: "manual", order: 2 },
+      { id: "c", name: "delta", type: "manual", order: 1 },
+      { id: "d", name: "alpha", type: "manual" },
+      { id: "e", name: "charlie", type: "manual", order: 2 },
+    ];
+    expect([...tags].sort(compareTagOrder).map((t) => t.name)).toEqual(["delta", "bravo", "charlie", "alpha", "zebra"]);
+  });
+});
+
+describe("groupTagAssignments", () => {
+  it("emits rows in fixed category order, each sorted, empty rows dropped", () => {
+    const groups = groupTagAssignments([
+      assignment("1", "manual", "custom", "note"),
+      assignment("2", "inferred", "manual", "podium"),
+      assignment("3", "default", "default", "zulu", 2),
+      assignment("4", "default", "default", "alpha"),
+      assignment("5", "default", "default", "mike", 1),
+    ]);
+    expect(groups.map((g) => g.category)).toEqual(["template", "custom", "ai"]);
+    expect(groups[0].assignments.map((a) => a.tag.name)).toEqual(["mike", "zulu", "alpha"]);
+  });
+});
+
+describe("toTagOrder", () => {
+  it("parses positive integers and clamps everything else to 0", () => {
+    expect(toTagOrder("3")).toBe(3);
+    expect(toTagOrder(7)).toBe(7);
+    expect(toTagOrder("")).toBe(0);
+    expect(toTagOrder(undefined)).toBe(0);
+    expect(toTagOrder(null)).toBe(0);
+    expect(toTagOrder("-2")).toBe(0);
+    expect(toTagOrder("abc")).toBe(0);
+  });
+});


### PR DESCRIPTION
## What ships

**Upload-batch image filter**
- Gallery toolbar gains an "Upload" picker; the active filter is route-driven (`?upload=`), mirroring the person filter (deep links, browser-back, grid snapshot restore).
- Entry points: "View in images" on the upload edit page and a photo-icon link on every kanban review card.
- Server already supported `uploadId` on `/api/images` — no backend change needed for this part.

**Tag order**
- New optional positive-integer `order` on image tags (ent schema, auto-migrated; create/update API with `0`-clears semantics).
- EXIF keyword injection sorts on download: lower rank first, ties alphabetical, unranked tags after all ranked ones (alphabetical).
- Image detail sidebar renders one row per tag category (template / manual / custom / ai), each row sorted by the same rule; project tag dialog and table expose the field.

## Tests
- Go: `internal/exif` sort + metadata unit tests; full unit tier and testcontainers e2e green locally.
- UI: `tagOrder` + `imageListParams` vitest suites (175 tests green); Playwright specs extended (`upload-filter.spec.ts`, gallery detail rows, tag CRUD order round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRpXXpFkLcxL9cbnmiMdbe