### PR TITLE
feat(people): person-scoped merge review, people pagination, gallery filter reset

### DIFF
--- a/api/internal/server/ai_controller.go
+++ b/api/internal/server/ai_controller.go
@@ -528,7 +528,8 @@ func (s *Server) aiPersonImagesGlobal(c *gin.Context) {
 }
 
 // aiMergeNext proxies the next similar-person merge candidate within the
-// caller's administered projects.
+// caller's administered projects. ?person=<ref> narrows the queue to pairs
+// involving that person (the gallery's "similar faces" review).
 func (s *Server) aiMergeNext(c *gin.Context) {
 	remote, ok := s.remote(c)
 	if !ok {
@@ -542,7 +543,7 @@ func (s *Server) aiMergeNext(c *gin.Context) {
 	if skip < 0 {
 		skip = 0
 	}
-	resp, err := remote.MergeCandidates(c.Request.Context(), scope, skip)
+	resp, err := remote.MergeCandidates(c.Request.Context(), scope, skip, c.Query("person"))
 	if abortAIError(c, err) {
 		return
 	}

--- a/api/internal/server/ai_controller_test.go
+++ b/api/internal/server/ai_controller_test.go
@@ -298,6 +298,7 @@ type fakeRemote struct {
 	personsScope    []string
 	rankedSampleRef string
 	mergeScopeSeen  []string
+	mergePersonSeen string
 	// merges (optional) overrides the fixed p1-p2 merge list fixture.
 	merges []aiserver.Merge
 }
@@ -337,8 +338,9 @@ func (f *fakeRemote) PersonImages(_ context.Context, projectID string, _ string,
 func (f *fakeRemote) Similar(context.Context, string, string, int, int) (aiserver.SimilarResponse, error) {
 	return aiserver.SimilarResponse{}, nil
 }
-func (f *fakeRemote) MergeCandidates(_ context.Context, projects []string, skip int) (aiserver.MergeCandidatesResponse, error) {
+func (f *fakeRemote) MergeCandidates(_ context.Context, projects []string, skip int, personRef string) (aiserver.MergeCandidatesResponse, error) {
 	f.mergeScopeSeen = projects
+	f.mergePersonSeen = personRef
 	if skip > 0 {
 		return aiserver.MergeCandidatesResponse{Remaining: 1}, nil
 	}
@@ -493,6 +495,13 @@ func TestAIMergeEndpoints(t *testing.T) {
 	assert.Equal(t, "p2", next.Candidate.PersonB)
 	assert.Equal(t, 1, next.Remaining)
 	assert.Contains(t, remote.mergeScopeSeen, m.Project, "admin scope spans all projects")
+	assert.Empty(t, remote.mergePersonSeen)
+
+	// ?person narrows the queue to pairs involving that person
+	c, rec = aiCtx(t, adminUser(), http.MethodGet, "/api/v1/ai/merge/next?person=p7", "")
+	s.aiMergeNext(c)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "p7", remote.mergePersonSeen)
 
 	// a projectAdmin's scope is exactly their administered projects
 	ctx := context.Background()

--- a/pkg/aiserver/aiserver_test.go
+++ b/pkg/aiserver/aiserver_test.go
@@ -18,6 +18,7 @@ type fakeServer struct {
 	lastSkip      int
 	lastDecision  MergeDecision
 	lastRaw       bool
+	lastPerson    string
 	deletedMerges []string
 	reclustered   []string
 	lastProjects  []string
@@ -78,9 +79,10 @@ func (f *fakeServer) Persons(_ context.Context, projectIDs []string, page, pageS
 	}, nil
 }
 
-func (f *fakeServer) MergeCandidates(_ context.Context, projectIDs []string, skip int) (MergeCandidatesResponse, error) {
+func (f *fakeServer) MergeCandidates(_ context.Context, projectIDs []string, skip int, personRef string) (MergeCandidatesResponse, error) {
 	f.lastSkip = skip
 	f.lastProjects = projectIDs
+	f.lastPerson = personRef
 	if skip > 0 {
 		return MergeCandidatesResponse{Remaining: 0}, nil
 	}
@@ -167,15 +169,18 @@ func TestClientHandlerRoundtrip(t *testing.T) {
 		t.Fatalf("persons project scope mangled: %v", fake.lastProjects)
 	}
 
-	cands, err := client.MergeCandidates(ctx, scope, 0)
+	cands, err := client.MergeCandidates(ctx, scope, 0, "")
 	if err != nil || cands.Remaining != 3 || cands.Candidate == nil || cands.Candidate.PersonB != "p2" {
 		t.Fatalf("mergeCandidates: %v %+v", err, cands)
 	}
-	if len(fake.lastProjects) != 2 {
-		t.Fatalf("mergeCandidates project scope mangled: %v", fake.lastProjects)
+	if len(fake.lastProjects) != 2 || fake.lastPerson != "" {
+		t.Fatalf("mergeCandidates scope mangled: %v person=%q", fake.lastProjects, fake.lastPerson)
 	}
-	if cands, err = client.MergeCandidates(ctx, scope, 5); err != nil || cands.Candidate != nil || fake.lastSkip != 5 {
+	if cands, err = client.MergeCandidates(ctx, scope, 5, ""); err != nil || cands.Candidate != nil || fake.lastSkip != 5 {
 		t.Fatalf("mergeCandidates skip mangled: %v %+v skip=%d", err, cands, fake.lastSkip)
+	}
+	if _, err = client.MergeCandidates(ctx, scope, 0, "p9"); err != nil || fake.lastPerson != "p9" {
+		t.Fatalf("mergeCandidates person filter mangled: %v person=%q", err, fake.lastPerson)
 	}
 	if err := client.DecideMerge(ctx, MergeDecision{PersonA: "p1", PersonB: "p2", Verdict: "same"}); err != nil {
 		t.Fatalf("decideMerge: %v", err)

--- a/pkg/aiserver/client.go
+++ b/pkg/aiserver/client.go
@@ -95,10 +95,13 @@ func (c *Client) Persons(ctx context.Context, projectIDs []string, page, pageSiz
 	return resp, err
 }
 
-func (c *Client) MergeCandidates(ctx context.Context, projectIDs []string, skip int) (MergeCandidatesResponse, error) {
+func (c *Client) MergeCandidates(ctx context.Context, projectIDs []string, skip int, personRef string) (MergeCandidatesResponse, error) {
 	var resp MergeCandidatesResponse
-	err := c.do(ctx, http.MethodGet,
-		fmt.Sprintf("%s/merge-candidates?skip=%d&%s", basePath, skip, projectQuery(projectIDs)), nil, &resp)
+	path := fmt.Sprintf("%s/merge-candidates?skip=%d&%s", basePath, skip, projectQuery(projectIDs))
+	if personRef != "" {
+		path += "&person=" + url.QueryEscape(personRef)
+	}
+	err := c.do(ctx, http.MethodGet, path, nil, &resp)
 	return resp, err
 }
 

--- a/pkg/aiserver/server.go
+++ b/pkg/aiserver/server.go
@@ -34,8 +34,9 @@ type Server interface {
 	Persons(ctx context.Context, projectIDs []string, page, pageSize int) (PersonsResponse, error)
 	// MergeCandidates returns the next undecided similar-person pair whose
 	// persons both appear in any of the given projects, skipping the first
-	// skip pairs (the client's "skip" depth).
-	MergeCandidates(ctx context.Context, projectIDs []string, skip int) (MergeCandidatesResponse, error)
+	// skip pairs (the client's "skip" depth). A non-empty personRef narrows
+	// the queue to pairs involving that person (or its merge group).
+	MergeCandidates(ctx context.Context, projectIDs []string, skip int, personRef string) (MergeCandidatesResponse, error)
 	// DecideMerge records a verdict for a pair; "same" creates a reversible
 	// merge entry. Merges are global — persons span projects.
 	DecideMerge(ctx context.Context, d MergeDecision) error
@@ -130,7 +131,7 @@ func NewHandler(s Server, apiKey string) http.Handler {
 		if skip < 0 {
 			skip = 0
 		}
-		resp, err := s.MergeCandidates(r.Context(), r.URL.Query()["projectId"], skip)
+		resp, err := s.MergeCandidates(r.Context(), r.URL.Query()["projectId"], skip, r.URL.Query().Get("person"))
 		respond(w, resp, err)
 	})
 

--- a/ui/src/api/ai.ts
+++ b/ui/src/api/ai.ts
@@ -199,8 +199,9 @@ export interface AiMergeCandidates {
   remaining: number;
 }
 
-export async function mergeNext(skip = 0): Promise<AiMergeCandidates> {
-  const { data } = await http.get<AiMergeCandidates>(`/ai/merge/next`, { params: { skip } });
+// person (optional) narrows the queue to pairs involving that person.
+export async function mergeNext(skip = 0, person = ""): Promise<AiMergeCandidates> {
+  const { data } = await http.get<AiMergeCandidates>(`/ai/merge/next`, { params: { skip, ...(person ? { person } : {}) } });
   return data;
 }
 

--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -32,6 +32,14 @@
           >
             all my projects
           </button>
+          <button
+            v-if="isProjectAdminOrHigher"
+            class="label-mono-sm cursor-pointer rounded-full border border-primary-300 px-3 py-1 text-primary-500 transition-colors hover:border-primary-400 hover:text-primary-700 dark:border-primary-700 dark:text-primary-400 dark:hover:text-primary-200"
+            title="Review face clusters similar to this person and merge them"
+            @click="openSimilarFaces()"
+          >
+            similar faces
+          </button>
         </div>
         <div :class="['mt-8 select-none', gridClasses]">
           <ImageGridTile
@@ -125,6 +133,7 @@ import AiImageListDialog from "src/components/image/AiImageListDialog.vue";
 import { api } from "src/api";
 import { AiFace } from "src/api/ai";
 import { faceBoxStyle } from "src/util/aiDetection";
+import { useUserStore } from "src/stores/user-store";
 import * as websocket from "src/util/websocket";
 
 import { DisplayMode, loadImages, triggerInfiniteScroll } from "./imageQueryLogic";
@@ -143,6 +152,7 @@ import {
   snapshotGrid,
   restoreGridSnapshot,
   invalidateGridSnapshot,
+  resetTransientFilters,
 } from "./imageQueryLogic";
 import { totalImageCount, images, imageIndex, imageIndices, multiselectStart, multiselectEnd, loading, activeProject } from "./imageQueryLogic";
 import { taggingDialogVisible, addImageTag } from "./imageQueryLogic";
@@ -190,6 +200,11 @@ const togglePersonScope = () =>
     if (q.personScope === "all") delete q.personScope;
     else q.personScope = "all";
   });
+
+// "similar faces": person-scoped merge review on the People page; back
+// returns here and remounts the grid, so fresh merges show up immediately.
+const isProjectAdminOrHigher = useUserStore().isProjectAdminOrHigher();
+const openSimilarFaces = () => router.push({ name: "people", query: { person: personFilter.value } });
 
 async function applyRoute(initial = false) {
   if (route.name !== "images") return;
@@ -283,6 +298,9 @@ async function onScroll() {
 }
 window.addEventListener("scroll", onScroll);
 
+// before the watchers below exist, so the reset itself never queues a reload
+resetTransientFilters();
+
 onMounted(() => applyRoute(true));
 // any other filter/sort change makes the saved unfiltered-grid position stale
 const reloadDebounced = useDebounceFn(() => {
@@ -318,11 +336,6 @@ function toggleGridDetail() {
   } else {
     closeDetail();
   }
-}
-
-onMounted(clearFilterTags);
-function clearFilterTags() {
-  filterTags.value = []; // person filter comes from the route query instead
 }
 
 const taggingDialog = ref<InstanceType<typeof TaggingDialog> | null>(null);

--- a/ui/src/pages/image/imageQueryLogic.ts
+++ b/ui/src/pages/image/imageQueryLogic.ts
@@ -54,6 +54,17 @@ export function updateAspectRatioFilter(aspectRatioState: string) {
   aspectRatioFilter.value = aspectRatioState;
 }
 
+// The ImagesHeader owns these controls and remounts clean, so a fresh Images
+// mount must reset them too — a value surviving here filters the grid
+// invisibly (a sticky portrait filter once shrank a 38-photo person view to 5).
+export function resetTransientFilters() {
+  if (!searchText.value && filterTags.value.length === 0 && aspectRatioFilter.value === "neutral") return;
+  invalidateGridSnapshot(); // the snapshot was taken under the filters being cleared
+  searchText.value = "";
+  filterTags.value = [];
+  aspectRatioFilter.value = "neutral";
+}
+
 // Implicit person filter: set by clicking a face box in the detail view,
 // cleared via the chip above the grid. No picker UI — the face IS the picker.
 // The value is driven by the route query (?person=) so the browser history

--- a/ui/src/pages/people/People.vue
+++ b/ui/src/pages/people/People.vue
@@ -56,31 +56,42 @@
             </div>
           </div>
           <div class="mt-2 flex items-baseline justify-between">
-            <span class="label-mono-sm text-primary-500 dark:text-primary-400">#{{ i + 1 }}</span>
+            <span class="label-mono-sm text-primary-500 dark:text-primary-400">#{{ (personsPage - 1) * PERSONS_PAGE_SIZE + i + 1 }}</span>
             <span class="text-sm font-medium text-primary-900 dark:text-white">{{ person.count.toLocaleString() }} photo{{ person.count === 1 ? "" : "s" }}</span>
           </div>
         </div>
       </div>
-      <div v-if="personsLoading" class="mt-6 text-center text-sm text-primary-500 dark:text-primary-400">Loading…</div>
+      <div v-if="personsLoading && persons.length === 0" class="mt-6 text-center text-sm text-primary-500 dark:text-primary-400">Loading…</div>
       <div v-else-if="persons.length === 0" class="mt-10 text-center text-sm text-primary-500 dark:text-primary-400">No detected persons yet.</div>
-      <div v-else-if="persons.length < personsTotal" class="mt-6 text-center">
-        <button
-          @click="loadMorePersons"
-          class="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-primary-200 bg-surface px-3.5 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:text-white"
-        >
-          Load more
+      <nav v-if="personsPageCount > 1" class="mt-6 flex items-center justify-center gap-1.5" aria-label="People pages">
+        <button @click="goToPage(personsPage - 1)" :disabled="personsPage === 1" title="Previous page" :class="pagerIdle">
+          <ChevronLeftIcon class="h-4 w-4" />
         </button>
-      </div>
+        <template v-for="(item, idx) in pageItems" :key="idx">
+          <span v-if="item === '…'" class="px-1 text-sm text-primary-400 dark:text-primary-600">…</span>
+          <button v-else @click="goToPage(item)" :class="item === personsPage ? pagerCurrent : pagerIdle">{{ item }}</button>
+        </template>
+        <button @click="goToPage(personsPage + 1)" :disabled="personsPage === personsPageCount" title="Next page" :class="pagerIdle">
+          <ChevronRightIcon class="h-4 w-4" />
+        </button>
+      </nav>
     </template>
 
     <!-- merge review: server-gated (projectAdmin on ≥1 project); hidden on 403 -->
-    <div v-if="canReview && !noAiServer" class="mt-12 border-t border-primary-200 pt-8 dark:border-primary-800">
+    <div v-if="canReview && !noAiServer" ref="reviewSection" class="mt-12 border-t border-primary-200 pt-8 dark:border-primary-800">
       <div class="flex items-baseline justify-between">
         <div>
           <h2 class="text-base font-semibold text-primary-900 dark:text-white">Face cluster review</h2>
           <p class="mt-1 text-sm text-primary-500 dark:text-primary-400">
             The AI server suggests pairs of face clusters that might be the same person. Confirming a pair merges them into one — reversibly, see below.
           </p>
+          <span
+            v-if="reviewPersonRef"
+            class="label-mono-sm mt-2 inline-flex items-center gap-2 rounded-full border border-accent-400/60 px-3 py-1 text-accent-600 dark:text-accent-300"
+          >
+            similar to {{ reviewPersonName || reviewPersonRef }}
+            <button class="cursor-pointer font-bold hover:text-accent-400" title="Review all clusters again" @click="clearReviewPerson()">×</button>
+          </span>
         </div>
         <div class="flex shrink-0 items-baseline gap-3">
           <span v-if="remaining > 0" class="label-mono-sm text-primary-500 dark:text-primary-400">{{ remaining }} pair{{ remaining === 1 ? "" : "s" }} left</span>
@@ -270,22 +281,24 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
-import { useRouter } from "vue-router";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import { useStorage } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from "@headlessui/vue";
-import { PencilIcon } from "@heroicons/vue/24/solid";
+import { ChevronLeftIcon, ChevronRightIcon, PencilIcon } from "@heroicons/vue/24/solid";
 import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
 import FaceCarousel from "src/components/project/FaceCarousel.vue";
 import { api } from "src/api";
 import { AiMerge, AiMergeCandidate, AiPersonImage, AiPersonImagesPage, AiRankedPerson } from "src/api/ai";
 import { faceRendition } from "src/util/aiDetection";
+import { pageWindow } from "src/util/pagination";
 import * as dateTimeUtil from "src/util/dateTimeUtil";
 import { showNotificationToast } from "src/boot/mitt";
 import { useUserStore } from "src/stores/user-store";
 
 const router = useRouter();
+const route = useRoute();
 const { activeProjectId } = storeToRefs(useUserStore());
 
 const PERSONS_PAGE_SIZE = 24;
@@ -293,10 +306,19 @@ const PERSONS_PAGE_SIZE = 24;
 const noAiServer = ref(false);
 
 // --- ranked persons -----------------------------------------------------------
+// The page lives in the route query (?page=2, 1-based, absent = 1) so the
+// browser back button returns to the exact page a person was opened from.
 const persons = ref<AiRankedPerson[]>([]);
 const personsTotal = ref(0);
-const personsPage = ref(0);
+const personsPage = computed(() => Math.max(1, parseInt(route.query.page as string) || 1));
+const personsPageCount = computed(() => Math.max(1, Math.ceil(personsTotal.value / PERSONS_PAGE_SIZE)));
+const pageItems = computed(() => pageWindow(personsPage.value, personsPageCount.value));
 const personsLoading = ref(true);
+
+const pagerIdle =
+  "inline-flex h-8 min-w-8 cursor-pointer items-center justify-center rounded-md border border-primary-200 bg-surface px-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 disabled:cursor-default disabled:opacity-40 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:text-white";
+const pagerCurrent =
+  "inline-flex h-8 min-w-8 items-center justify-center rounded-md border border-accent-500 bg-accent-600/10 px-2 text-sm font-semibold text-accent-700 dark:text-accent-300";
 // the gallery person filter needs a project anchor; without an active project
 // the cards are plain tiles
 const canBrowse = computed(() => !!activeProjectId.value);
@@ -313,29 +335,42 @@ function fail(error: any) {
   }
 }
 
-async function loadPersons(reset = false) {
+// latest-wins guard: a stale response (fast page clicks) never lands
+let personsGen = 0;
+
+async function loadPersons() {
+  const gen = ++personsGen;
   personsLoading.value = true;
   try {
-    if (reset) personsPage.value = 0;
-    const page = await api.ai.rankedPersons(personsPage.value, PERSONS_PAGE_SIZE);
+    const page = await api.ai.rankedPersons(personsPage.value - 1, PERSONS_PAGE_SIZE);
+    if (gen !== personsGen) return;
     personsTotal.value = page.total;
-    // on reset, swap the list only once the data is here — no blank flash
-    if (reset) {
-      persons.value = page.items;
-    } else {
-      persons.value.push(...page.items);
+    // swap the list only once the data is here — no blank flash on page flips
+    persons.value = page.items;
+    // a stale deep link beyond the last page falls back to page 1
+    if (page.items.length === 0 && page.total > 0 && personsPage.value > 1) {
+      router.replace({ query: { ...route.query, page: undefined } });
     }
   } catch (error: any) {
+    if (gen !== personsGen) return;
     fail(error);
   } finally {
-    personsLoading.value = false;
+    if (gen === personsGen) personsLoading.value = false;
   }
 }
 
-async function loadMorePersons() {
-  personsPage.value++;
-  await loadPersons();
+function goToPage(page: number) {
+  if (page < 1 || page > personsPageCount.value || page === personsPage.value) return;
+  router.push({ query: { ...route.query, page: page === 1 ? undefined : String(page) } });
+  window.scrollTo({ top: 0, behavior: "smooth" });
 }
+
+watch(
+  () => route.query.page,
+  () => {
+    if (route.name === "people") loadPersons();
+  },
+);
 
 function showInGallery(person: AiRankedPerson) {
   router.push({ name: "images", query: { person: person.personRef, personScope: "all" } });
@@ -416,6 +451,33 @@ const sides = computed(() => {
 const merges = ref<AiMerge[]>([]);
 const expanded = ref<{ key: string; side: "A" | "B"; personRef: string } | null>(null);
 
+// --- person-scoped review (?person=<ref>) ------------------------------------
+// The gallery's "similar faces" button lands here: the queue narrows to pairs
+// involving this person. Route-driven so the scope survives back/forward.
+const reviewSection = ref<HTMLElement | null>(null);
+const reviewPersonRef = computed(() => (route.query.person as string) || "");
+const reviewPersonName = ref("");
+
+async function loadReviewPersonName() {
+  reviewPersonName.value = "";
+  if (!reviewPersonRef.value) return;
+  try {
+    const names = await api.ai.personNames([reviewPersonRef.value]);
+    reviewPersonName.value = names[reviewPersonRef.value] ?? "";
+  } catch {
+    // the scope chip falls back to the raw ref
+  }
+}
+
+const clearReviewPerson = () => router.push({ query: { ...route.query, person: undefined } });
+
+watch(reviewPersonRef, () => {
+  if (route.name !== "people") return;
+  flushQueue();
+  refill();
+  loadReviewPersonName();
+});
+
 function pairKey(c: AiMergeCandidate) {
   return `${c.personA}/${c.personB}`;
 }
@@ -460,7 +522,7 @@ async function refill() {
     // ponytail: cursor capped at 500 — with that many locally skipped pairs in
     // one generation the server needs a skip-aware endpoint anyway.
     while (queue.value.length < PREFETCH && cursor < 500) {
-      const next = await api.ai.mergeNext(cursor);
+      const next = await api.ai.mergeNext(cursor, reviewPersonRef.value);
       if (gen !== refillGen) return;
       if (!next.candidate) {
         exhausted.value = true;
@@ -540,7 +602,7 @@ async function decide(verdict: "same" | "different") {
       if (nameA && nameB && nameA !== nameB) {
         nameConflict.value = { personRef: entry.candidate.personA, options: [nameA, nameB], chosen: nameA };
       }
-      await Promise.all([loadMerges(), loadPersons(true)]);
+      await Promise.all([loadMerges(), loadPersons()]);
     }
   } catch (error: any) {
     fail(error);
@@ -557,7 +619,7 @@ async function unmerge(m: AiMerge) {
     expanded.value = null;
     flushQueue();
     refill();
-    await Promise.all([loadMerges(), loadPersons(true)]);
+    await Promise.all([loadMerges(), loadPersons()]);
   } catch (error: any) {
     fail(error);
   } finally {
@@ -592,15 +654,18 @@ async function resolveNameConflict() {
   try {
     await api.ai.setPersonName(personRef, name);
     showNotificationToast({ headline: `Merged person named “${name}”`, type: "success" });
-    await Promise.all([loadMerges(), loadPersons(true)]);
+    await Promise.all([loadMerges(), loadPersons()]);
   } catch (error: any) {
     fail(error);
   }
 }
 
 onMounted(() => {
-  loadPersons(true);
+  loadPersons();
   refill();
   loadMerges();
+  loadReviewPersonName();
+  // arriving via "similar faces": the review section is the destination
+  if (reviewPersonRef.value) nextTick(() => reviewSection.value?.scrollIntoView({ behavior: "smooth", block: "start" }));
 });
 </script>

--- a/ui/src/util/pagination.ts
+++ b/ui/src/util/pagination.ts
@@ -1,0 +1,12 @@
+// pageWindow returns the 1-based page buttons a pager should render: every
+// page when they all fit, otherwise first/last plus a current±1 window with
+// "…" marking the gaps.
+export function pageWindow(current: number, count: number): (number | "…")[] {
+  if (count <= 7) return Array.from({ length: count }, (_, i) => i + 1);
+  const out: (number | "…")[] = [1];
+  if (current > 3) out.push("…");
+  for (let p = Math.max(2, current - 1); p <= Math.min(count - 1, current + 1); p++) out.push(p);
+  if (current < count - 2) out.push("…");
+  out.push(count);
+  return out;
+}

--- a/ui/tests/pagination.spec.ts
+++ b/ui/tests/pagination.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { pageWindow } from "src/util/pagination";
+
+describe("pageWindow (pager buttons with ellipsis gaps)", () => {
+  it("lists every page while they fit", () => {
+    expect(pageWindow(1, 1)).toEqual([1]);
+    expect(pageWindow(3, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("collapses the tail when current is near the start", () => {
+    expect(pageWindow(1, 10)).toEqual([1, 2, "…", 10]);
+    expect(pageWindow(3, 10)).toEqual([1, 2, 3, 4, "…", 10]);
+  });
+
+  it("collapses the head when current is near the end", () => {
+    expect(pageWindow(10, 10)).toEqual([1, "…", 9, 10]);
+    expect(pageWindow(8, 10)).toEqual([1, "…", 7, 8, 9, 10]);
+  });
+
+  it("collapses both sides around a middle page", () => {
+    expect(pageWindow(5, 10)).toEqual([1, "…", 4, 5, 6, "…", 10]);
+  });
+
+  it("renders no buttons for zero pages", () => {
+    expect(pageWindow(1, 0)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What ships

- **Similar faces** button on the gallery's person view (projectAdmin+): opens the People page's face-cluster review scoped to that person via a new optional `personRef` on the `MergeCandidates` aiserver contract (resolved to the person's merge group server-side). Scope chip with clear, scroll-to-review on arrival, route-driven so back lands on the refreshed person grid.
- **People page pagination**: route-driven `?page=` (numbered pager with ellipsis) replaces 'load more'; browser history restores the exact page.
- **Fix**: person grid showed 5 of 38 photos — transient gallery filters (`searchText`/`aspectRatioFilter`) survived remounts in module scope while the header remounted clean; a sticky portrait filter silently ANDed into the person query. All transient filters now reset on mount.

## Deploy note

The `person` param needs the fsai counterpart (committed in fsai, deployed separately) — an old fsai ignores it and the scoped review falls back to the global queue.

## Tests

- `pkg/aiserver` roundtrip + api controller person-passthrough assertions
- fsai e2e: scoped queue by either pair side / stranger / garbage ref
- `pageWindow` vitest suite; api unit + e2e and ui suites green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRpXXpFkLcxL9cbnmiMdbe