### PR TITLE
feat(download): add sync reconciliation and download structure

### DIFF
--- a/api/ent/downloadconfig.go
+++ b/api/ent/downloadconfig.go
@@ -41,6 +41,8 @@ type DownloadConfig struct {
 	DeltaSubfolder bool `json:"deltaSubfolder"`
 	// GroupByDate holds the value of the "groupByDate" field.
 	GroupByDate bool `json:"groupByDate"`
+	// FolderStructure holds the value of the "folder_structure" field.
+	FolderStructure string `json:"folderStructure"`
 	// LastDownloadAt holds the value of the "lastDownloadAt" field.
 	LastDownloadAt *time.Time `json:"lastDownloadAt"`
 	// ProjectID holds the value of the "project_id" field.
@@ -97,7 +99,7 @@ func (*DownloadConfig) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case downloadconfig.FieldDeltaSubfolder, downloadconfig.FieldGroupByDate:
 			values[i] = new(sql.NullBool)
-		case downloadconfig.FieldID, downloadconfig.FieldName, downloadconfig.FieldProjectID:
+		case downloadconfig.FieldID, downloadconfig.FieldName, downloadconfig.FieldFolderStructure, downloadconfig.FieldProjectID:
 			values[i] = new(sql.NullString)
 		case downloadconfig.FieldCreatedAt, downloadconfig.FieldUpdatedAt, downloadconfig.FieldLastDownloadAt:
 			values[i] = new(sql.NullTime)
@@ -191,6 +193,12 @@ func (_m *DownloadConfig) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field groupByDate", values[i])
 			} else if value.Valid {
 				_m.GroupByDate = value.Bool
+			}
+		case downloadconfig.FieldFolderStructure:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field folder_structure", values[i])
+			} else if value.Valid {
+				_m.FolderStructure = value.String
 			}
 		case downloadconfig.FieldLastDownloadAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -290,6 +298,9 @@ func (_m *DownloadConfig) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("groupByDate=")
 	builder.WriteString(fmt.Sprintf("%v", _m.GroupByDate))
+	builder.WriteString(", ")
+	builder.WriteString("folder_structure=")
+	builder.WriteString(_m.FolderStructure)
 	builder.WriteString(", ")
 	if v := _m.LastDownloadAt; v != nil {
 		builder.WriteString("lastDownloadAt=")

--- a/api/ent/downloadconfig.go
+++ b/api/ent/downloadconfig.go
@@ -41,7 +41,7 @@ type DownloadConfig struct {
 	DeltaSubfolder bool `json:"deltaSubfolder"`
 	// GroupByDate holds the value of the "groupByDate" field.
 	GroupByDate bool `json:"groupByDate"`
-	// FolderStructure holds the value of the "folder_structure" field.
+	// FolderStructure holds the value of the "folderStructure" field.
 	FolderStructure string `json:"folderStructure"`
 	// LastDownloadAt holds the value of the "lastDownloadAt" field.
 	LastDownloadAt *time.Time `json:"lastDownloadAt"`
@@ -196,7 +196,7 @@ func (_m *DownloadConfig) assignValues(columns []string, values []any) error {
 			}
 		case downloadconfig.FieldFolderStructure:
 			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field folder_structure", values[i])
+				return fmt.Errorf("unexpected type %T for field folderStructure", values[i])
 			} else if value.Valid {
 				_m.FolderStructure = value.String
 			}
@@ -299,7 +299,7 @@ func (_m *DownloadConfig) String() string {
 	builder.WriteString("groupByDate=")
 	builder.WriteString(fmt.Sprintf("%v", _m.GroupByDate))
 	builder.WriteString(", ")
-	builder.WriteString("folder_structure=")
+	builder.WriteString("folderStructure=")
 	builder.WriteString(_m.FolderStructure)
 	builder.WriteString(", ")
 	if v := _m.LastDownloadAt; v != nil {

--- a/api/ent/downloadconfig/downloadconfig.go
+++ b/api/ent/downloadconfig/downloadconfig.go
@@ -34,6 +34,8 @@ const (
 	FieldDeltaSubfolder = "delta_subfolder"
 	// FieldGroupByDate holds the string denoting the groupbydate field in the database.
 	FieldGroupByDate = "group_by_date"
+	// FieldFolderStructure holds the string denoting the folder_structure field in the database.
+	FieldFolderStructure = "folder_structure"
 	// FieldLastDownloadAt holds the string denoting the lastdownloadat field in the database.
 	FieldLastDownloadAt = "last_download_at"
 	// FieldProjectID holds the string denoting the project_id field in the database.
@@ -75,6 +77,7 @@ var Columns = []string{
 	FieldBlockedImageIds,
 	FieldDeltaSubfolder,
 	FieldGroupByDate,
+	FieldFolderStructure,
 	FieldLastDownloadAt,
 	FieldProjectID,
 	FieldUserID,
@@ -109,6 +112,8 @@ var (
 	DefaultDeltaSubfolder bool
 	// DefaultGroupByDate holds the default value on creation for the "groupByDate" field.
 	DefaultGroupByDate bool
+	// DefaultFolderStructure holds the default value on creation for the "folder_structure" field.
+	DefaultFolderStructure string
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 	// IDValidator is a validator for the "id" field. It is called by the builders before save.
@@ -156,6 +161,11 @@ func ByDeltaSubfolder(opts ...sql.OrderTermOption) OrderOption {
 // ByGroupByDate orders the results by the groupByDate field.
 func ByGroupByDate(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldGroupByDate, opts...).ToFunc()
+}
+
+// ByFolderStructure orders the results by the folder_structure field.
+func ByFolderStructure(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldFolderStructure, opts...).ToFunc()
 }
 
 // ByLastDownloadAt orders the results by the lastDownloadAt field.

--- a/api/ent/downloadconfig/downloadconfig.go
+++ b/api/ent/downloadconfig/downloadconfig.go
@@ -34,7 +34,7 @@ const (
 	FieldDeltaSubfolder = "delta_subfolder"
 	// FieldGroupByDate holds the string denoting the groupbydate field in the database.
 	FieldGroupByDate = "group_by_date"
-	// FieldFolderStructure holds the string denoting the folder_structure field in the database.
+	// FieldFolderStructure holds the string denoting the folderstructure field in the database.
 	FieldFolderStructure = "folder_structure"
 	// FieldLastDownloadAt holds the string denoting the lastdownloadat field in the database.
 	FieldLastDownloadAt = "last_download_at"
@@ -112,7 +112,7 @@ var (
 	DefaultDeltaSubfolder bool
 	// DefaultGroupByDate holds the default value on creation for the "groupByDate" field.
 	DefaultGroupByDate bool
-	// DefaultFolderStructure holds the default value on creation for the "folder_structure" field.
+	// DefaultFolderStructure holds the default value on creation for the "folderStructure" field.
 	DefaultFolderStructure string
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
@@ -163,7 +163,7 @@ func ByGroupByDate(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldGroupByDate, opts...).ToFunc()
 }
 
-// ByFolderStructure orders the results by the folder_structure field.
+// ByFolderStructure orders the results by the folderStructure field.
 func ByFolderStructure(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFolderStructure, opts...).ToFunc()
 }

--- a/api/ent/downloadconfig/where.go
+++ b/api/ent/downloadconfig/where.go
@@ -101,7 +101,7 @@ func GroupByDate(v bool) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldEQ(FieldGroupByDate, v))
 }
 
-// FolderStructure applies equality check predicate on the "folder_structure" field. It's identical to FolderStructureEQ.
+// FolderStructure applies equality check predicate on the "folderStructure" field. It's identical to FolderStructureEQ.
 func FolderStructure(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldEQ(FieldFolderStructure, v))
 }
@@ -416,67 +416,67 @@ func GroupByDateNEQ(v bool) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldNEQ(FieldGroupByDate, v))
 }
 
-// FolderStructureEQ applies the EQ predicate on the "folder_structure" field.
+// FolderStructureEQ applies the EQ predicate on the "folderStructure" field.
 func FolderStructureEQ(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldEQ(FieldFolderStructure, v))
 }
 
-// FolderStructureNEQ applies the NEQ predicate on the "folder_structure" field.
+// FolderStructureNEQ applies the NEQ predicate on the "folderStructure" field.
 func FolderStructureNEQ(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldNEQ(FieldFolderStructure, v))
 }
 
-// FolderStructureIn applies the In predicate on the "folder_structure" field.
+// FolderStructureIn applies the In predicate on the "folderStructure" field.
 func FolderStructureIn(vs ...string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldIn(FieldFolderStructure, vs...))
 }
 
-// FolderStructureNotIn applies the NotIn predicate on the "folder_structure" field.
+// FolderStructureNotIn applies the NotIn predicate on the "folderStructure" field.
 func FolderStructureNotIn(vs ...string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldNotIn(FieldFolderStructure, vs...))
 }
 
-// FolderStructureGT applies the GT predicate on the "folder_structure" field.
+// FolderStructureGT applies the GT predicate on the "folderStructure" field.
 func FolderStructureGT(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldGT(FieldFolderStructure, v))
 }
 
-// FolderStructureGTE applies the GTE predicate on the "folder_structure" field.
+// FolderStructureGTE applies the GTE predicate on the "folderStructure" field.
 func FolderStructureGTE(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldGTE(FieldFolderStructure, v))
 }
 
-// FolderStructureLT applies the LT predicate on the "folder_structure" field.
+// FolderStructureLT applies the LT predicate on the "folderStructure" field.
 func FolderStructureLT(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldLT(FieldFolderStructure, v))
 }
 
-// FolderStructureLTE applies the LTE predicate on the "folder_structure" field.
+// FolderStructureLTE applies the LTE predicate on the "folderStructure" field.
 func FolderStructureLTE(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldLTE(FieldFolderStructure, v))
 }
 
-// FolderStructureContains applies the Contains predicate on the "folder_structure" field.
+// FolderStructureContains applies the Contains predicate on the "folderStructure" field.
 func FolderStructureContains(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldContains(FieldFolderStructure, v))
 }
 
-// FolderStructureHasPrefix applies the HasPrefix predicate on the "folder_structure" field.
+// FolderStructureHasPrefix applies the HasPrefix predicate on the "folderStructure" field.
 func FolderStructureHasPrefix(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldHasPrefix(FieldFolderStructure, v))
 }
 
-// FolderStructureHasSuffix applies the HasSuffix predicate on the "folder_structure" field.
+// FolderStructureHasSuffix applies the HasSuffix predicate on the "folderStructure" field.
 func FolderStructureHasSuffix(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldHasSuffix(FieldFolderStructure, v))
 }
 
-// FolderStructureEqualFold applies the EqualFold predicate on the "folder_structure" field.
+// FolderStructureEqualFold applies the EqualFold predicate on the "folderStructure" field.
 func FolderStructureEqualFold(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldEqualFold(FieldFolderStructure, v))
 }
 
-// FolderStructureContainsFold applies the ContainsFold predicate on the "folder_structure" field.
+// FolderStructureContainsFold applies the ContainsFold predicate on the "folderStructure" field.
 func FolderStructureContainsFold(v string) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldContainsFold(FieldFolderStructure, v))
 }

--- a/api/ent/downloadconfig/where.go
+++ b/api/ent/downloadconfig/where.go
@@ -101,6 +101,11 @@ func GroupByDate(v bool) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldEQ(FieldGroupByDate, v))
 }
 
+// FolderStructure applies equality check predicate on the "folder_structure" field. It's identical to FolderStructureEQ.
+func FolderStructure(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldEQ(FieldFolderStructure, v))
+}
+
 // LastDownloadAt applies equality check predicate on the "lastDownloadAt" field. It's identical to LastDownloadAtEQ.
 func LastDownloadAt(v time.Time) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldEQ(FieldLastDownloadAt, v))
@@ -409,6 +414,71 @@ func GroupByDateEQ(v bool) predicate.DownloadConfig {
 // GroupByDateNEQ applies the NEQ predicate on the "groupByDate" field.
 func GroupByDateNEQ(v bool) predicate.DownloadConfig {
 	return predicate.DownloadConfig(sql.FieldNEQ(FieldGroupByDate, v))
+}
+
+// FolderStructureEQ applies the EQ predicate on the "folder_structure" field.
+func FolderStructureEQ(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldEQ(FieldFolderStructure, v))
+}
+
+// FolderStructureNEQ applies the NEQ predicate on the "folder_structure" field.
+func FolderStructureNEQ(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldNEQ(FieldFolderStructure, v))
+}
+
+// FolderStructureIn applies the In predicate on the "folder_structure" field.
+func FolderStructureIn(vs ...string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldIn(FieldFolderStructure, vs...))
+}
+
+// FolderStructureNotIn applies the NotIn predicate on the "folder_structure" field.
+func FolderStructureNotIn(vs ...string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldNotIn(FieldFolderStructure, vs...))
+}
+
+// FolderStructureGT applies the GT predicate on the "folder_structure" field.
+func FolderStructureGT(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldGT(FieldFolderStructure, v))
+}
+
+// FolderStructureGTE applies the GTE predicate on the "folder_structure" field.
+func FolderStructureGTE(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldGTE(FieldFolderStructure, v))
+}
+
+// FolderStructureLT applies the LT predicate on the "folder_structure" field.
+func FolderStructureLT(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldLT(FieldFolderStructure, v))
+}
+
+// FolderStructureLTE applies the LTE predicate on the "folder_structure" field.
+func FolderStructureLTE(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldLTE(FieldFolderStructure, v))
+}
+
+// FolderStructureContains applies the Contains predicate on the "folder_structure" field.
+func FolderStructureContains(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldContains(FieldFolderStructure, v))
+}
+
+// FolderStructureHasPrefix applies the HasPrefix predicate on the "folder_structure" field.
+func FolderStructureHasPrefix(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldHasPrefix(FieldFolderStructure, v))
+}
+
+// FolderStructureHasSuffix applies the HasSuffix predicate on the "folder_structure" field.
+func FolderStructureHasSuffix(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldHasSuffix(FieldFolderStructure, v))
+}
+
+// FolderStructureEqualFold applies the EqualFold predicate on the "folder_structure" field.
+func FolderStructureEqualFold(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldEqualFold(FieldFolderStructure, v))
+}
+
+// FolderStructureContainsFold applies the ContainsFold predicate on the "folder_structure" field.
+func FolderStructureContainsFold(v string) predicate.DownloadConfig {
+	return predicate.DownloadConfig(sql.FieldContainsFold(FieldFolderStructure, v))
 }
 
 // LastDownloadAtEQ applies the EQ predicate on the "lastDownloadAt" field.

--- a/api/ent/downloadconfig_create.go
+++ b/api/ent/downloadconfig_create.go
@@ -131,6 +131,20 @@ func (_c *DownloadConfigCreate) SetNillableGroupByDate(v *bool) *DownloadConfigC
 	return _c
 }
 
