### PR TITLE
fix(images): prefetch past navigation threshold and show all tags in zen

### DIFF
--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -124,7 +124,7 @@
     <div class="absolute inset-x-0 top-0 flex justify-center bg-black/70 py-1">
       <img class="h-5" src="~assets/img/shutterbase-header-logo-dark.png" alt="shutterbase" />
     </div>
-    <!-- thin footer: name | applied tags (EXIF export order; click removes) | position -->
+    <!-- thin footer: name | all applied tags (sidebar category order; click removes) | position -->
     <div class="absolute inset-x-0 bottom-0 flex items-center gap-4 bg-black/70 px-3 py-1">
       <span class="min-w-0 shrink truncate font-data text-sm text-primary-200">{{ images[imageIndex].computedFileName }}</span>
       <div class="flex flex-1 flex-wrap items-center justify-center gap-2">
@@ -163,7 +163,7 @@ import FilmStrip from "src/components/image/FilmStrip.vue";
 import ZoomableImage from "src/components/image/ZoomableImage.vue";
 import ImageTagBadge from "src/components/image/ImageTagBadge.vue";
 import { canRemoveTagAssignment, removeTagAssignment } from "src/util/imageTags";
-import { exifKeywordAssignments } from "src/util/tagOrder";
+import { groupTagAssignments } from "src/util/tagOrder";
 import { devPlaceholder } from "src/util/devPlaceholder";
 import { ImageWithTagsType } from "src/types/custom";
 import { onMounted, onUnmounted, reactive, ref, computed, watch, nextTick } from "vue";
@@ -392,7 +392,9 @@ function toggleZen() {
   if (imageIndex.value === -1 && images.value.length > 0) imageIndex.value = 0;
   if (images.value[imageIndex.value]) zenMode.value = true;
 }
-const zenTags = computed(() => exifKeywordAssignments(images.value[imageIndex.value]?.tags ?? []));
+// All tags, not just the EXIF-exported subset — zen is primarily a tagging
+// view, so custom/AI tags must be visible too. Sidebar category order.
+const zenTags = computed(() => groupTagAssignments(images.value[imageIndex.value]?.tags ?? []).flatMap((g) => g.assignments));
 
 const taggingDialog = ref<InstanceType<typeof TaggingDialog> | null>(null);
 

--- a/ui/src/pages/image/imageQueryLogic.ts
+++ b/ui/src/pages/image/imageQueryLogic.ts
@@ -288,7 +288,7 @@ export function nextImage() {
   if (imageIndex.value < images.value.length - 1) {
     imageIndex.value++;
   }
-  if (imageIndex.value === images.value.length - 4) {
+  if (imageIndex.value >= images.value.length - 4) {
     triggerInfiniteScroll();
   }
   emitter.emit("update-image-grid-scroll-position");

--- a/ui/tests/e2e/zen-tagging.spec.ts
+++ b/ui/tests/e2e/zen-tagging.spec.ts
@@ -60,11 +60,22 @@ test.describe("detail view keyboard flow", () => {
     const zen = page.getByTestId("zen-overlay");
     const first = imageParam(page);
 
+    // apply a custom tag first — zen must list it too (all tags, not just the EXIF subset)
+    const uniq = `e2e-zenall-${Date.now()}`;
+    await page.keyboard.press("t");
+    const search = page.getByPlaceholder("Search tag...");
+    await expect(search).toBeVisible();
+    await search.fill(uniq);
+    await page.getByRole("button", { name: /Create custom tag/ }).click();
+    await expect(visibleBadge(page, uniq)).toHaveCount(1);
+    await page.keyboard.press("Escape");
+
     await page.keyboard.press("z"); // detail → zen
     await expect(zen).toBeVisible();
     // header: centered logo; footer: file name left, tags middle, position right
     await expect(zen.locator('img[alt="shutterbase"]')).toBeVisible();
     await expect(zen.locator('span:text-is("Default")')).toBeVisible(); // seeded EXIF tag
+    await expect(zen.locator(`span:text-is("${uniq}")`)).toBeVisible(); // custom tag, not EXIF-exported
     await expect(zen.locator("span").filter({ hasText: /\.jpg$/i }).first()).toBeVisible();
     await expect(zen.locator("span").filter({ hasText: /^\d+ \/ \d+$/ })).toBeVisible();
 

--- a/ui/tests/imageNavigationPrefetch.spec.ts
+++ b/ui/tests/imageNavigationPrefetch.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { ImageWithTagsType } from "src/types/custom";
+
+const { imagesApi } = vi.hoisted(() => ({
+  imagesApi: { list: vi.fn(), get: vi.fn() },
+}));
+
+vi.mock("src/api", () => ({
+  api: { images: imagesApi },
+}));
+
+// imageQueryLogic touches the user store at import time, so pinia must be live first
+setActivePinia(createPinia());
+const { images, imageIndex, totalImageCount, nextImage, nextRow } = await import("src/pages/image/imageQueryLogic");
+
+function fakeImages(count: number, offset = 0): ImageWithTagsType[] {
+  return Array.from({ length: count }, (_, i) => ({ id: `img-${offset + i}`, tags: [] }) as unknown as ImageWithTagsType);
+}
+
+describe("detail/zen navigation prefetch", () => {
+  beforeEach(() => {
+    imagesApi.list.mockReset();
+    imagesApi.list.mockResolvedValue({ items: fakeImages(20, 20), total: 40 });
+    images.value = fakeImages(20);
+    totalImageCount.value = 40;
+  });
+
+  it("prefetches the next page when stepping onto the length-4 threshold", () => {
+    imageIndex.value = 15;
+    nextImage(); // -> 16 === 20 - 4
+    expect(imagesApi.list).toHaveBeenCalled();
+  });
+
+  it("prefetches when entering past the threshold (regression: strict equality missed the one-shot moment)", () => {
+    imageIndex.value = 18; // entered detail/zen on a late image
+    nextImage(); // -> 19, already past length - 4
+    expect(imagesApi.list).toHaveBeenCalled();
+  });
+
+  it("retries the load when stuck on the last loaded image", () => {
+    imageIndex.value = 19;
+    nextImage(); // cannot advance, but must still trigger the fetch
+    expect(imageIndex.value).toBe(19);
+    expect(imagesApi.list).toHaveBeenCalled();
+  });
+
+  it("does not fetch once everything is loaded", () => {
+    totalImageCount.value = 20;
+    imageIndex.value = 19;
+    nextImage();
+    nextRow();
+    expect(imagesApi.list).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The detail/zen next-image prefetch fired only on imageIndex === length-4,
a one-shot moment missed when entering on a late image or when a load was
already in flight — leaving the user stuck on the last loaded image as if
the gallery ended. Trigger on >= instead (matching nextRow), which also
retries a failed load on the next keypress.

Zen mode now lists every applied tag in sidebar category order instead of
only the EXIF-exported subset — zen is primarily a tagging view, so custom
and AI tags must be visible too.