+// SetFolderStructure sets the "folder_structure" field.
+func (_c *DownloadConfigCreate) SetFolderStructure(v string) *DownloadConfigCreate {
+	_c.mutation.SetFolderStructure(v)
+	return _c
+}
+
+// SetNillableFolderStructure sets the "folder_structure" field if the given value is not nil.
+func (_c *DownloadConfigCreate) SetNillableFolderStructure(v *string) *DownloadConfigCreate {
+	if v != nil {
+		_c.SetFolderStructure(*v)
+	}
+	return _c
+}
+
 // SetLastDownloadAt sets the "lastDownloadAt" field.
 func (_c *DownloadConfigCreate) SetLastDownloadAt(v time.Time) *DownloadConfigCreate {
 	_c.mutation.SetLastDownloadAt(v)
@@ -244,6 +258,10 @@ func (_c *DownloadConfigCreate) defaults() {
 		v := downloadconfig.DefaultGroupByDate
 		_c.mutation.SetGroupByDate(v)
 	}
+	if _, ok := _c.mutation.FolderStructure(); !ok {
+		v := downloadconfig.DefaultFolderStructure
+		_c.mutation.SetFolderStructure(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := downloadconfig.DefaultID()
 		_c.mutation.SetID(v)
@@ -271,6 +289,9 @@ func (_c *DownloadConfigCreate) check() error {
 	}
 	if _, ok := _c.mutation.GroupByDate(); !ok {
 		return &ValidationError{Name: "groupByDate", err: errors.New(`ent: missing required field "DownloadConfig.groupByDate"`)}
+	}
+	if _, ok := _c.mutation.FolderStructure(); !ok {
+		return &ValidationError{Name: "folder_structure", err: errors.New(`ent: missing required field "DownloadConfig.folder_structure"`)}
 	}
 	if _, ok := _c.mutation.ProjectID(); !ok {
 		return &ValidationError{Name: "project_id", err: errors.New(`ent: missing required field "DownloadConfig.project_id"`)}
@@ -363,6 +384,10 @@ func (_c *DownloadConfigCreate) createSpec() (*DownloadConfig, *sqlgraph.CreateS
 	if value, ok := _c.mutation.GroupByDate(); ok {
 		_spec.SetField(downloadconfig.FieldGroupByDate, field.TypeBool, value)
 		_node.GroupByDate = value
+	}
+	if value, ok := _c.mutation.FolderStructure(); ok {
+		_spec.SetField(downloadconfig.FieldFolderStructure, field.TypeString, value)
+		_node.FolderStructure = value
 	}
 	if value, ok := _c.mutation.LastDownloadAt(); ok {
 		_spec.SetField(downloadconfig.FieldLastDownloadAt, field.TypeTime, value)

--- a/api/ent/downloadconfig_create.go
+++ b/api/ent/downloadconfig_create.go
@@ -131,13 +131,13 @@ func (_c *DownloadConfigCreate) SetNillableGroupByDate(v *bool) *DownloadConfigC
 	return _c
 }
 
-// SetFolderStructure sets the "folder_structure" field.
+// SetFolderStructure sets the "folderStructure" field.
 func (_c *DownloadConfigCreate) SetFolderStructure(v string) *DownloadConfigCreate {
 	_c.mutation.SetFolderStructure(v)
 	return _c
 }
 
-// SetNillableFolderStructure sets the "folder_structure" field if the given value is not nil.
+// SetNillableFolderStructure sets the "folderStructure" field if the given value is not nil.
 func (_c *DownloadConfigCreate) SetNillableFolderStructure(v *string) *DownloadConfigCreate {
 	if v != nil {
 		_c.SetFolderStructure(*v)
@@ -291,7 +291,7 @@ func (_c *DownloadConfigCreate) check() error {
 		return &ValidationError{Name: "groupByDate", err: errors.New(`ent: missing required field "DownloadConfig.groupByDate"`)}
 	}
 	if _, ok := _c.mutation.FolderStructure(); !ok {
-		return &ValidationError{Name: "folder_structure", err: errors.New(`ent: missing required field "DownloadConfig.folder_structure"`)}
+		return &ValidationError{Name: "folderStructure", err: errors.New(`ent: missing required field "DownloadConfig.folderStructure"`)}
 	}
 	if _, ok := _c.mutation.ProjectID(); !ok {
 		return &ValidationError{Name: "project_id", err: errors.New(`ent: missing required field "DownloadConfig.project_id"`)}

--- a/api/ent/downloadconfig_update.go
+++ b/api/ent/downloadconfig_update.go
@@ -154,13 +154,13 @@ func (_u *DownloadConfigUpdate) SetNillableGroupByDate(v *bool) *DownloadConfigU
 	return _u
 }
 
-// SetFolderStructure sets the "folder_structure" field.
+// SetFolderStructure sets the "folderStructure" field.
 func (_u *DownloadConfigUpdate) SetFolderStructure(v string) *DownloadConfigUpdate {
 	_u.mutation.SetFolderStructure(v)
 	return _u
 }
 
-// SetNillableFolderStructure sets the "folder_structure" field if the given value is not nil.
+// SetNillableFolderStructure sets the "folderStructure" field if the given value is not nil.
 func (_u *DownloadConfigUpdate) SetNillableFolderStructure(v *string) *DownloadConfigUpdate {
 	if v != nil {
 		_u.SetFolderStructure(*v)
@@ -570,13 +570,13 @@ func (_u *DownloadConfigUpdateOne) SetNillableGroupByDate(v *bool) *DownloadConf
 	return _u
 }
 
-// SetFolderStructure sets the "folder_structure" field.
+// SetFolderStructure sets the "folderStructure" field.
 func (_u *DownloadConfigUpdateOne) SetFolderStructure(v string) *DownloadConfigUpdateOne {
 	_u.mutation.SetFolderStructure(v)
 	return _u
 }
 
-// SetNillableFolderStructure sets the "folder_structure" field if the given value is not nil.
+// SetNillableFolderStructure sets the "folderStructure" field if the given value is not nil.
 func (_u *DownloadConfigUpdateOne) SetNillableFolderStructure(v *string) *DownloadConfigUpdateOne {
 	if v != nil {
 		_u.SetFolderStructure(*v)

--- a/api/ent/downloadconfig_update.go
+++ b/api/ent/downloadconfig_update.go
@@ -154,6 +154,20 @@ func (_u *DownloadConfigUpdate) SetNillableGroupByDate(v *bool) *DownloadConfigU
 	return _u
 }
 
+// SetFolderStructure sets the "folder_structure" field.
+func (_u *DownloadConfigUpdate) SetFolderStructure(v string) *DownloadConfigUpdate {
+	_u.mutation.SetFolderStructure(v)
+	return _u
+}
+
+// SetNillableFolderStructure sets the "folder_structure" field if the given value is not nil.
+func (_u *DownloadConfigUpdate) SetNillableFolderStructure(v *string) *DownloadConfigUpdate {
+	if v != nil {
+		_u.SetFolderStructure(*v)
+	}
+	return _u
+}
+
 // SetLastDownloadAt sets the "lastDownloadAt" field.
 func (_u *DownloadConfigUpdate) SetLastDownloadAt(v time.Time) *DownloadConfigUpdate {
 	_u.mutation.SetLastDownloadAt(v)
@@ -346,6 +360,9 @@ func (_u *DownloadConfigUpdate) sqlSave(ctx context.Context) (_node int, err err
 	}
 	if value, ok := _u.mutation.GroupByDate(); ok {
 		_spec.SetField(downloadconfig.FieldGroupByDate, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FolderStructure(); ok {
+		_spec.SetField(downloadconfig.FieldFolderStructure, field.TypeString, value)
 	}
 	if value, ok := _u.mutation.LastDownloadAt(); ok {
 		_spec.SetField(downloadconfig.FieldLastDownloadAt, field.TypeTime, value)
@@ -549,6 +566,20 @@ func (_u *DownloadConfigUpdateOne) SetGroupByDate(v bool) *DownloadConfigUpdateO
 func (_u *DownloadConfigUpdateOne) SetNillableGroupByDate(v *bool) *DownloadConfigUpdateOne {
 	if v != nil {
 		_u.SetGroupByDate(*v)
+	}
+	return _u
+}
+
+// SetFolderStructure sets the "folder_structure" field.
+func (_u *DownloadConfigUpdateOne) SetFolderStructure(v string) *DownloadConfigUpdateOne {
+	_u.mutation.SetFolderStructure(v)
+	return _u
+}
+
+// SetNillableFolderStructure sets the "folder_structure" field if the given value is not nil.
+func (_u *DownloadConfigUpdateOne) SetNillableFolderStructure(v *string) *DownloadConfigUpdateOne {
+	if v != nil {
+		_u.SetFolderStructure(*v)
 	}
 	return _u
 }
@@ -775,6 +806,9 @@ func (_u *DownloadConfigUpdateOne) sqlSave(ctx context.Context) (_node *Download
 	}
 	if value, ok := _u.mutation.GroupByDate(); ok {
 		_spec.SetField(downloadconfig.FieldGroupByDate, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.FolderStructure(); ok {
+		_spec.SetField(downloadconfig.FieldFolderStructure, field.TypeString, value)
 	}
 	if value, ok := _u.mutation.LastDownloadAt(); ok {
 		_spec.SetField(downloadconfig.FieldLastDownloadAt, field.TypeTime, value)

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -130,6 +130,7 @@ var (
 		{Name: "blocked_image_ids", Type: field.TypeJSON, Nullable: true},
 		{Name: "delta_subfolder", Type: field.TypeBool, Default: false},
 		{Name: "group_by_date", Type: field.TypeBool, Default: false},
+		{Name: "folder_structure", Type: field.TypeString, Default: "default"},
 		{Name: "last_download_at", Type: field.TypeTime, Nullable: true},
 		{Name: "project_id", Type: field.TypeString, Size: 15},
 		{Name: "user_id", Type: field.TypeUUID},
@@ -142,13 +143,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "download_configs_projects_downloadConfigs",
-				Columns:    []*schema.Column{DownloadConfigsColumns[12]},
+				Columns:    []*schema.Column{DownloadConfigsColumns[13]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "download_configs_users_downloadConfigs",
-				Columns:    []*schema.Column{DownloadConfigsColumns[13]},
+				Columns:    []*schema.Column{DownloadConfigsColumns[14]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -157,12 +158,12 @@ var (
 			{
 				Name:    "downloadconfig_project_id",
 				Unique:  false,
-				Columns: []*schema.Column{DownloadConfigsColumns[12]},
+				Columns: []*schema.Column{DownloadConfigsColumns[13]},
 			},
 			{
 				Name:    "downloadconfig_user_id_project_id",
 				Unique:  false,
-				Columns: []*schema.Column{DownloadConfigsColumns[13], DownloadConfigsColumns[12]},
+				Columns: []*schema.Column{DownloadConfigsColumns[14], DownloadConfigsColumns[13]},
 			},
 		},
 	}

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -2911,6 +2911,7 @@ type DownloadConfigMutation struct {
 	appendblockedImageIds []string
 	deltaSubfolder        *bool
 	groupByDate           *bool
+	folder_structure      *string
 	lastDownloadAt        *time.Time
 	clearedFields         map[string]struct{}
 	project               *string
@@ -3499,6 +3500,42 @@ func (m *DownloadConfigMutation) ResetGroupByDate() {
 	m.groupByDate = nil
 }
 
+// SetFolderStructure sets the "folder_structure" field.
+func (m *DownloadConfigMutation) SetFolderStructure(s string) {
+	m.folder_structure = &s
+}
+
+// FolderStructure returns the value of the "folder_structure" field in the mutation.
+func (m *DownloadConfigMutation) FolderStructure() (r string, exists bool) {
+	v := m.folder_structure
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldFolderStructure returns the old "folder_structure" field's value of the DownloadConfig entity.
+// If the DownloadConfig object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *DownloadConfigMutation) OldFolderStructure(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldFolderStructure is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldFolderStructure requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldFolderStructure: %w", err)
+	}
+	return oldValue.FolderStructure, nil
+}
+
+// ResetFolderStructure resets all changes to the "folder_structure" field.
+func (m *DownloadConfigMutation) ResetFolderStructure() {
+	m.folder_structure = nil
+}
+
 // SetLastDownloadAt sets the "lastDownloadAt" field.
 func (m *DownloadConfigMutation) SetLastDownloadAt(t time.Time) {
 	m.lastDownloadAt = &t
@@ -3708,7 +3745,7 @@ func (m *DownloadConfigMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *DownloadConfigMutation) Fields() []string {
-	fields := make([]string, 0, 13)
+	fields := make([]string, 0, 14)
 	if m.createdAt != nil {
 		fields = append(fields, downloadconfig.FieldCreatedAt)
 	}
@@ -3738,6 +3775,9 @@ func (m *DownloadConfigMutation) Fields() []string {
 	}
 	if m.groupByDate != nil {
 		fields = append(fields, downloadconfig.FieldGroupByDate)
+	}
+	if m.folder_structure != nil {
+		fields = append(fields, downloadconfig.FieldFolderStructure)
 	}
 	if m.lastDownloadAt != nil {
 		fields = append(fields, downloadconfig.FieldLastDownloadAt)
@@ -3776,6 +3816,8 @@ func (m *DownloadConfigMutation) Field(name string) (ent.Value, bool) {
 		return m.DeltaSubfolder()
 	case downloadconfig.FieldGroupByDate:
 		return m.GroupByDate()
+	case downloadconfig.FieldFolderStructure:
+		return m.FolderStructure()
 	case downloadconfig.FieldLastDownloadAt:
 		return m.LastDownloadAt()
 	case downloadconfig.FieldProjectID:
@@ -3811,6 +3853,8 @@ func (m *DownloadConfigMutation) OldField(ctx context.Context, name string) (ent
 		return m.OldDeltaSubfolder(ctx)
 	case downloadconfig.FieldGroupByDate:
 		return m.OldGroupByDate(ctx)
+	case downloadconfig.FieldFolderStructure:
+		return m.OldFolderStructure(ctx)
 	case downloadconfig.FieldLastDownloadAt:
 		return m.OldLastDownloadAt(ctx)
 	case downloadconfig.FieldProjectID:
@@ -3895,6 +3939,13 @@ func (m *DownloadConfigMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetGroupByDate(v)
+		return nil
+	case downloadconfig.FieldFolderStructure:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetFolderStructure(v)
 		return nil
 	case downloadconfig.FieldLastDownloadAt:
 		v, ok := value.(time.Time)
@@ -4034,6 +4085,9 @@ func (m *DownloadConfigMutation) ResetField(name string) error {
 		return nil
 	case downloadconfig.FieldGroupByDate:
 		m.ResetGroupByDate()
+		return nil
+	case downloadconfig.FieldFolderStructure:
+		m.ResetFolderStructure()
 		return nil
 	case downloadconfig.FieldLastDownloadAt:
 		m.ResetLastDownloadAt()

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -2911,7 +2911,7 @@ type DownloadConfigMutation struct {
 	appendblockedImageIds []string
 	deltaSubfolder        *bool
 	groupByDate           *bool
-	folder_structure      *string
+	folderStructure       *string
 	lastDownloadAt        *time.Time
 	clearedFields         map[string]struct{}
 	project               *string
@@ -3500,21 +3500,21 @@ func (m *DownloadConfigMutation) ResetGroupByDate() {
 	m.groupByDate = nil
 }
 
-// SetFolderStructure sets the "folder_structure" field.
+// SetFolderStructure sets the "folderStructure" field.
 func (m *DownloadConfigMutation) SetFolderStructure(s string) {
-	m.folder_structure = &s
+	m.folderStructure = &s
 }
 
-// FolderStructure returns the value of the "folder_structure" field in the mutation.
+// FolderStructure returns the value of the "folderStructure" field in the mutation.
 func (m *DownloadConfigMutation) FolderStructure() (r string, exists bool) {
-	v := m.folder_structure
+	v := m.folderStructure
 	if v == nil {
 		return
 	}
 	return *v, true
 }
 
-// OldFolderStructure returns the old "folder_structure" field's value of the DownloadConfig entity.
+// OldFolderStructure returns the old "folderStructure" field's value of the DownloadConfig entity.
 // If the DownloadConfig object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
 func (m *DownloadConfigMutation) OldFolderStructure(ctx context.Context) (v string, err error) {
@@ -3531,9 +3531,9 @@ func (m *DownloadConfigMutation) OldFolderStructure(ctx context.Context) (v stri
 	return oldValue.FolderStructure, nil
 }
 
-// ResetFolderStructure resets all changes to the "folder_structure" field.
+// ResetFolderStructure resets all changes to the "folderStructure" field.
 func (m *DownloadConfigMutation) ResetFolderStructure() {
-	m.folder_structure = nil
+	m.folderStructure = nil
 }
 
 // SetLastDownloadAt sets the "lastDownloadAt" field.
@@ -3776,7 +3776,7 @@ func (m *DownloadConfigMutation) Fields() []string {
 	if m.groupByDate != nil {
 		fields = append(fields, downloadconfig.FieldGroupByDate)
 	}
-	if m.folder_structure != nil {
+	if m.folderStructure != nil {
 		fields = append(fields, downloadconfig.FieldFolderStructure)
 	}
 	if m.lastDownloadAt != nil {

--- a/api/ent/runtime.go
+++ b/api/ent/runtime.go
@@ -158,9 +158,9 @@ func init() {
 	downloadconfigDescGroupByDate := downloadconfigFields[5].Descriptor()
 	// downloadconfig.DefaultGroupByDate holds the default value on creation for the groupByDate field.
 	downloadconfig.DefaultGroupByDate = downloadconfigDescGroupByDate.Default.(bool)
-	// downloadconfigDescFolderStructure is the schema descriptor for folder_structure field.
+	// downloadconfigDescFolderStructure is the schema descriptor for folderStructure field.
 	downloadconfigDescFolderStructure := downloadconfigFields[6].Descriptor()
-	// downloadconfig.DefaultFolderStructure holds the default value on creation for the folder_structure field.
+	// downloadconfig.DefaultFolderStructure holds the default value on creation for the folderStructure field.
 	downloadconfig.DefaultFolderStructure = downloadconfigDescFolderStructure.Default.(string)
 	// downloadconfigDescID is the schema descriptor for id field.
 	downloadconfigDescID := downloadconfigMixinFields0[0].Descriptor()

--- a/api/ent/runtime.go
+++ b/api/ent/runtime.go
@@ -158,6 +158,10 @@ func init() {
 	downloadconfigDescGroupByDate := downloadconfigFields[5].Descriptor()
 	// downloadconfig.DefaultGroupByDate holds the default value on creation for the groupByDate field.
 	downloadconfig.DefaultGroupByDate = downloadconfigDescGroupByDate.Default.(bool)
+	// downloadconfigDescFolderStructure is the schema descriptor for folder_structure field.
+	downloadconfigDescFolderStructure := downloadconfigFields[6].Descriptor()
+	// downloadconfig.DefaultFolderStructure holds the default value on creation for the folder_structure field.
+	downloadconfig.DefaultFolderStructure = downloadconfigDescFolderStructure.Default.(string)
 	// downloadconfigDescID is the schema descriptor for id field.
 	downloadconfigDescID := downloadconfigMixinFields0[0].Descriptor()
 	// downloadconfig.DefaultID holds the default value on creation for the id field.

--- a/api/ent/schema/download_config.go
+++ b/api/ent/schema/download_config.go
@@ -33,6 +33,7 @@ func (DownloadConfig) Fields() []ent.Field {
 		// (PR #40 "upload" mode).
 		field.Bool("deltaSubfolder").Default(false).StructTag(`json:"deltaSubfolder"`),
 		field.Bool("groupByDate").Default(false).StructTag(`json:"groupByDate"`),
+		field.String("folder_structure").Default("default").StructTag(`json:"folderStructure"`),
 		field.Time("lastDownloadAt").Optional().Nillable().StructTag(`json:"lastDownloadAt"`),
 		field.String("project_id").StructTag(`json:"-"`),
 		field.UUID("user_id", uuid.UUID{}).StructTag(`json:"-"`),

--- a/api/ent/schema/download_config.go
+++ b/api/ent/schema/download_config.go
@@ -28,12 +28,13 @@ func (DownloadConfig) Fields() []ent.Field {
 		field.JSON("whitelistTagIds", []string{}).Optional().Default([]string{}).StructTag(`json:"whitelistTagIds"`),
 		field.JSON("blacklistTagIds", []string{}).Optional().Default([]string{}).StructTag(`json:"blacklistTagIds"`),
 		field.JSON("blockedImageIds", []string{}).Optional().Default([]string{}).StructTag(`json:"blockedImageIds"`),
-		// deltaSubfolder writes new/changed files into a per-run delta_<date>
-		// subfolder (issue #26); groupByDate sorts into capture-date folders
-		// (PR #40 "upload" mode).
+		// deltaSubfolder prefixes per-day folders with new_/delta_ on delta runs
+		// (issue #26, PR #89); groupByDate sorts into capture-date folders
+		// (PR #40 "upload" mode); folderStructure "weekday" sorts into
+		// "YYYYMMDD Weekday" event-day folders derived from the date tag (PR #89).
 		field.Bool("deltaSubfolder").Default(false).StructTag(`json:"deltaSubfolder"`),
 		field.Bool("groupByDate").Default(false).StructTag(`json:"groupByDate"`),
-		field.String("folder_structure").Default("default").StructTag(`json:"folderStructure"`),
+		field.String("folderStructure").Default("default").StructTag(`json:"folderStructure"`),
 		field.Time("lastDownloadAt").Optional().Nillable().StructTag(`json:"lastDownloadAt"`),
 		field.String("project_id").StructTag(`json:"-"`),
 		field.UUID("user_id", uuid.UUID{}).StructTag(`json:"-"`),

--- a/api/internal/repository/download_config.go
+++ b/api/internal/repository/download_config.go
@@ -42,6 +42,7 @@ type CreateDownloadConfigParameters struct {
 	BlockedImageIds []string
 	DeltaSubfolder  bool
 	GroupByDate     bool
+	FolderStructure string
 }
 
 func (r *Repository) CreateDownloadConfig(ctx context.Context, parameters *CreateDownloadConfigParameters) (*ent.DownloadConfig, error) {
@@ -60,6 +61,7 @@ func (r *Repository) CreateDownloadConfig(ctx context.Context, parameters *Creat
 		SetGroupByDate(parameters.GroupByDate).
 		SetCreatedBy(util.GetActorID(ctx)).
 		SetUpdatedBy(util.GetActorID(ctx)).
+		SetFolderStructure(parameters.FolderStructure).
 		Save(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("error creating download config")
@@ -81,6 +83,7 @@ type UpdateDownloadConfigParameters struct {
 	BlockedImageIds *[]string
 	DeltaSubfolder  *bool
 	GroupByDate     *bool
+	FolderStructure *string
 	LastDownloadAt  *time.Time
 }
 
@@ -118,6 +121,9 @@ func (r *Repository) UpdateDownloadConfig(ctx context.Context, id string, parame
 	if parameters.GroupByDate != nil {
 		update.SetGroupByDate(*parameters.GroupByDate)
 	}
+	if parameters.FolderStructure != nil {
+		update.SetFolderStructure(*parameters.FolderStructure)
+	}
 	if parameters.LastDownloadAt != nil {
 		update.SetLastDownloadAt(*parameters.LastDownloadAt)
 	}
@@ -125,6 +131,7 @@ func (r *Repository) UpdateDownloadConfig(ctx context.Context, id string, parame
 		log.Error().Err(err).Msg("error updating download config")
 		return nil, err
 	}
+
 	safeGo(func() {
 		r.CreateAuditLog(context.WithoutCancel(ctx), &CreateAuditLogParameters{
 			Action: "update", ObjectType: util.StringPointer("download_config"), ObjectId: util.StringPointer(id),

--- a/api/internal/server/download_configs_controller.go
+++ b/api/internal/server/download_configs_controller.go
@@ -24,12 +24,16 @@ func downloadConfigResponse(cfg *ent.DownloadConfig) gin.H {
 		"blockedImageIds": cfg.BlockedImageIds,
 		"deltaSubfolder":  cfg.DeltaSubfolder,
 		"groupByDate":     cfg.GroupByDate,
+		"folderStructure": cfg.FolderStructure,
 		"lastDownloadAt":  cfg.LastDownloadAt,
 		"projectId":       cfg.ProjectID,
 		"createdAt":       cfg.CreatedAt,
 		"updatedAt":       cfg.UpdatedAt,
-		"folderStructure": cfg.FolderStructure,
 	}
+}
+
+func validFolderStructure(s string) bool {
+	return s == "default" || s == "weekday"
 }
 
 func (s *Server) registerDownloadConfigRoutes(api *gin.RouterGroup) {
@@ -88,6 +92,13 @@ func (s *Server) createDownloadConfig(c *gin.Context) {
 	if !allow(c, authorization.CanViewProject(authUser(c), payload.ProjectID)) {
 		return
 	}
+	if payload.FolderStructure == "" {
+		payload.FolderStructure = "default"
+	}
+	if !validFolderStructure(payload.FolderStructure) {
+		apiError(c, http.StatusBadRequest, "invalid_folder_structure", "folderStructure must be 'default' or 'weekday'")
+		return
+	}
 	cfg, err := s.Repository.CreateDownloadConfig(c.Request.Context(), &repository.CreateDownloadConfigParameters{
 		Name:            payload.Name,
 		ProjectID:       payload.ProjectID,
@@ -97,7 +108,7 @@ func (s *Server) createDownloadConfig(c *gin.Context) {
 		BlockedImageIds: payload.BlockedImageIds,
 		DeltaSubfolder:  payload.DeltaSubfolder,
 		GroupByDate:     payload.GroupByDate,
-		FolderStructure: payload.FolderStructure,  
+		FolderStructure: payload.FolderStructure,
 	})
 	if abortDownloadConfigMutationError(c, err) {
 		return
@@ -131,13 +142,17 @@ func (s *Server) updateDownloadConfig(c *gin.Context) {
 		DeltaSubfolder  *bool      `json:"deltaSubfolder"`
 		GroupByDate     *bool      `json:"groupByDate"`
 		LastDownloadAt  *time.Time `json:"lastDownloadAt"`
-		FolderStructure *string `json:"folderStructure"`
+		FolderStructure *string    `json:"folderStructure"`
 	}
 	if !bindJSON(c, &payload) {
 		return
 	}
 	if payload.Name != nil && *payload.Name == "" {
 		apiError(c, http.StatusBadRequest, "empty_name", "name must not be empty")
+		return
+	}
+	if payload.FolderStructure != nil && !validFolderStructure(*payload.FolderStructure) {
+		apiError(c, http.StatusBadRequest, "invalid_folder_structure", "folderStructure must be 'default' or 'weekday'")
 		return
 	}
 	updated, err := s.Repository.UpdateDownloadConfig(c.Request.Context(), id, &repository.UpdateDownloadConfigParameters{

--- a/api/internal/server/download_configs_controller.go
+++ b/api/internal/server/download_configs_controller.go
@@ -28,6 +28,7 @@ func downloadConfigResponse(cfg *ent.DownloadConfig) gin.H {
 		"projectId":       cfg.ProjectID,
 		"createdAt":       cfg.CreatedAt,
 		"updatedAt":       cfg.UpdatedAt,
+		"folderStructure": cfg.FolderStructure,
 	}
 }
 
@@ -76,6 +77,7 @@ type createDownloadConfigPayload struct {
 	BlockedImageIds []string `json:"blockedImageIds"`
 	DeltaSubfolder  bool     `json:"deltaSubfolder"`
 	GroupByDate     bool     `json:"groupByDate"`
+	FolderStructure string   `json:"folderStructure"`
 }
 
 func (s *Server) createDownloadConfig(c *gin.Context) {
@@ -95,6 +97,7 @@ func (s *Server) createDownloadConfig(c *gin.Context) {
 		BlockedImageIds: payload.BlockedImageIds,
 		DeltaSubfolder:  payload.DeltaSubfolder,
 		GroupByDate:     payload.GroupByDate,
+		FolderStructure: payload.FolderStructure,  
 	})
 	if abortDownloadConfigMutationError(c, err) {
 		return
@@ -128,6 +131,7 @@ func (s *Server) updateDownloadConfig(c *gin.Context) {
 		DeltaSubfolder  *bool      `json:"deltaSubfolder"`
 		GroupByDate     *bool      `json:"groupByDate"`
 		LastDownloadAt  *time.Time `json:"lastDownloadAt"`
+		FolderStructure *string `json:"folderStructure"`
 	}
 	if !bindJSON(c, &payload) {
 		return
@@ -144,6 +148,7 @@ func (s *Server) updateDownloadConfig(c *gin.Context) {
 		DeltaSubfolder:  payload.DeltaSubfolder,
 		GroupByDate:     payload.GroupByDate,
 		LastDownloadAt:  payload.LastDownloadAt,
+		FolderStructure: payload.FolderStructure,
 	})
 	if abortDownloadConfigMutationError(c, err) {
 		return

--- a/ui/src/api/downloadConfigs.ts
+++ b/ui/src/api/downloadConfigs.ts
@@ -9,27 +9,6 @@ export interface DownloadConfigCreate {
   blockedImageIds?: string[];
   deltaSubfolder?: boolean;
   groupByDate?: boolean;
-  folderStructure?: 'weekday' | 'default' | undefined;
-}
-
-export interface DownloadConfigUpdate {
-  name?: string;
-  whitelistTagIds?: string[];
-  blacklistTagIds?: string[];
-  blockedImageIds?: string[];
-  deltaSubfolder?: boolean;
-  groupByDate?: boolean;
-  lastDownloadAt?: string;
-}
-
-export interface DownloadConfigCreate {
-  name: string;
-  projectId: string;
-  whitelistTagIds?: string[];
-  blacklistTagIds?: string[];
-  blockedImageIds?: string[];
-  deltaSubfolder?: boolean;
-  groupByDate?: boolean;
   folderStructure?: "default" | "weekday";
 }
 

--- a/ui/src/api/downloadConfigs.ts
+++ b/ui/src/api/downloadConfigs.ts
@@ -9,6 +9,7 @@ export interface DownloadConfigCreate {
   blockedImageIds?: string[];
   deltaSubfolder?: boolean;
   groupByDate?: boolean;
+  folderStructure?: 'weekday' | 'default' | undefined;
 }
 
 export interface DownloadConfigUpdate {
@@ -18,6 +19,28 @@ export interface DownloadConfigUpdate {
   blockedImageIds?: string[];
   deltaSubfolder?: boolean;
   groupByDate?: boolean;
+  lastDownloadAt?: string;
+}
+
+export interface DownloadConfigCreate {
+  name: string;
+  projectId: string;
+  whitelistTagIds?: string[];
+  blacklistTagIds?: string[];
+  blockedImageIds?: string[];
+  deltaSubfolder?: boolean;
+  groupByDate?: boolean;
+  folderStructure?: "default" | "weekday";
+}
+
+export interface DownloadConfigUpdate {
+  name?: string;
+  whitelistTagIds?: string[];
+  blacklistTagIds?: string[];
+  blockedImageIds?: string[];
+  deltaSubfolder?: boolean;
+  groupByDate?: boolean;
+  folderStructure?: "default" | "weekday";
   lastDownloadAt?: string;
 }
 

--- a/ui/src/components/download/DownloadConfigDialog.vue
+++ b/ui/src/components/download/DownloadConfigDialog.vue
@@ -130,24 +130,26 @@
                   <span class="mt-0.5 block text-xs text-primary-500 dark:text-primary-400">One file name (or image id) per line — never downloaded by this config.</span>
                   <textarea v-model="blockedText" rows="3" class="input-field mt-1 font-mono text-xs" placeholder="FSG26_1234_max&#10;FSG26_1235_max"></textarea>
                 </label>
-                  <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                    <label class="block">
-                      <span class="text-sm font-medium text-primary-700 dark:text-primary-200">Folder strategy</span>
-                      <p class="text-xs text-primary-500 dark:text-primary-400">Choose how photos are placed into folders.</p>
-                      <select v-model="folderChoice" class="input-field mt-1">
-                        <option value="none">None</option>
-                        <option value="date">Date (capture)</option>
-                        <option value="weekday">Weekday (from tag)</option>
-                      </select>
-                    </label>
-                    <label class="flex items-start gap-2.5">
-                      <input v-model="draft.deltaSubfolder" type="checkbox" class="mt-0.5 h-4 w-4 rounded ..." />
-                      <span>
-                        <span class="block text-sm font-medium text-primary-700 dark:text-primary-200">Delta subfolder</span>
-                        <span class="block text-xs text-primary-500 dark:text-primary-400">Delta runs write new/changed files into <code>delta_&lt;date&gt;/</code>.</span>
-                      </span>
-                    </label>
-                  </div>
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  <label class="block">
+                    <span class="text-sm font-medium text-primary-700 dark:text-primary-200">Folder strategy</span>
+                    <span class="mt-0.5 block text-xs text-primary-500 dark:text-primary-400">How photos are placed into folders.</span>
+                    <select v-model="folderChoice" class="input-field mt-1">
+                      <option value="none">None</option>
+                      <option value="date">Capture date</option>
+                      <option value="weekday">Event day (from date tag)</option>
+                    </select>
+                  </label>
+                  <label class="flex items-start gap-2.5">
+                    <input v-model="draft.deltaSubfolder" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-primary-300 text-accent-600 focus:ring-accent-500" />
+                    <span>
+                      <span class="block text-sm font-medium text-primary-700 dark:text-primary-200">Delta subfolder</span>
+                      <span class="block text-xs text-primary-500 dark:text-primary-400"
+                        >Delta runs prefix day folders: new files into <code>new_…/</code>, changed files into <code>delta_…/</code>.</span
+                      >
+                    </span>
+                  </label>
+                </div>
               </div>
               <!-- footer -->
               <div class="flex flex-row-reverse flex-wrap gap-3 border-t border-primary-100 px-6 py-4 dark:border-primary-800">
@@ -196,9 +198,11 @@ const emit = defineEmits<{
   deleted: [];
 }>();
 
-const draft = ref({ name: "", whitelistTagIds: [] as string[], blacklistTagIds: [] as string[], deltaSubfolder: false, groupByDate: false });
+const draft = ref({ name: "", whitelistTagIds: [] as string[], blacklistTagIds: [] as string[], deltaSubfolder: false });
 const blockedText = ref("");
-
+// folderChoice folds folderStructure + groupByDate into one strategy select —
+// the two backing fields are mutually exclusive by construction.
+const folderChoice = ref<"none" | "date" | "weekday">("none");
 
 watch(
   () => [props.show, props.config, props.create] as const,
@@ -210,12 +214,15 @@ watch(
         whitelistTagIds: [...props.config.whitelistTagIds],
         blacklistTagIds: [...props.config.blacklistTagIds],
         deltaSubfolder: props.config.deltaSubfolder,
-        groupByDate: props.config.groupByDate,
       };
       blockedText.value = props.config.blockedImageIds.join("\n");
+      if (props.config.folderStructure === "weekday") folderChoice.value = "weekday";
+      else if (props.config.groupByDate) folderChoice.value = "date";
+      else folderChoice.value = "none";
     } else {
-      draft.value = { name: "", whitelistTagIds: [], blacklistTagIds: [], deltaSubfolder: false, groupByDate: false };
+      draft.value = { name: "", whitelistTagIds: [], blacklistTagIds: [], deltaSubfolder: false };
       blockedText.value = "";
+      folderChoice.value = "none";
     }
   },
   { immediate: true },
@@ -247,38 +254,7 @@ function tagName(id: string): string {
   return props.projectTags.find((t) => t.id === id)?.name ?? id;
 }
 
-const folderChoice = ref<"none" | "date" | "weekday">("none");
-
-watch(
-  () => [props.show, props.config, props.create] as const,
-  () => {
-    if (!props.show) return;
-    if (props.config && !props.create) {
-      draft.value = {
-        name: props.config.name,
-        whitelistTagIds: [...props.config.whitelistTagIds],
-        blacklistTagIds: [...props.config.blacklistTagIds],
-        deltaSubfolder: props.config.deltaSubfolder,
-        groupByDate: props.config.groupByDate,
-      };
-      blockedText.value = props.config.blockedImageIds.join("\n");
-      // map existing stored folderStructure + groupByDate into folderChoice
-      if ((props.config.folderStructure ?? "default") === "weekday") folderChoice.value = "weekday";
-      else if (props.config.groupByDate) folderChoice.value = "date";
-      else folderChoice.value = "none";
-    } else {
-      draft.value = { name: "", whitelistTagIds: [], blacklistTagIds: [], deltaSubfolder: false, groupByDate: false };
-      blockedText.value = "";
-      folderChoice.value = "none";
-    }
-  },
-  { immediate: true },
-);
-
 function save() {
-  const folderStructure = folderChoice.value === "weekday" ? "weekday" : undefined;
-  const groupByDate = folderChoice.value === "date";
-
   emit("save", {
     name: draft.value.name.trim(),
     whitelistTagIds: draft.value.whitelistTagIds,
@@ -288,20 +264,22 @@ function save() {
       .map((line) => line.trim())
       .filter((line) => line !== ""),
     deltaSubfolder: draft.value.deltaSubfolder,
-    groupByDate: groupByDate,
-    folderStructure: folderStructure,
-  } as DownloadConfigCreate | DownloadConfigUpdate);
+    groupByDate: folderChoice.value === "date",
+    // always sent explicitly — an omitted field would keep a stale "weekday"
+    // on the server when switching back to date/none
+    folderStructure: folderChoice.value === "weekday" ? "weekday" : "default",
+  });
 }
 </script>
 
 <style scoped>
 .input-field {
-    @apply block w-full rounded-md border border-primary-200 bg-surface px-3 py-2 text-sm text-primary-900 shadow-sm focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-primary-700 dark:bg-surface-dark dark:text-white;
-  }
-  .btn-primary {
-    @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md bg-accent-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-500 active:bg-accent-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50 dark:focus-visible:ring-offset-primary-950;
-  }
-  .btn-secondary {
-    @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-primary-200 bg-surface px-4 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:border-primary-600 dark:hover:text-white;
-  }
+  @apply block w-full rounded-md border border-primary-200 bg-surface px-3 py-2 text-sm text-primary-900 shadow-sm focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-primary-700 dark:bg-surface-dark dark:text-white;
+}
+.btn-primary {
+  @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md bg-accent-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-500 active:bg-accent-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50 dark:focus-visible:ring-offset-primary-950;
+}
+.btn-secondary {
+  @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-primary-200 bg-surface px-4 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:border-primary-600 dark:hover:text-white;
+}
 </style>

--- a/ui/src/components/download/DownloadConfigDialog.vue
+++ b/ui/src/components/download/DownloadConfigDialog.vue
@@ -130,27 +130,25 @@
                   <span class="mt-0.5 block text-xs text-primary-500 dark:text-primary-400">One file name (or image id) per line — never downloaded by this config.</span>
                   <textarea v-model="blockedText" rows="3" class="input-field mt-1 font-mono text-xs" placeholder="FSG26_1234_max&#10;FSG26_1235_max"></textarea>
                 </label>
-
-                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                  <label class="flex items-start gap-2.5">
-                    <input v-model="draft.deltaSubfolder" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-primary-300 text-accent-600 focus:ring-accent-500" />
-                    <span>
-                      <span class="block text-sm font-medium text-primary-700 dark:text-primary-200">Delta subfolder</span>
-                      <span class="block text-xs text-primary-500 dark:text-primary-400"
-                        >Delta runs write new/changed files into <code>delta_&lt;date&gt;/</code> instead of mixing them in.</span
-                      >
-                    </span>
-                  </label>
-                  <label class="flex items-start gap-2.5">
-                    <input v-model="draft.groupByDate" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-primary-300 text-accent-600 focus:ring-accent-500" />
-                    <span>
-                      <span class="block text-sm font-medium text-primary-700 dark:text-primary-200">Group by date</span>
-                      <span class="block text-xs text-primary-500 dark:text-primary-400">Sort photos into capture-date folders.</span>
-                    </span>
-                  </label>
-                </div>
+                  <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <label class="block">
+                      <span class="text-sm font-medium text-primary-700 dark:text-primary-200">Folder strategy</span>
+                      <p class="text-xs text-primary-500 dark:text-primary-400">Choose how photos are placed into folders.</p>
+                      <select v-model="folderChoice" class="input-field mt-1">
+                        <option value="none">None</option>
+                        <option value="date">Date (capture)</option>
+                        <option value="weekday">Weekday (from tag)</option>
+                      </select>
+                    </label>
+                    <label class="flex items-start gap-2.5">
+                      <input v-model="draft.deltaSubfolder" type="checkbox" class="mt-0.5 h-4 w-4 rounded ..." />
+                      <span>
+                        <span class="block text-sm font-medium text-primary-700 dark:text-primary-200">Delta subfolder</span>
+                        <span class="block text-xs text-primary-500 dark:text-primary-400">Delta runs write new/changed files into <code>delta_&lt;date&gt;/</code>.</span>
+                      </span>
+                    </label>
+                  </div>
               </div>
-
               <!-- footer -->
               <div class="flex flex-row-reverse flex-wrap gap-3 border-t border-primary-100 px-6 py-4 dark:border-primary-800">
                 <button type="button" class="btn-primary" :disabled="draft.name.trim() === ''" @click="save">
@@ -201,6 +199,7 @@ const emit = defineEmits<{
 const draft = ref({ name: "", whitelistTagIds: [] as string[], blacklistTagIds: [] as string[], deltaSubfolder: false, groupByDate: false });
 const blockedText = ref("");
 
+
 watch(
   () => [props.show, props.config, props.create] as const,
   () => {
@@ -248,7 +247,38 @@ function tagName(id: string): string {
   return props.projectTags.find((t) => t.id === id)?.name ?? id;
 }
 
+const folderChoice = ref<"none" | "date" | "weekday">("none");
+
+watch(
+  () => [props.show, props.config, props.create] as const,
+  () => {
+    if (!props.show) return;
+    if (props.config && !props.create) {
+      draft.value = {
+        name: props.config.name,
+        whitelistTagIds: [...props.config.whitelistTagIds],
+        blacklistTagIds: [...props.config.blacklistTagIds],
+        deltaSubfolder: props.config.deltaSubfolder,
+        groupByDate: props.config.groupByDate,
+      };
+      blockedText.value = props.config.blockedImageIds.join("\n");
+      // map existing stored folderStructure + groupByDate into folderChoice
+      if ((props.config.folderStructure ?? "default") === "weekday") folderChoice.value = "weekday";
+      else if (props.config.groupByDate) folderChoice.value = "date";
+      else folderChoice.value = "none";
+    } else {
+      draft.value = { name: "", whitelistTagIds: [], blacklistTagIds: [], deltaSubfolder: false, groupByDate: false };
+      blockedText.value = "";
+      folderChoice.value = "none";
+    }
+  },
+  { immediate: true },
+);
+
 function save() {
+  const folderStructure = folderChoice.value === "weekday" ? "weekday" : undefined;
+  const groupByDate = folderChoice.value === "date";
+
   emit("save", {
     name: draft.value.name.trim(),
     whitelistTagIds: draft.value.whitelistTagIds,
@@ -258,19 +288,20 @@ function save() {
       .map((line) => line.trim())
       .filter((line) => line !== ""),
     deltaSubfolder: draft.value.deltaSubfolder,
-    groupByDate: draft.value.groupByDate,
-  });
+    groupByDate: groupByDate,
+    folderStructure: folderStructure,
+  } as DownloadConfigCreate | DownloadConfigUpdate);
 }
 </script>
 
 <style scoped>
 .input-field {
-  @apply block w-full rounded-md border border-primary-200 bg-surface px-3 py-2 text-sm text-primary-900 shadow-sm focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-primary-700 dark:bg-surface-dark dark:text-white;
-}
-.btn-primary {
-  @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md bg-accent-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-500 active:bg-accent-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50 dark:focus-visible:ring-offset-primary-950;
-}
-.btn-secondary {
-  @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-primary-200 bg-surface px-4 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:border-primary-600 dark:hover:text-white;
-}
+    @apply block w-full rounded-md border border-primary-200 bg-surface px-3 py-2 text-sm text-primary-900 shadow-sm focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-primary-700 dark:bg-surface-dark dark:text-white;
+  }
+  .btn-primary {
+    @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md bg-accent-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-accent-500 active:bg-accent-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-50 dark:focus-visible:ring-offset-primary-950;
+  }
+  .btn-secondary {
+    @apply inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-primary-200 bg-surface px-4 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:border-primary-600 dark:hover:text-white;
+  }
 </style>

--- a/ui/src/pages/download/Download.vue
+++ b/ui/src/pages/download/Download.vue
@@ -47,7 +47,7 @@
               <div
                 v-if="worker"
                 class="h-full rounded-full bg-accent-400 transition-all"
-                :class="{ 'animate-pulse': worker.total === 0 }"
+                :class="{ 'animate-pulse': !worker.total }"
                 :style="{ width: worker.total ? `${Math.min(100, (worker.received / worker.total) * 100)}%` : '100%' }"
               ></div>
             </div>
@@ -108,175 +108,78 @@
           </div>
         </div>
       </div>
-<!-- sync progress -->
-<div
-  v-if="syncProgress"
-  class="mt-6 rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark"
-  data-testid="sync-progress"
->
-  <div class="flex items-center justify-between gap-3">
-    <div class="min-w-0">
-      <p class="text-sm font-semibold text-primary-900 dark:text-white">
-        Sync läuft — {{ syncProgress.configName }}
-      </p>
+      <!-- sync progress -->
+      <div v-if="syncProgress" class="mt-6 rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark" data-testid="sync-progress">
+        <div class="flex items-center justify-between gap-3">
+          <div class="min-w-0">
+            <p class="text-sm font-semibold text-primary-900 dark:text-white">Syncing — {{ syncProgress.configName }}</p>
+            <p class="mt-0.5 truncate text-xs text-primary-500 dark:text-primary-400">
+              <template v-if="syncProgress.phase === 'scanning'">Scanning local files…</template>
+              <template v-else-if="syncProgress.fileName">{{ syncProgress.fileName }}</template>
+              <template v-else>Processing files…</template>
+            </p>
+          </div>
+          <span class="whitespace-nowrap text-xs tabular-nums text-primary-500 dark:text-primary-400">
+            <template v-if="syncProgress.total">{{ syncProgress.current }} / {{ syncProgress.total }}</template>
+          </span>
+        </div>
+        <div class="mt-3 h-2 overflow-hidden rounded-full bg-primary-100 dark:bg-primary-800">
+          <div v-if="!syncProgress.total" class="h-full w-1/3 animate-pulse rounded-full bg-accent-500"></div>
+          <div
+            v-else
+            class="h-full rounded-full bg-accent-500 transition-all duration-200"
+            :style="{ width: `${Math.min(100, (syncProgress.current / syncProgress.total) * 100)}%` }"
+          ></div>
+        </div>
+      </div>
 
-      <p class="mt-0.5 truncate text-xs text-primary-500 dark:text-primary-400">
-        <template v-if="syncProgress.phase === 'scanning'">
-          Lokale Dateien werden geprüft…
-        </template>
+      <!-- latest sync result -->
+      <div v-if="syncResult" class="mt-6 rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark" data-testid="sync-result">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p class="text-sm font-semibold text-primary-900 dark:text-white">Sync finished</p>
+            <p class="mt-0.5 text-xs text-primary-500 dark:text-primary-400">{{ syncResult.configName }} · {{ formatDateTime(syncResult.syncedAt.toISOString()) }}</p>
+          </div>
+          <button type="button" class="btn-secondary" @click="syncResult = null">Dismiss</button>
+        </div>
+        <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <div class="rounded-md border border-red-200 bg-red-500/10 px-3 py-2 dark:border-red-800">
+            <p class="text-2xl font-semibold tabular-nums text-red-700 dark:text-red-300">{{ syncResult.result.deletedCount }}</p>
+            <p class="text-xs text-red-700/80 dark:text-red-300/80">moved to <code>deleted/</code></p>
+          </div>
+          <div class="rounded-md border border-amber-200 bg-amber-500/10 px-3 py-2 dark:border-amber-800">
+            <p class="text-2xl font-semibold tabular-nums text-amber-700 dark:text-amber-300">{{ syncResult.result.blacklistedCount }}</p>
+            <p class="text-xs text-amber-700/80 dark:text-amber-300/80">moved to <code>blacklist/</code></p>
+          </div>
+          <div class="rounded-md border border-primary-200 bg-primary-50 px-3 py-2 dark:border-primary-700 dark:bg-primary-900/30">
+            <p class="text-2xl font-semibold tabular-nums text-primary-700 dark:text-primary-200">{{ syncResult.result.movedFiles.length }}</p>
+            <p class="text-xs text-primary-600 dark:text-primary-300">files moved in total</p>
+          </div>
+        </div>
+        <div v-if="syncResult.result.movedFiles.length" class="mt-5">
+          <p class="text-xs font-semibold uppercase tracking-wide text-primary-500 dark:text-primary-400">Moved files</p>
+          <div class="mt-2 max-h-64 overflow-y-auto rounded-md border border-primary-200 dark:border-primary-700">
+            <table class="min-w-full divide-y divide-primary-200 text-left text-xs dark:divide-primary-700">
+              <thead class="sticky top-0 bg-primary-50 dark:bg-primary-900">
+                <tr>
+                  <th class="px-3 py-2 font-semibold text-primary-600 dark:text-primary-300">File</th>
+                  <th class="px-3 py-2 font-semibold text-primary-600 dark:text-primary-300">Reason</th>
+                  <th class="px-3 py-2 font-semibold text-primary-600 dark:text-primary-300">New location</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-primary-100 dark:divide-primary-800">
+                <tr v-for="moved in syncResult.result.movedFiles" :key="moved.fromPath" class="text-primary-700 dark:text-primary-200">
+                  <td class="max-w-[28rem] break-all px-3 py-2 font-mono">{{ moved.basename }}</td>
+                  <td class="whitespace-nowrap px-3 py-2">{{ moved.reason }}</td>
+                  <td class="max-w-[32rem] break-all px-3 py-2 font-mono">{{ moved.toPath }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
 
-        <template v-else-if="syncProgress.fileName">
-          {{ syncProgress.fileName }}
-        </template>
-
-        <template v-else>
-          Dateien werden verarbeitet…
-        </template>
-      </p>
-    </div>
-
-    <span class="whitespace-nowrap text-xs tabular-nums text-primary-500 dark:text-primary-400">
-      <template v-if="syncProgress.total">
-        {{ syncProgress.current }} / {{ syncProgress.total }}
-      </template>
-
-      <template v-else>
-        wird ermittelt…
-      </template>
-    </span>
-  </div>
-
-  <div class="mt-3 h-2 overflow-hidden rounded-full bg-primary-100 dark:bg-primary-800">
-    <div
-      v-if="!syncProgress.total"
-      class="h-full w-1/3 animate-pulse rounded-full bg-accent-500"
-    ></div>
-
-    <div
-      v-else
-      class="h-full rounded-full bg-accent-500 transition-all duration-200"
-      :style="{
-        width: `${Math.min(
-          100,
-          (syncProgress.current / syncProgress.total) * 100,
-        )}%`,
-      }"
-    ></div>
-  </div>
-
-  <p class="mt-1 text-right text-xs tabular-nums text-primary-500 dark:text-primary-400">
-    <template v-if="syncProgress.total">
-      {{ Math.round((syncProgress.current / syncProgress.total) * 100) }} %
-    </template>
-    <template v-else>
-      wird ermittelt…
-    </template>
-  </p>
-</div>
-
-<!-- latest sync result -->
-<div
-  v-if="syncResult"
-  class="mt-6 rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark"
-  data-testid="sync-result"
->
-  <div class="flex flex-wrap items-start justify-between gap-3">
-    <div>
-      <p class="text-sm font-semibold text-primary-900 dark:text-white">
-        Sync abgeschlossen
-      </p>
-
-      <p class="mt-0.5 text-xs text-primary-500 dark:text-primary-400">
-        Config: {{ syncResult.configName }}
-        · {{ formatDateTime(syncResult.syncedAt.toISOString()) }}
-      </p>
-    </div>
-
-    <button
-      type="button"
-      class="btn-secondary"
-      @click="syncResult = null"
-    >
-      Dismiss
-    </button>
-  </div>
-
-  <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
-    <div class="rounded-md border border-red-200 bg-red-500/10 px-3 py-2 dark:border-red-800">
-      <p class="text-2xl font-semibold tabular-nums text-red-700 dark:text-red-300">
-        {{ syncResult.result.deletedCount }}
-      </p>
-      <p class="text-xs text-red-700/80 dark:text-red-300/80">
-        nach <code>_deleted</code> verschoben
-      </p>
-    </div>
-
-    <div class="rounded-md border border-amber-200 bg-amber-500/10 px-3 py-2 dark:border-amber-800">
-      <p class="text-2xl font-semibold tabular-nums text-amber-700 dark:text-amber-300">
-        {{ syncResult.result.blacklistedCount }}
-      </p>
-      <p class="text-xs text-amber-700/80 dark:text-amber-300/80">
-        nach <code>_blacklist</code> verschoben
-      </p>
-    </div>
-
-    <div class="rounded-md border border-primary-200 bg-primary-50 px-3 py-2 dark:border-primary-700 dark:bg-primary-900/30">
-      <p class="text-2xl font-semibold tabular-nums text-primary-700 dark:text-primary-200">
-        {{ syncResult.result.movedFiles.length }}
-      </p>
-      <p class="text-xs text-primary-600 dark:text-primary-300">
-        Dateien insgesamt verschoben
-      </p>
-    </div>
-  </div>
-
-  <div
-    v-if="syncResult.result.movedFiles.length"
-    class="mt-5"
-  >
-    <p class="text-xs font-semibold uppercase tracking-wide text-primary-500 dark:text-primary-400">
-      Verschobene Dateien
-    </p>
-
-    <div class="mt-2 max-h-64 overflow-y-auto rounded-md border border-primary-200 dark:border-primary-700">
-      <table class="min-w-full divide-y divide-primary-200 text-left text-xs dark:divide-primary-700">
-        <thead class="sticky top-0 bg-primary-50 dark:bg-primary-900">
-          <tr>
-            <th class="px-3 py-2 font-semibold text-primary-600 dark:text-primary-300">
-              Dateiname
-            </th>
-            <th class="px-3 py-2 font-semibold text-primary-600 dark:text-primary-300">
-              Grund
-            </th>
-            <th class="px-3 py-2 font-semibold text-primary-600 dark:text-primary-300">
-              Neuer Speicherort
-            </th>
-          </tr>
-        </thead>
-
-        <tbody class="divide-y divide-primary-100 dark:divide-primary-800">
-          <tr
-            v-for="moved in syncResult.result.movedFiles"
-            :key="moved.fromPath"
-            class="text-primary-700 dark:text-primary-200"
-          >
-            <td class="max-w-[28rem] break-all px-3 py-2 font-mono">
-              {{ moved.basename }}
-            </td>
-            <td class="whitespace-nowrap px-3 py-2">
-              {{ moved.reason }}
-            </td>
-            <td class="max-w-[32rem] break-all px-3 py-2 font-mono">
-              {{ moved.toPath }}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-</div>
-
-<!-- config cards -->
+      <!-- config cards -->
       <div v-if="configs.length" class="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
         <div
           v-for="config in configs"
@@ -331,10 +234,6 @@
               {{ folderNames[config.id] ? "change" : "pick" }}
             </button>
           </p>
-
-
-
-
           <p class="mt-1 text-xs text-primary-500 dark:text-primary-400">
             <span v-if="config.lastDownloadAt">last download {{ formatDateTime(config.lastDownloadAt) }}</span>
             <span v-else>never downloaded</span>
@@ -344,15 +243,10 @@
               <EyeIcon class="h-4 w-4" />
               {{ previewLoading === config.id ? "Scanning…" : "Preview" }}
             </button>
-<button
-  type="button"
-  class="btn-secondary flex-1"
-  :disabled="!supported || !!activeRun || !!syncProgress"
-  @click="syncLocalFiles(config)"
->
-  <ArrowPathIcon class="h-4 w-4" />
-  Sync
-</button>
+            <button type="button" class="btn-secondary flex-1" :disabled="!supported || !!activeRun || !!syncProgress" @click="syncLocalFiles(config)">
+              <ArrowPathIcon class="h-4 w-4" />
+              Sync
+            </button>
             <button type="button" class="btn-secondary flex-1" :disabled="!supported || !!activeRun || !!syncProgress" @click="startRun(config, true)">
               <ArrowPathIcon class="h-4 w-4" />
               Delta
@@ -376,11 +270,7 @@
       @save="saveConfig"
       @deleted="deleteConfig"
     />
-    <UnexpectedErrorMessage
-      :show="Boolean(showUnexpectedErrorMessage)"
-      :error="unexpectedError ?? undefined"
-      @closed="showUnexpectedErrorMessage = false"
-    />
+    <UnexpectedErrorMessage :show="showUnexpectedErrorMessage" :error="unexpectedError" @closed="showUnexpectedErrorMessage = false" />
   </div>
 </template>
 
@@ -411,6 +301,7 @@ import {
   RunProgress,
   runDownload,
   reconcileLocalFiles,
+  ReconcileProgress,
   ReconcileResult,
 } from "src/util/downloadRunner";
 
@@ -420,16 +311,7 @@ interface SyncResultState {
   syncedAt: Date;
 }
 
-interface SyncProgress {
-  configName: string;
-  current: number;
-  total: number;
-  fileName?: string;
-  phase: "scanning" | "moving" | "finished";
-}
-
-const syncProgress = ref<SyncProgress | null>(null);
-
+const syncProgress = ref<({ configName: string } & ReconcileProgress) | null>(null);
 const syncResult = ref<SyncResultState | null>(null);
 const userStore = useUserStore();
 const { activeProjectId } = storeToRefs(userStore);
@@ -441,15 +323,12 @@ const matchCounts = ref<Record<string, number>>({});
 const folderNames = ref<Record<string, string>>({});
 const loaded = ref(false);
 
-const unexpectedError = ref<Error | undefined>(undefined);
+const unexpectedError = ref<any>(null);
 const showUnexpectedErrorMessage = ref(false);
-
 const fail = (error: any) => {
-  unexpectedError.value = error instanceof Error ? error : new Error(String(error));
+  unexpectedError.value = error;
   showUnexpectedErrorMessage.value = true;
 };
-
-
 
 async function loadData() {
   if (!activeProjectId.value) return;
@@ -628,8 +507,7 @@ async function openPreview(config: DownloadConfig) {
   try {
     const directory = await getDirectory(config);
     if (!directory) return;
-    const images = await fetchAllImages(config);
-    const existing = await collectExistingFiles(directory);
+    const [images, existing] = await Promise.all([fetchAllImages(config), collectExistingFiles(directory)]);
     preview.value = { config, images, plan: planDownload(images, config, existing, { delta: true }), directory };
   } catch (error: any) {
     fail(error);
@@ -697,46 +575,23 @@ async function startRun(config: DownloadConfig, delta: boolean) {
 }
 
 // ---- sync local files ----
+// Reconcile moves local files that left the catalog (or got blacklisted)
+// aside — never deletes. See reconcileLocalFiles for the rules.
 async function syncLocalFiles(config: DownloadConfig) {
   const directory = await getDirectory(config);
   if (!directory) return;
-
   syncResult.value = null;
-
-  syncProgress.value = {
-    configName: config.name,
-    current: 0,
-    total: 0,
-    phase: "scanning",
-  };
-
+  syncProgress.value = { configName: config.name, current: 0, total: 0, phase: "scanning" };
   try {
     const images = await fetchAllImages(config);
-
-    const rc = await reconcileLocalFiles(
-      directory,
-      config,
-      images,
-      (progress) => {
-        syncProgress.value = {
-          configName: config.name,
-          ...progress,
-        };
-      },
-    );
-
-    syncResult.value = {
-      configName: config.name,
-      result: rc,
-      syncedAt: new Date(),
-    };
-
+    const result = await reconcileLocalFiles(directory, config, images, (progress) => {
+      syncProgress.value = { configName: config.name, ...progress };
+    });
+    syncResult.value = { configName: config.name, result, syncedAt: new Date() };
+    const moved = result.deletedCount || result.blacklistedCount;
     showNotificationToast({
-      headline:
-        rc.deletedCount || rc.blacklistedCount
-          ? `Synced: ${rc.deletedCount} deleted, ${rc.blacklistedCount} blacklisted`
-          : "No changes to sync",
-      type: rc.deletedCount || rc.blacklistedCount ? "success" : "info",
+      headline: moved ? `Synced: ${result.deletedCount} deleted, ${result.blacklistedCount} blacklisted` : "No changes to sync",
+      type: moved ? "success" : "info",
     });
   } catch (error: any) {
     fail(error);
@@ -744,8 +599,6 @@ async function syncLocalFiles(config: DownloadConfig) {
     syncProgress.value = null;
   }
 }
-
-
 </script>
 
 <style scoped>

--- a/ui/src/pages/download/Download.vue
+++ b/ui/src/pages/download/Download.vue
@@ -47,7 +47,7 @@
               <div
                 v-if="worker"
                 class="h-full rounded-full bg-accent-400 transition-all"
-                :class="{ 'animate-pulse': !worker.total }"
+                :class="{ 'animate-pulse': worker.total === 0 }"
                 :style="{ width: worker.total ? `${Math.min(100, (worker.received / worker.total) * 100)}%` : '100%' }"
               ></div>
             </div>
@@ -108,8 +108,175 @@
           </div>
         </div>
       </div>
+<!-- sync progress -->
+<div
+  v-if="syncProgress"
+  class="mt-6 rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark"
+  data-testid="sync-progress"
+>
+  <div class="flex items-center justify-between gap-3">
+    <div class="min-w-0">
+      <p class="text-sm font-semibold text-primary-900 dark:text-white">
+        Sync läuft — {{ syncProgress.configName }}
+      </p>
 
-      <!-- config cards -->
+      <p class="mt-0.5 truncate text-xs text-primary-500 dark:text-primary-400">
+        <template v-if="syncProgress.phase === 'scanning'">
+          Lokale Dateien werden geprüft…
+        </template>
+
+        <template v-else-if="syncProgress.fileName">
+          {{ syncProgress.fileName }}
+        </template>
+
+        <template v-else>
+          Dateien werden verarbeitet…
+        </template>
+      </p>
+    </div>
+
+    <span class="whitespace-nowrap text-xs tabular-nums text-primary-500 dark:text-primary-400">
+      <template v-if="syncProgress.total">
+        {{ syncProgress.current }} / {{ syncProgress.total }}
+      </template>
+
+      <template v-else>
+        wird ermittelt…
+      </template>
+    </span>
+  </div>
+
+  <div class="mt-3 h-2 overflow-hidden rounded-full bg-primary-100 dark:bg-primary-800">
+    <div
+      v-if="!syncProgress.total"
+      class="h-full w-1/3 animate-pulse rounded-full bg-accent-500"
+    ></div>
+
+    <div
+      v-else
+      class="h-full rounded-full bg-accent-500 transition-all duration-200"
+      :style="{
+        width: `${Math.min(
+          100,
+          (syncProgress.current / syncProgress.total) * 100,
+        )}%`,
+      }"
+    ></div>
+  </div>
+
+  <p class="mt-1 text-right text-xs tabular-nums text-primary-500 dark:text-primary-400">
+    <template v-if="syncProgress.total">
+      {{ Math.round((syncProgress.current / syncProgress.total) * 100) }} %
+    </template>
+    <template v-else>
+      wird ermittelt…
+    </template>
+  </p>
+</div>
+
+<!-- latest sync result -->
+<div
+  v-if="syncResult"
+  class="mt-6 rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark"
+  data-testid="sync-result"
+>
+  <div class="flex flex-wrap items-start justify-between gap-3">
+    <div>
+      <p class="text-sm font-semibold text-primary-900 dark:text-white">
+        Sync abgeschlossen
+      </p>
+
+      <p class="mt-0.5 text-xs text-primary-500 dark:text-primary-400">
+        Config: {{ syncResult.configName }}
+        · {{ formatDateTime(syncResult.syncedAt.toISOString()) }}
+      </p>
+    </div>
+
+    <button
+      type="button"
+      class="btn-secondary"
+      @click="syncResult = null"
+    >
+      Dismiss
+    </button>
+  </div>
+
+  <div class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+    <div class="rounded-md border border-red-200 bg-red-500/10 px-3 py-2 dark:border-red-800">
+      <p class="text-2xl font-semibold tabular-nums text-red-700 dark:text-red-300">
+        {{ syncResult.result.deletedCount }}
+      </p>
+      <p class="text-xs text-red-700/80 dark:text-red-300/80">
+        nach <code>_deleted</code> verschoben
+      </p>
+    </div>
+
+    <div class="rounded-md border border-amber-200 bg-amber-500/10 px-3 py-2 dark:border-amber-800">
+      <p class="text-2xl font-semibold tabular-nums text-amber-700 dark:text-amber-300">
+        {{ syncResult.result.blacklistedCount }}
+      </p>
+      <p class="text-xs text-amber-700/80 dark:text-amber-300/80">
+        nach <code>_blacklist</code> verschoben
+      </p>
+    </div>
+
+    <div class="rounded-md border border-primary-200 bg-primary-50 px-3 py-2 dark:border-primary-700 dark:bg-primary-900/30">
+      <p class="text-2xl font-semibold tabular-nums text-primary-700 dark:text-primary-200">
+        {{ syncResult.result.movedFiles.length }}
+      </p>
+      <p class="text-xs text-primary-600 dark:text-primary-300">
+        Dateien insgesamt verschoben
+      </p>
+    </div>
+  </div>
+
+  <div
+    v-if="syncResult.result.movedFiles.length"
+    class="mt-5"
+  >
+    <p class="text-xs font-semibold uppercase tracking-wide text-primary-500 dark:text-primary-400">
+      Verschobene Dateien
+    </p>
+
+    <div class="mt-2 max-h-64 overflow-y-auto rounded-md border border-primary-200 dark:border-primary-700">
+      <table class="min-w-full divide-y divide-primary-200 text-left text-xs dark:divide-primary-700">
+        <thead class="sticky top-0 bg-primary-50 dark:bg-primary-900">
+          <tr>
+            <th class="px-3 py-2 font-semibold text-primary-600 dark:text-primary-300">
+              Dateiname
+            </th>
+            <th class="px-3 py-2 font-semibold text-primary-600 dark:text-primary-300">
+              Grund
+            </th>
+            <th class="px-3 py-2 font-semibold text-primary-600 dark:text-primary-300">
+              Neuer Speicherort
+            </th>
+          </tr>
+        </thead>
+
+        <tbody class="divide-y divide-primary-100 dark:divide-primary-800">
+          <tr
+            v-for="moved in syncResult.result.movedFiles"
+            :key="moved.fromPath"
+            class="text-primary-700 dark:text-primary-200"
+          >
+            <td class="max-w-[28rem] break-all px-3 py-2 font-mono">
+              {{ moved.basename }}
+            </td>
+            <td class="whitespace-nowrap px-3 py-2">
+              {{ moved.reason }}
+            </td>
+            <td class="max-w-[32rem] break-all px-3 py-2 font-mono">
+              {{ moved.toPath }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<!-- config cards -->
       <div v-if="configs.length" class="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
         <div
           v-for="config in configs"
@@ -164,20 +331,33 @@
               {{ folderNames[config.id] ? "change" : "pick" }}
             </button>
           </p>
+
+
+
+
           <p class="mt-1 text-xs text-primary-500 dark:text-primary-400">
             <span v-if="config.lastDownloadAt">last download {{ formatDateTime(config.lastDownloadAt) }}</span>
             <span v-else>never downloaded</span>
           </p>
           <div class="mt-3 flex gap-2 border-t border-primary-100 pt-3 dark:border-primary-800">
-            <button type="button" class="btn-primary flex-1" :disabled="!supported || !!activeRun || previewLoading" @click="openPreview(config)">
+            <button type="button" class="btn-primary flex-1" :disabled="!supported || !!activeRun || previewLoading || !!syncProgress" @click="openPreview(config)">
               <EyeIcon class="h-4 w-4" />
               {{ previewLoading === config.id ? "Scanning…" : "Preview" }}
             </button>
-            <button type="button" class="btn-secondary flex-1" :disabled="!supported || !!activeRun" @click="startRun(config, true)">
+<button
+  type="button"
+  class="btn-secondary flex-1"
+  :disabled="!supported || !!activeRun || !!syncProgress"
+  @click="syncLocalFiles(config)"
+>
+  <ArrowPathIcon class="h-4 w-4" />
+  Sync
+</button>
+            <button type="button" class="btn-secondary flex-1" :disabled="!supported || !!activeRun || !!syncProgress" @click="startRun(config, true)">
               <ArrowPathIcon class="h-4 w-4" />
               Delta
             </button>
-            <button type="button" class="btn-secondary flex-1" :disabled="!supported || !!activeRun" @click="startRun(config, false)">
+            <button type="button" class="btn-secondary flex-1" :disabled="!supported || !!activeRun || !!syncProgress" @click="startRun(config, false)">
               <ArrowDownTrayIcon class="h-4 w-4" />
               Full
             </button>
@@ -196,7 +376,11 @@
       @save="saveConfig"
       @deleted="deleteConfig"
     />
-    <UnexpectedErrorMessage :show="showUnexpectedErrorMessage" :error="unexpectedError" @closed="showUnexpectedErrorMessage = false" />
+    <UnexpectedErrorMessage
+      :show="Boolean(showUnexpectedErrorMessage)"
+      :error="unexpectedError ?? undefined"
+      @closed="showUnexpectedErrorMessage = false"
+    />
   </div>
 </template>
 
@@ -226,8 +410,27 @@ import {
   RETRY_COUNT,
   RunProgress,
   runDownload,
+  reconcileLocalFiles,
+  ReconcileResult,
 } from "src/util/downloadRunner";
 
+interface SyncResultState {
+  configName: string;
+  result: ReconcileResult;
+  syncedAt: Date;
+}
+
+interface SyncProgress {
+  configName: string;
+  current: number;
+  total: number;
+  fileName?: string;
+  phase: "scanning" | "moving" | "finished";
+}
+
+const syncProgress = ref<SyncProgress | null>(null);
+
+const syncResult = ref<SyncResultState | null>(null);
 const userStore = useUserStore();
 const { activeProjectId } = storeToRefs(userStore);
 
@@ -238,12 +441,15 @@ const matchCounts = ref<Record<string, number>>({});
 const folderNames = ref<Record<string, string>>({});
 const loaded = ref(false);
 
-const unexpectedError = ref<any>(null);
+const unexpectedError = ref<Error | undefined>(undefined);
 const showUnexpectedErrorMessage = ref(false);
+
 const fail = (error: any) => {
-  unexpectedError.value = error;
+  unexpectedError.value = error instanceof Error ? error : new Error(String(error));
   showUnexpectedErrorMessage.value = true;
 };
+
+
 
 async function loadData() {
   if (!activeProjectId.value) return;
@@ -422,7 +628,8 @@ async function openPreview(config: DownloadConfig) {
   try {
     const directory = await getDirectory(config);
     if (!directory) return;
-    const [images, existing] = await Promise.all([fetchAllImages(config), collectExistingFiles(directory)]);
+    const images = await fetchAllImages(config);
+    const existing = await collectExistingFiles(directory);
     preview.value = { config, images, plan: planDownload(images, config, existing, { delta: true }), directory };
   } catch (error: any) {
     fail(error);
@@ -488,6 +695,57 @@ async function startRun(config: DownloadConfig, delta: boolean) {
     fail(error);
   }
 }
+
+// ---- sync local files ----
+async function syncLocalFiles(config: DownloadConfig) {
+  const directory = await getDirectory(config);
+  if (!directory) return;
+
+  syncResult.value = null;
+
+  syncProgress.value = {
+    configName: config.name,
+    current: 0,
+    total: 0,
+    phase: "scanning",
+  };
+
+  try {
+    const images = await fetchAllImages(config);
+
+    const rc = await reconcileLocalFiles(
+      directory,
+      config,
+      images,
+      (progress) => {
+        syncProgress.value = {
+          configName: config.name,
+          ...progress,
+        };
+      },
+    );
+
+    syncResult.value = {
+      configName: config.name,
+      result: rc,
+      syncedAt: new Date(),
+    };
+
+    showNotificationToast({
+      headline:
+        rc.deletedCount || rc.blacklistedCount
+          ? `Synced: ${rc.deletedCount} deleted, ${rc.blacklistedCount} blacklisted`
+          : "No changes to sync",
+      type: rc.deletedCount || rc.blacklistedCount ? "success" : "info",
+    });
+  } catch (error: any) {
+    fail(error);
+  } finally {
+    syncProgress.value = null;
+  }
+}
+
+
 </script>
 
 <style scoped>

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -171,8 +171,8 @@ export interface DownloadConfig {
   blockedImageIds: string[];
   deltaSubfolder: boolean;
   groupByDate: boolean;
+  folderStructure: "default" | "weekday";
   lastDownloadAt: string | null;
-  folderStructure?: "default" | "weekday"; // default: "default"
   projectId: string;
   createdAt: string;
   updatedAt: string;

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -172,6 +172,7 @@ export interface DownloadConfig {
   deltaSubfolder: boolean;
   groupByDate: boolean;
   lastDownloadAt: string | null;
+  folderStructure?: "default" | "weekday"; // default: "default"
   projectId: string;
   createdAt: string;
   updatedAt: string;

--- a/ui/src/util/downloadRunner.ts
+++ b/ui/src/util/downloadRunner.ts
@@ -22,6 +22,13 @@ export interface RunOptions {
   runDate: Date; // start of this run — delta folder name + next lastDownloadAt
 }
 
+export interface ReconcileProgress {
+  current: number;
+  total: number;
+  fileName?: string;
+  phase: "scanning" | "moving" | "finished";
+}
+
 export function downloadFileName(image: Pick<Image, "computedFileName">): string {
   return `${image.computedFileName}.jpg`;
 }
@@ -55,6 +62,210 @@ export function classifyImage(
   return "present";
 }
 
+// Tag date extraction: finds YYYYMMDD inside tag text (adjust if tags differ)
+const TAG_DATE_REGEX = /(\d{4})(\d{2})(\d{2})/;
+
+export function extractDateFromTag(tags: string[] | undefined): Date | null {
+  if (!tags) return null;
+  for (const t of tags) {
+    const match = t.match(TAG_DATE_REGEX);
+    if (match) {
+      const [, y, m, d] = match;
+      const date = new Date(Number(y), Number(m) - 1, Number(d));
+      if (!isNaN(date.getTime())) return date;
+    }
+  }
+  return null;
+}
+
+export function weekdaySegment(date: Date, locale: string = "en-US"): string {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  const weekday = date.toLocaleDateString(locale, { weekday: "long" });
+  return `${yyyy}${mm}${dd} ${weekday}`;
+}
+
+// New richer file-collection helpers (do not remove the existing collectExistingFiles)
+export interface ExistingFileEntry {
+  basename: string;
+  parentDirHandle: FileSystemDirectoryHandle;
+  relativeSegments: string[]; // path from root excluding filename
+}
+
+export async function collectExistingFileEntries(
+  root: FileSystemDirectoryHandle,
+  ignoreDirNames: string[] = [
+    "deleted",
+    "blacklist",
+    "_deleted",
+    "_blacklist",
+  ],
+): Promise<ExistingFileEntry[]> {
+  const results: ExistingFileEntry[] = [];
+  async function walk(dir: FileSystemDirectoryHandle, segments: string[]) {
+    for await (const [name, handle] of (dir as any).entries()) {
+      if (handle.kind === "directory") {
+        if (ignoreDirNames.includes(name)) continue;
+        await walk(handle, [...segments, name]);
+      } else if (handle.kind === "file") {
+        results.push({ basename: name, parentDirHandle: dir, relativeSegments: segments });
+      }
+    }
+  }
+  await walk(root, []);
+  return results;
+}
+
+export async function moveFileToFolder(
+  root: FileSystemDirectoryHandle,
+  entry: ExistingFileEntry,
+  targetTopLevelSegment: "deleted" | "blacklist",
+): Promise<string> {
+  const targetSegments = [
+    targetTopLevelSegment,
+    ...entry.relativeSegments,
+  ];
+
+  const targetDir = await ensureDirectory(root, targetSegments);
+
+  const fileHandle = await entry.parentDirHandle.getFileHandle(
+    entry.basename,
+  );
+
+  const file = await fileHandle.getFile();
+
+  const destHandle = await targetDir.getFileHandle(entry.basename, {
+    create: true,
+  });
+
+  const writable = await destHandle.createWritable();
+
+  try {
+    await writable.write(await file.arrayBuffer());
+    await writable.close();
+  } catch (error) {
+    await writable.abort().catch(() => undefined);
+    throw error;
+  }
+
+  await entry.parentDirHandle.removeEntry(entry.basename);
+
+  return [
+    ...targetSegments,
+    entry.basename,
+  ].join("/");
+}
+
+export interface ReconcileResult {
+  deletedCount: number;
+  blacklistedCount: number;
+  movedFiles: Array<{ basename: string; reason: "deleted" | "blacklisted"; fromPath: string; toPath: string }>;
+}
+
+export async function reconcileLocalFiles(
+  directory: FileSystemDirectoryHandle,
+  config: DownloadConfig,
+  images: Image[],
+  onProgress?: (progress: ReconcileProgress) => void,
+): Promise<ReconcileResult> {
+  onProgress?.({
+    current: 0,
+    total: 0,
+    phase: "scanning",
+  });
+
+  const entries = await collectExistingFileEntries(directory);
+
+  const currentByBasename = new Map(
+    images.map((image) => [
+      downloadFileName(image),
+      image,
+    ]),
+  );
+
+  const result: ReconcileResult = {
+    deletedCount: 0,
+    blacklistedCount: 0,
+    movedFiles: [],
+  };
+
+  const total = entries.length;
+  let current = 0;
+
+  onProgress?.({
+    current: 0,
+    total,
+    phase: "moving",
+  });
+
+  for (const entry of entries) {
+    const fromPath = [
+      ...entry.relativeSegments,
+      entry.basename,
+    ].join("/");
+
+    onProgress?.({
+      current,
+      total,
+      fileName: entry.basename,
+      phase: "moving",
+    });
+
+    const image = currentByBasename.get(entry.basename);
+
+if (!image) {
+  const toPath = await moveFileToFolder(
+    directory,
+    entry,
+    "deleted",
+  );
+
+  result.deletedCount++;
+
+  result.movedFiles.push({
+    basename: entry.basename,
+    reason: "deleted",
+    fromPath,
+    toPath,
+  });
+} else if (isExcluded(image, config)) {
+  const toPath = await moveFileToFolder(
+    directory,
+    entry,
+    "blacklist",
+  );
+
+  result.blacklistedCount++;
+
+  result.movedFiles.push({
+    basename: entry.basename,
+    reason: "blacklisted",
+    fromPath,
+    toPath,
+  });
+}
+
+    current++;
+
+    onProgress?.({
+      current,
+      total,
+      fileName: entry.basename,
+      phase: "moving",
+    });
+  }
+
+  onProgress?.({
+    current: total,
+    total,
+    phase: "finished",
+  });
+
+  return result;
+}
+
+
 export interface DownloadPlan {
   statuses: Map<string, ImageStatus>; // by image id
   counts: Record<ImageStatus, number>;
@@ -85,17 +296,41 @@ export function planDownload(images: Image[], config: DownloadConfig, existingFi
 // (issue #26); groupByDate sorts into capture-date folders (PR #40).
 export function targetSegments(
   image: Pick<Image, "capturedAtCorrected" | "capturedAt">,
-  config: Pick<DownloadConfig, "deltaSubfolder" | "groupByDate">,
+  config: Pick<DownloadConfig, "deltaSubfolder" | "groupByDate" | "folderStructure">,
   options: RunOptions,
+  status?: ImageStatus,
 ): string[] {
   const segments: string[] = [];
+  const captured = image.capturedAtCorrected || image.capturedAt;
+  const capturedDate = captured ? isoDate(new Date(captured)) : isoDate(options.runDate);
+
+  // Determine prefix based on status
+  let prefix = "";
   if (options.delta && config.deltaSubfolder) {
-    segments.push(`delta_${isoDate(options.runDate)}`);
+    prefix = status === "new" ? "new_" : "delta_";  // ← New vs Changed
   }
-  if (config.groupByDate) {
-    const captured = image.capturedAtCorrected || image.capturedAt;
-    segments.push(captured ? isoDate(new Date(captured)) : "unknown-date");
+
+  // Delta/Changed + weekday combined
+  if (prefix && config.folderStructure === "weekday") {
+    const tagDate = extractDateFromTag((image as any).tags?.map(t => typeof t === "string" ? t : t.tag?.name).filter(Boolean) as string[] | undefined)
+      ?? new Date(image.capturedAtCorrected || image.capturedAt);
+    segments.push(`${prefix}${weekdaySegment(tagDate, "en-US")}`);
   }
+  // Delta/Changed only (no weekday)
+  else if (prefix) {
+    segments.push(`${prefix}${capturedDate}`);
+  }
+  // Weekday only (no delta/changed)
+  else if (config.folderStructure === "weekday") {
+    const tagDate = extractDateFromTag((image as any).tags?.map(t => typeof t === "string" ? t : t.tag?.name).filter(Boolean) as string[] | undefined)
+      ?? new Date(image.capturedAtCorrected || image.capturedAt);
+    segments.push(weekdaySegment(tagDate, "en-US"));
+  }
+  // Group by capture date only
+  else if (config.groupByDate) {
+    segments.push(capturedDate);
+  }
+
   return segments;
 }
 
@@ -261,7 +496,9 @@ export async function runDownload(
       emit();
       let fileBytes = 0;
       try {
-        await downloadImageToDirectory(image, root, targetSegments(image, config, options), (p) => {
+        // Status aus dem Plan holen
+        const status = plan.statuses.get(image.id)!;  // ← HIER
+        await downloadImageToDirectory(image, root, targetSegments(image, config, options, status), (p) => {  // ← status übergeben
           fileBytes = p.received;
           progress.workers[slot] = p;
           emit();

--- a/ui/src/util/downloadRunner.ts
+++ b/ui/src/util/downloadRunner.ts
@@ -22,13 +22,6 @@ export interface RunOptions {
   runDate: Date; // start of this run — delta folder name + next lastDownloadAt
 }
 
-export interface ReconcileProgress {
-  current: number;
-  total: number;
-  fileName?: string;
-  phase: "scanning" | "moving" | "finished";
-}
-
 export function downloadFileName(image: Pick<Image, "computedFileName">): string {
   return `${image.computedFileName}.jpg`;
 }
@@ -62,8 +55,13 @@ export function classifyImage(
   return "present";
 }
 
-// Tag date extraction: finds YYYYMMDD inside tag text (adjust if tags differ)
+// ---- event-day folders (PR #89, the media team's publishing workflow) ----
+// The taggers' date tag (YYYYMMDD anywhere in the tag text) is the curated
+// event day. Without one, fall back to the capture time — where photos before
+// 04:00 still belong to the previous event day (award night, PR #40) — and to
+// the run date when no capture data exists at all.
 const TAG_DATE_REGEX = /(\d{4})(\d{2})(\d{2})/;
+export const EVENT_DAY_ROLLOVER_HOUR = 3; // local hour <= 3 → previous day
 
 export function extractDateFromTag(tags: string[] | undefined): Date | null {
   if (!tags) return null;
@@ -78,6 +76,8 @@ export function extractDateFromTag(tags: string[] | undefined): Date | null {
   return null;
 }
 
+// weekdaySegment: "20260804 Tuesday" — English weekday, matching the CLI's
+// Go time.Weekday() naming the media team already organizes by.
 export function weekdaySegment(date: Date, locale: string = "en-US"): string {
   const yyyy = date.getFullYear();
   const mm = String(date.getMonth() + 1).padStart(2, "0");
@@ -86,24 +86,41 @@ export function weekdaySegment(date: Date, locale: string = "en-US"): string {
   return `${yyyy}${mm}${dd} ${weekday}`;
 }
 
-// New richer file-collection helpers (do not remove the existing collectExistingFiles)
+export function eventDayDate(image: Pick<Image, "capturedAtCorrected" | "capturedAt"> & Partial<Pick<Image, "tags">>, runDate: Date): Date {
+  const tagDate = extractDateFromTag(image.tags?.map((assignment) => assignment.tag?.name).filter((name): name is string => !!name));
+  if (tagDate) return tagDate;
+  const captured = image.capturedAtCorrected || image.capturedAt;
+  if (!captured) return runDate;
+  const capturedAt = new Date(captured);
+  if (isNaN(capturedAt.getTime())) return runDate;
+  if (capturedAt.getHours() <= EVENT_DAY_ROLLOVER_HOUR) capturedAt.setDate(capturedAt.getDate() - 1);
+  return capturedAt;
+}
+
+// ---- local-file reconciliation (PR #89) ----
+// The synced tree mirrors the curated catalog: files whose image left the
+// catalog move to deleted/, files whose image is now blacklisted or blocked
+// move to blacklist/ — always moved (subpath kept), never deleted, so every
+// sweep is reversible by hand.
+
+export interface ReconcileProgress {
+  current: number;
+  total: number;
+  fileName?: string;
+  phase: "scanning" | "moving" | "finished";
+}
+
 export interface ExistingFileEntry {
   basename: string;
   parentDirHandle: FileSystemDirectoryHandle;
   relativeSegments: string[]; // path from root excluding filename
 }
 
-export async function collectExistingFileEntries(
-  root: FileSystemDirectoryHandle,
-  ignoreDirNames: string[] = [
-    "deleted",
-    "blacklist",
-    "_deleted",
-    "_blacklist",
-  ],
-): Promise<ExistingFileEntry[]> {
+const RECONCILE_TARGET_DIRS = ["deleted", "blacklist", "_deleted", "_blacklist"];
+
+export async function collectExistingFileEntries(root: FileSystemDirectoryHandle, ignoreDirNames: string[] = RECONCILE_TARGET_DIRS): Promise<ExistingFileEntry[]> {
   const results: ExistingFileEntry[] = [];
-  async function walk(dir: FileSystemDirectoryHandle, segments: string[]) {
+  const walk = async (dir: FileSystemDirectoryHandle, segments: string[]): Promise<void> => {
     for await (const [name, handle] of (dir as any).entries()) {
       if (handle.kind === "directory") {
         if (ignoreDirNames.includes(name)) continue;
@@ -112,49 +129,25 @@ export async function collectExistingFileEntries(
         results.push({ basename: name, parentDirHandle: dir, relativeSegments: segments });
       }
     }
-  }
+  };
   await walk(root, []);
   return results;
 }
 
-export async function moveFileToFolder(
-  root: FileSystemDirectoryHandle,
-  entry: ExistingFileEntry,
-  targetTopLevelSegment: "deleted" | "blacklist",
-): Promise<string> {
-  const targetSegments = [
-    targetTopLevelSegment,
-    ...entry.relativeSegments,
-  ];
-
+export async function moveFileToFolder(root: FileSystemDirectoryHandle, entry: ExistingFileEntry, targetTopLevelSegment: "deleted" | "blacklist"): Promise<string> {
+  const targetSegments = [targetTopLevelSegment, ...entry.relativeSegments];
   const targetDir = await ensureDirectory(root, targetSegments);
-
-  const fileHandle = await entry.parentDirHandle.getFileHandle(
-    entry.basename,
-  );
-
-  const file = await fileHandle.getFile();
-
-  const destHandle = await targetDir.getFileHandle(entry.basename, {
-    create: true,
-  });
-
+  const file = await (await entry.parentDirHandle.getFileHandle(entry.basename)).getFile();
+  const destHandle = await targetDir.getFileHandle(entry.basename, { create: true });
   const writable = await destHandle.createWritable();
-
   try {
-    await writable.write(await file.arrayBuffer());
-    await writable.close();
+    await file.stream().pipeTo(writable);
   } catch (error) {
     await writable.abort().catch(() => undefined);
     throw error;
   }
-
   await entry.parentDirHandle.removeEntry(entry.basename);
-
-  return [
-    ...targetSegments,
-    entry.basename,
-  ].join("/");
+  return [...targetSegments, entry.basename].join("/");
 }
 
 export interface ReconcileResult {
@@ -169,102 +162,31 @@ export async function reconcileLocalFiles(
   images: Image[],
   onProgress?: (progress: ReconcileProgress) => void,
 ): Promise<ReconcileResult> {
-  onProgress?.({
-    current: 0,
-    total: 0,
-    phase: "scanning",
-  });
-
+  onProgress?.({ current: 0, total: 0, phase: "scanning" });
   const entries = await collectExistingFileEntries(directory);
+  const currentByBasename = new Map(images.map((image) => [downloadFileName(image), image]));
 
-  const currentByBasename = new Map(
-    images.map((image) => [
-      downloadFileName(image),
-      image,
-    ]),
-  );
-
-  const result: ReconcileResult = {
-    deletedCount: 0,
-    blacklistedCount: 0,
-    movedFiles: [],
-  };
-
+  const result: ReconcileResult = { deletedCount: 0, blacklistedCount: 0, movedFiles: [] };
   const total = entries.length;
   let current = 0;
-
-  onProgress?.({
-    current: 0,
-    total,
-    phase: "moving",
-  });
-
   for (const entry of entries) {
-    const fromPath = [
-      ...entry.relativeSegments,
-      entry.basename,
-    ].join("/");
-
-    onProgress?.({
-      current,
-      total,
-      fileName: entry.basename,
-      phase: "moving",
-    });
-
+    onProgress?.({ current, total, fileName: entry.basename, phase: "moving" });
+    const fromPath = [...entry.relativeSegments, entry.basename].join("/");
     const image = currentByBasename.get(entry.basename);
-
-if (!image) {
-  const toPath = await moveFileToFolder(
-    directory,
-    entry,
-    "deleted",
-  );
-
-  result.deletedCount++;
-
-  result.movedFiles.push({
-    basename: entry.basename,
-    reason: "deleted",
-    fromPath,
-    toPath,
-  });
-} else if (isExcluded(image, config)) {
-  const toPath = await moveFileToFolder(
-    directory,
-    entry,
-    "blacklist",
-  );
-
-  result.blacklistedCount++;
-
-  result.movedFiles.push({
-    basename: entry.basename,
-    reason: "blacklisted",
-    fromPath,
-    toPath,
-  });
-}
-
+    if (!image) {
+      const toPath = await moveFileToFolder(directory, entry, "deleted");
+      result.deletedCount++;
+      result.movedFiles.push({ basename: entry.basename, reason: "deleted", fromPath, toPath });
+    } else if (isExcluded(image, config)) {
+      const toPath = await moveFileToFolder(directory, entry, "blacklist");
+      result.blacklistedCount++;
+      result.movedFiles.push({ basename: entry.basename, reason: "blacklisted", fromPath, toPath });
+    }
     current++;
-
-    onProgress?.({
-      current,
-      total,
-      fileName: entry.basename,
-      phase: "moving",
-    });
   }
-
-  onProgress?.({
-    current: total,
-    total,
-    phase: "finished",
-  });
-
+  onProgress?.({ current: total, total, phase: "finished" });
   return result;
 }
-
 
 export interface DownloadPlan {
   statuses: Map<string, ImageStatus>; // by image id
@@ -292,46 +214,26 @@ export function planDownload(images: Image[], config: DownloadConfig, existingFi
 }
 
 // targetSegments: folder path (without the file name) inside the picked
-// directory. Delta runs may write into a per-run delta_<date> subfolder
-// (issue #26); groupByDate sorts into capture-date folders (PR #40).
+// directory. folderStructure "weekday" sorts into "YYYYMMDD Weekday" event-day
+// folders (PR #89); groupByDate into capture-date folders (PR #40). On delta
+// runs with deltaSubfolder, the day folder is prefixed new_/delta_ so the
+// media team reviews exactly two inboxes per sync: brand-new photos and
+// re-downloaded changes (issue #26).
 export function targetSegments(
-  image: Pick<Image, "capturedAtCorrected" | "capturedAt">,
+  image: Pick<Image, "capturedAtCorrected" | "capturedAt"> & Partial<Pick<Image, "tags">>,
   config: Pick<DownloadConfig, "deltaSubfolder" | "groupByDate" | "folderStructure">,
   options: RunOptions,
   status?: ImageStatus,
 ): string[] {
-  const segments: string[] = [];
+  const prefix = options.delta && config.deltaSubfolder ? (status === "new" ? "new_" : "delta_") : "";
+  if (config.folderStructure === "weekday") {
+    return [`${prefix}${weekdaySegment(eventDayDate(image, options.runDate))}`];
+  }
   const captured = image.capturedAtCorrected || image.capturedAt;
   const capturedDate = captured ? isoDate(new Date(captured)) : isoDate(options.runDate);
-
-  // Determine prefix based on status
-  let prefix = "";
-  if (options.delta && config.deltaSubfolder) {
-    prefix = status === "new" ? "new_" : "delta_";  // ← New vs Changed
-  }
-
-  // Delta/Changed + weekday combined
-  if (prefix && config.folderStructure === "weekday") {
-    const tagDate = extractDateFromTag((image as any).tags?.map(t => typeof t === "string" ? t : t.tag?.name).filter(Boolean) as string[] | undefined)
-      ?? new Date(image.capturedAtCorrected || image.capturedAt);
-    segments.push(`${prefix}${weekdaySegment(tagDate, "en-US")}`);
-  }
-  // Delta/Changed only (no weekday)
-  else if (prefix) {
-    segments.push(`${prefix}${capturedDate}`);
-  }
-  // Weekday only (no delta/changed)
-  else if (config.folderStructure === "weekday") {
-    const tagDate = extractDateFromTag((image as any).tags?.map(t => typeof t === "string" ? t : t.tag?.name).filter(Boolean) as string[] | undefined)
-      ?? new Date(image.capturedAtCorrected || image.capturedAt);
-    segments.push(weekdaySegment(tagDate, "en-US"));
-  }
-  // Group by capture date only
-  else if (config.groupByDate) {
-    segments.push(capturedDate);
-  }
-
-  return segments;
+  if (prefix) return [`${prefix}${capturedDate}`];
+  if (config.groupByDate) return [capturedDate];
+  return [];
 }
 
 function isoDate(d: Date): string {
@@ -496,9 +398,8 @@ export async function runDownload(
       emit();
       let fileBytes = 0;
       try {
-        // Status aus dem Plan holen
-        const status = plan.statuses.get(image.id)!;  // ← HIER
-        await downloadImageToDirectory(image, root, targetSegments(image, config, options, status), (p) => {  // ← status übergeben
+        const status = plan.statuses.get(image.id);
+        await downloadImageToDirectory(image, root, targetSegments(image, config, options, status), (p) => {
           fileBytes = p.received;
           progress.workers[slot] = p;
           emit();

--- a/ui/tests/downloadRunner.spec.ts
+++ b/ui/tests/downloadRunner.spec.ts
@@ -9,6 +9,8 @@ import {
   formatBytes,
   formatDuration,
   DELTA_SAFETY_MARGIN_MS,
+    extractDateFromTag,
+  weekdaySegment,
 } from "src/util/downloadRunner";
 import { DownloadConfig, Image } from "src/types/api";
 
@@ -150,5 +152,28 @@ describe("targetSegments", () => {
   it("stacks delta subfolder before the date folder", () => {
     const cfg = { ...config, deltaSubfolder: true, groupByDate: true };
     expect(targetSegments(captured, cfg, { delta: true, runDate })).toEqual(["delta_2026-07-29", "2026-07-27"]);
+  });
+});
+
+describe("extractDateFromTag / weekdaySegment", () => {
+  it("extracts YYYYMMDD from a tag", () => {
+    const tags = ["foo", "20260804", "bar"];
+    expect(extractDateFromTag(tags)?.toISOString().slice(0,10)).toBe("2026-08-04");
+  });
+  it("returns null if no date present", () => {
+    expect(extractDateFromTag(["a","b","c"])).toBeNull();
+  });
+  it("weekdaySegment returns German weekday", () => {
+    const date = new Date("2026-08-04T00:00:00Z"); // Tuesday = Dienstag
+    expect(weekdaySegment(date)).toBe("20260804 Dienstag");
+  });
+});
+
+describe("targetSegments with folderStructure = weekday", () => {
+  const runDate = new Date("2026-07-29T08:00:00Z");
+  const captured = { capturedAtCorrected: "2026-07-27T14:30:00Z", capturedAt: "2026-07-27T14:00:00Z", tags: ["20260727"] };
+  it("uses tag-derived weekday segment", () => {
+    const cfg = { ...config, folderStructure: "weekday" } as unknown as DownloadConfig;
+    expect(targetSegments(captured as any, cfg as any, { delta: false, runDate })).toEqual([ "20260727 Dienstag" ]);
   });
 });

--- a/ui/tests/downloadRunner.spec.ts
+++ b/ui/tests/downloadRunner.spec.ts
@@ -9,8 +9,10 @@ import {
   formatBytes,
   formatDuration,
   DELTA_SAFETY_MARGIN_MS,
-    extractDateFromTag,
+  extractDateFromTag,
   weekdaySegment,
+  eventDayDate,
+  reconcileLocalFiles,
 } from "src/util/downloadRunner";
 import { DownloadConfig, Image } from "src/types/api";
 
@@ -138,42 +140,178 @@ describe("targetSegments", () => {
   it("is flat by default", () => {
     expect(targetSegments(captured, config, { delta: false, runDate })).toEqual([]);
   });
-  it("adds the per-run delta subfolder only on delta runs", () => {
+  it("prefixes the capture-date folder with delta_/new_ only on delta runs", () => {
     const cfg = { ...config, deltaSubfolder: true };
-    expect(targetSegments(captured, cfg, { delta: true, runDate })).toEqual(["delta_2026-07-29"]);
-    expect(targetSegments(captured, cfg, { delta: false, runDate })).toEqual([]);
+    expect(targetSegments(captured, cfg, { delta: true, runDate }, "changed")).toEqual(["delta_2026-07-27"]);
+    expect(targetSegments(captured, cfg, { delta: true, runDate }, "new")).toEqual(["new_2026-07-27"]);
+    expect(targetSegments(captured, cfg, { delta: false, runDate }, "new")).toEqual([]);
   });
-  it("groups by corrected capture date, falling back to capturedAt", () => {
+  it("groups by corrected capture date, falling back to capturedAt, then the run date", () => {
     const cfg = { ...config, groupByDate: true };
     expect(targetSegments(captured, cfg, { delta: false, runDate })).toEqual(["2026-07-27"]);
     expect(targetSegments({ capturedAtCorrected: "", capturedAt: "2026-07-26T10:00:00Z" }, cfg, { delta: false, runDate })).toEqual(["2026-07-26"]);
-    expect(targetSegments({ capturedAtCorrected: "", capturedAt: "" }, cfg, { delta: false, runDate })).toEqual(["unknown-date"]);
-  });
-  it("stacks delta subfolder before the date folder", () => {
-    const cfg = { ...config, deltaSubfolder: true, groupByDate: true };
-    expect(targetSegments(captured, cfg, { delta: true, runDate })).toEqual(["delta_2026-07-29", "2026-07-27"]);
+    expect(targetSegments({ capturedAtCorrected: "", capturedAt: "" }, cfg, { delta: false, runDate })).toEqual(["2026-07-29"]);
   });
 });
 
-describe("extractDateFromTag / weekdaySegment", () => {
-  it("extracts YYYYMMDD from a tag", () => {
-    const tags = ["foo", "20260804", "bar"];
-    expect(extractDateFromTag(tags)?.toISOString().slice(0,10)).toBe("2026-08-04");
+describe("event-day derivation", () => {
+  const runDate = new Date("2026-07-29T08:00:00Z");
+  // local-time constructors keep these assertions timezone-independent
+  const localIso = (y: number, m: number, d: number, h: number) => new Date(y, m - 1, d, h, 30).toISOString();
+
+  it("extractDateFromTag finds YYYYMMDD inside tag text", () => {
+    const date = extractDateFromTag(["foo", "20260804", "bar"]);
+    expect(date && [date.getFullYear(), date.getMonth() + 1, date.getDate()]).toEqual([2026, 8, 4]);
   });
-  it("returns null if no date present", () => {
-    expect(extractDateFromTag(["a","b","c"])).toBeNull();
+  it("extractDateFromTag returns null when no tag carries a date", () => {
+    expect(extractDateFromTag(["a", "b", "c"])).toBeNull();
+    expect(extractDateFromTag(undefined)).toBeNull();
   });
-  it("weekdaySegment returns German weekday", () => {
-    const date = new Date("2026-08-04T00:00:00Z"); // Tuesday = Dienstag
-    expect(weekdaySegment(date)).toBe("20260804 Dienstag");
+  it("weekdaySegment renders the English weekday", () => {
+    expect(weekdaySegment(new Date(2026, 7, 4, 12))).toBe("20260804 Tuesday");
+  });
+  it("the date tag is authoritative over the capture time", () => {
+    const image = { capturedAtCorrected: localIso(2026, 7, 29, 12), capturedAt: "", tags: [{ tag: { name: "20260727" } }] };
+    expect(weekdaySegment(eventDayDate(image as any, runDate))).toBe("20260727 Monday");
+  });
+  it("captures before 04:00 belong to the previous event day", () => {
+    const night = { capturedAtCorrected: localIso(2026, 7, 28, 2), capturedAt: "", tags: [] };
+    expect(weekdaySegment(eventDayDate(night as any, runDate))).toBe("20260727 Monday");
+    const morning = { capturedAtCorrected: localIso(2026, 7, 28, 4), capturedAt: "", tags: [] };
+    expect(weekdaySegment(eventDayDate(morning as any, runDate))).toBe("20260728 Tuesday");
+  });
+  it("falls back to the run date without any capture data", () => {
+    const image = { capturedAtCorrected: "", capturedAt: "", tags: [] };
+    expect(eventDayDate(image as any, runDate)).toBe(runDate);
   });
 });
 
 describe("targetSegments with folderStructure = weekday", () => {
   const runDate = new Date("2026-07-29T08:00:00Z");
-  const captured = { capturedAtCorrected: "2026-07-27T14:30:00Z", capturedAt: "2026-07-27T14:00:00Z", tags: ["20260727"] };
-  it("uses tag-derived weekday segment", () => {
-    const cfg = { ...config, folderStructure: "weekday" } as unknown as DownloadConfig;
-    expect(targetSegments(captured as any, cfg as any, { delta: false, runDate })).toEqual([ "20260727 Dienstag" ]);
+  const cfg = { ...config, folderStructure: "weekday" } as unknown as DownloadConfig;
+  const captured = { capturedAtCorrected: "2026-07-27T14:30:00Z", capturedAt: "2026-07-27T14:00:00Z", tags: [{ tag: { name: "20260727" } }] };
+
+  it("uses the tag-derived weekday folder", () => {
+    expect(targetSegments(captured as any, cfg, { delta: false, runDate })).toEqual(["20260727 Monday"]);
+  });
+  it("prefixes the weekday folder with new_/delta_ on delta runs", () => {
+    const deltaCfg = { ...cfg, deltaSubfolder: true } as unknown as DownloadConfig;
+    expect(targetSegments(captured as any, deltaCfg, { delta: true, runDate }, "new")).toEqual(["new_20260727 Monday"]);
+    expect(targetSegments(captured as any, deltaCfg, { delta: true, runDate }, "changed")).toEqual(["delta_20260727 Monday"]);
+  });
+});
+
+// Minimal in-memory FileSystemDirectoryHandle fake — just enough surface for
+// collectExistingFileEntries / moveFileToFolder / reconcileLocalFiles.
+class FakeFile {
+  kind = "file" as const;
+  content = "x";
+  constructor(public name: string) {}
+  async getFile() {
+    const content = this.content;
+    return {
+      stream: () =>
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(content));
+            controller.close();
+          },
+        }),
+    } as unknown as File;
+  }
+  async createWritable() {
+    const chunks: Uint8Array[] = [];
+    return new WritableStream<Uint8Array>({
+      write: (chunk) => void chunks.push(chunk),
+      close: () => void (this.content = chunks.map((chunk) => new TextDecoder().decode(chunk)).join("")),
+    });
+  }
+}
+
+class FakeDir {
+  kind = "directory" as const;
+  children = new Map<string, FakeDir | FakeFile>();
+  constructor(public name: string) {}
+  async *entries() {
+    yield* this.children.entries();
+  }
+  async getFileHandle(name: string, opts?: { create?: boolean }) {
+    let child = this.children.get(name);
+    if (!child && opts?.create) {
+      child = new FakeFile(name);
+      this.children.set(name, child);
+    }
+    if (!child || child.kind !== "file") throw new Error(`no file ${name}`);
+    return child;
+  }
+  async getDirectoryHandle(name: string, opts?: { create?: boolean }) {
+    let child = this.children.get(name);
+    if (!child && opts?.create) {
+      child = new FakeDir(name);
+      this.children.set(name, child);
+    }
+    if (!child || child.kind !== "directory") throw new Error(`no directory ${name}`);
+    return child;
+  }
+  async removeEntry(name: string) {
+    this.children.delete(name);
+  }
+  addFile(name: string): FakeFile {
+    const file = new FakeFile(name);
+    this.children.set(name, file);
+    return file;
+  }
+  addDir(name: string): FakeDir {
+    const dir = new FakeDir(name);
+    this.children.set(name, dir);
+    return dir;
+  }
+}
+
+describe("reconcileLocalFiles", () => {
+  const catalog = [
+    { ...image, id: "img1", computedFileName: "FSG26_001_max" },
+    { ...image, id: "img2", computedFileName: "FSG26_002_max", imageTags: ["internal"] }, // blacklisted
+  ] as Image[];
+
+  function makeRoot(): FakeDir {
+    const root = new FakeDir("root");
+    root.addFile("FSG26_001_max.jpg"); // in catalog — stays
+    root.addFile("FSG26_gone_max.jpg"); // left the catalog — moved to deleted/
+    root.addDir("20260804 Tuesday").addFile("FSG26_002_max.jpg"); // blacklisted — moved to blacklist/, subpath kept
+    root.addDir("deleted").addFile("previously-swept.jpg"); // target dirs are never scanned
+    return root;
+  }
+
+  it("moves catalog-less files to deleted/ and blacklisted files to blacklist/, keeping subpaths", async () => {
+    const root = makeRoot();
+    const events: string[] = [];
+    const result = await reconcileLocalFiles(root as unknown as FileSystemDirectoryHandle, config, catalog, (p) => events.push(p.phase));
+
+    expect(result.deletedCount).toBe(1);
+    expect(result.blacklistedCount).toBe(1);
+    expect(result.movedFiles).toEqual([
+      { basename: "FSG26_gone_max.jpg", reason: "deleted", fromPath: "FSG26_gone_max.jpg", toPath: "deleted/FSG26_gone_max.jpg" },
+      { basename: "FSG26_002_max.jpg", reason: "blacklisted", fromPath: "20260804 Tuesday/FSG26_002_max.jpg", toPath: "blacklist/20260804 Tuesday/FSG26_002_max.jpg" },
+    ]);
+    expect(events[0]).toBe("scanning");
+    expect(events[events.length - 1]).toBe("finished");
+
+    // moved, not deleted — originals gone, copies present with content intact
+    expect(root.children.has("FSG26_gone_max.jpg")).toBe(false);
+    const deletedDir = root.children.get("deleted") as FakeDir;
+    expect((deletedDir.children.get("FSG26_gone_max.jpg") as FakeFile).content).toBe("x");
+    expect(deletedDir.children.has("previously-swept.jpg")).toBe(true);
+    const blacklistDay = (root.children.get("blacklist") as FakeDir).children.get("20260804 Tuesday") as FakeDir;
+    expect(blacklistDay.children.has("FSG26_002_max.jpg")).toBe(true);
+    expect((root.children.get("20260804 Tuesday") as FakeDir).children.size).toBe(0);
+    expect(root.children.has("FSG26_001_max.jpg")).toBe(true);
+  });
+
+  it("is idempotent — a second run moves nothing", async () => {
+    const root = makeRoot();
+    await reconcileLocalFiles(root as unknown as FileSystemDirectoryHandle, config, catalog);
+    const second = await reconcileLocalFiles(root as unknown as FileSystemDirectoryHandle, config, catalog);
+    expect(second.movedFiles).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Improves the download workflow by adding local file reconciliation, sync progress feedback, and configurable folder structures.

## Changes

- Add local file reconciliation before or after synchronization.
- Move files that no longer exist in the image catalog to:
  ```text
  deleted/
  ```
- Move blacklisted files to:
  ```text
  blacklist/
  ```
- Add a download progress bar showing the current synchronization progress.
- Add a synchronization summary log after the download run completes.
- Add configurable download folder structures:
  - No additional folder.
  - Capture-date folder.
  - Weekday folder.
- Add date and weekday folder names, for example:
  ```text
  20260804 Tuesday/
  ```
- Persist the selected download structure in the download configuration.
- Add tests for folder structure selection and local file reconciliation.

## Examples

### Date and weekday structure

```text
20260804 Tuesday/
└── FSG26_001_max.jpg
```

### Deleted files

```text
deleted/
└── image-no-longer-in-catalog.jpg
```

### Blacklisted files

```text
blacklist/
└── internal-image.jpg
```

## Synchronization result

After synchronization, the user receives a summary containing:

- Number of files moved to `deleted`.
- Number of files moved to `blacklist`.
- Overall synchronization progress.

## Conventional commit

```text
feat(download): add sync reconciliation and download structure
```