### PR TITLE
feat(exif): project-wide copyright tag prefix rendered at EXIF export

### DIFF
--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -396,7 +396,7 @@ var (
 		{Name: "description", Type: field.TypeString},
 		{Name: "copyright", Type: field.TypeString},
 		{Name: "copyright_reference", Type: field.TypeString},
-		{Name: "copyright_tag_prefix", Type: field.TypeString, Nullable: true},
+		{Name: "copyright_tag_prefix", Type: field.TypeString, Nullable: true, Size: 20},
 		{Name: "location_name", Type: field.TypeString},
 		{Name: "location_code", Type: field.TypeString},
 		{Name: "location_city", Type: field.TypeString},

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -396,6 +396,7 @@ var (
 		{Name: "description", Type: field.TypeString},
 		{Name: "copyright", Type: field.TypeString},
 		{Name: "copyright_reference", Type: field.TypeString},
+		{Name: "copyright_tag_prefix", Type: field.TypeString, Nullable: true},
 		{Name: "location_name", Type: field.TypeString},
 		{Name: "location_code", Type: field.TypeString},
 		{Name: "location_city", Type: field.TypeString},

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -9149,6 +9149,7 @@ type ProjectMutation struct {
 	description               *string
 	copyright                 *string
 	copyrightReference        *string
+	copyrightTagPrefix        *string
 	locationName              *string
 	locationCode              *string
 	locationCity              *string
@@ -9599,6 +9600,55 @@ func (m *ProjectMutation) OldCopyrightReference(ctx context.Context) (v string, 
 // ResetCopyrightReference resets all changes to the "copyrightReference" field.
 func (m *ProjectMutation) ResetCopyrightReference() {
 	m.copyrightReference = nil
+}
+
+// SetCopyrightTagPrefix sets the "copyrightTagPrefix" field.
+func (m *ProjectMutation) SetCopyrightTagPrefix(s string) {
+	m.copyrightTagPrefix = &s
+}
+
+// CopyrightTagPrefix returns the value of the "copyrightTagPrefix" field in the mutation.
+func (m *ProjectMutation) CopyrightTagPrefix() (r string, exists bool) {
+	v := m.copyrightTagPrefix
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCopyrightTagPrefix returns the old "copyrightTagPrefix" field's value of the Project entity.
+// If the Project object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ProjectMutation) OldCopyrightTagPrefix(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCopyrightTagPrefix is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCopyrightTagPrefix requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCopyrightTagPrefix: %w", err)
+	}
+	return oldValue.CopyrightTagPrefix, nil
+}
+
+// ClearCopyrightTagPrefix clears the value of the "copyrightTagPrefix" field.
+func (m *ProjectMutation) ClearCopyrightTagPrefix() {
+	m.copyrightTagPrefix = nil
+	m.clearedFields[project.FieldCopyrightTagPrefix] = struct{}{}
+}
+
+// CopyrightTagPrefixCleared returns if the "copyrightTagPrefix" field was cleared in this mutation.
+func (m *ProjectMutation) CopyrightTagPrefixCleared() bool {
+	_, ok := m.clearedFields[project.FieldCopyrightTagPrefix]
+	return ok
+}
+
+// ResetCopyrightTagPrefix resets all changes to the "copyrightTagPrefix" field.
+func (m *ProjectMutation) ResetCopyrightTagPrefix() {
+	m.copyrightTagPrefix = nil
+	delete(m.clearedFields, project.FieldCopyrightTagPrefix)
 }
 
 // SetLocationName sets the "locationName" field.
@@ -10304,7 +10354,7 @@ func (m *ProjectMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ProjectMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 16)
 	if m.createdAt != nil {
 		fields = append(fields, project.FieldCreatedAt)
 	}
@@ -10328,6 +10378,9 @@ func (m *ProjectMutation) Fields() []string {
 	}
 	if m.copyrightReference != nil {
 		fields = append(fields, project.FieldCopyrightReference)
+	}
+	if m.copyrightTagPrefix != nil {
+		fields = append(fields, project.FieldCopyrightTagPrefix)
 	}
 	if m.locationName != nil {
 		fields = append(fields, project.FieldLocationName)
@@ -10374,6 +10427,8 @@ func (m *ProjectMutation) Field(name string) (ent.Value, bool) {
 		return m.Copyright()
 	case project.FieldCopyrightReference:
 		return m.CopyrightReference()
+	case project.FieldCopyrightTagPrefix:
+		return m.CopyrightTagPrefix()
 	case project.FieldLocationName:
 		return m.LocationName()
 	case project.FieldLocationCode:
@@ -10413,6 +10468,8 @@ func (m *ProjectMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldCopyright(ctx)
 	case project.FieldCopyrightReference:
 		return m.OldCopyrightReference(ctx)
+	case project.FieldCopyrightTagPrefix:
+		return m.OldCopyrightTagPrefix(ctx)
 	case project.FieldLocationName:
 		return m.OldLocationName(ctx)
 	case project.FieldLocationCode:
@@ -10491,6 +10548,13 @@ func (m *ProjectMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetCopyrightReference(v)
+		return nil
+	case project.FieldCopyrightTagPrefix:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCopyrightTagPrefix(v)
 		return nil
 	case project.FieldLocationName:
 		v, ok := value.(string)
@@ -10577,6 +10641,9 @@ func (m *ProjectMutation) ClearedFields() []string {
 	if m.FieldCleared(project.FieldUpdatedBy) {
 		fields = append(fields, project.FieldUpdatedBy)
 	}
+	if m.FieldCleared(project.FieldCopyrightTagPrefix) {
+		fields = append(fields, project.FieldCopyrightTagPrefix)
+	}
 	if m.FieldCleared(project.FieldAiSystemMessage) {
 		fields = append(fields, project.FieldAiSystemMessage)
 	}
@@ -10605,6 +10672,9 @@ func (m *ProjectMutation) ClearField(name string) error {
 		return nil
 	case project.FieldUpdatedBy:
 		m.ClearUpdatedBy()
+		return nil
+	case project.FieldCopyrightTagPrefix:
+		m.ClearCopyrightTagPrefix()
 		return nil
 	case project.FieldAiSystemMessage:
 		m.ClearAiSystemMessage()
@@ -10646,6 +10716,9 @@ func (m *ProjectMutation) ResetField(name string) error {
 		return nil
 	case project.FieldCopyrightReference:
 		m.ResetCopyrightReference()
+		return nil
+	case project.FieldCopyrightTagPrefix:
+		m.ResetCopyrightTagPrefix()
 		return nil
 	case project.FieldLocationName:
 		m.ResetLocationName()

--- a/api/ent/project.go
+++ b/api/ent/project.go
@@ -34,6 +34,8 @@ type Project struct {
 	Copyright string `json:"copyright"`
 	// CopyrightReference holds the value of the "copyrightReference" field.
 	CopyrightReference string `json:"copyrightReference"`
+	// CopyrightTagPrefix holds the value of the "copyrightTagPrefix" field.
+	CopyrightTagPrefix string `json:"copyrightTagPrefix"`
 	// LocationName holds the value of the "locationName" field.
 	LocationName string `json:"locationName"`
 	// LocationCode holds the value of the "locationCode" field.
@@ -147,7 +149,7 @@ func (*Project) scanValues(columns []string) ([]any, error) {
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		case project.FieldUploadReviewEnabled:
 			values[i] = new(sql.NullBool)
-		case project.FieldID, project.FieldName, project.FieldDescription, project.FieldCopyright, project.FieldCopyrightReference, project.FieldLocationName, project.FieldLocationCode, project.FieldLocationCity, project.FieldAiSystemMessage:
+		case project.FieldID, project.FieldName, project.FieldDescription, project.FieldCopyright, project.FieldCopyrightReference, project.FieldCopyrightTagPrefix, project.FieldLocationName, project.FieldLocationCode, project.FieldLocationCity, project.FieldAiSystemMessage:
 			values[i] = new(sql.NullString)
 		case project.FieldCreatedAt, project.FieldUpdatedAt, project.FieldStartAt, project.FieldEndAt:
 			values[i] = new(sql.NullTime)
@@ -221,6 +223,12 @@ func (_m *Project) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field copyrightReference", values[i])
 			} else if value.Valid {
 				_m.CopyrightReference = value.String
+			}
+		case project.FieldCopyrightTagPrefix:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field copyrightTagPrefix", values[i])
+			} else if value.Valid {
+				_m.CopyrightTagPrefix = value.String
 			}
 		case project.FieldLocationName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -364,6 +372,9 @@ func (_m *Project) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("copyrightReference=")
 	builder.WriteString(_m.CopyrightReference)
+	builder.WriteString(", ")
+	builder.WriteString("copyrightTagPrefix=")
+	builder.WriteString(_m.CopyrightTagPrefix)
 	builder.WriteString(", ")
 	builder.WriteString("locationName=")
 	builder.WriteString(_m.LocationName)

--- a/api/ent/project/project.go
+++ b/api/ent/project/project.go
@@ -159,6 +159,8 @@ var (
 	CopyrightValidator func(string) error
 	// CopyrightReferenceValidator is a validator for the "copyrightReference" field. It is called by the builders before save.
 	CopyrightReferenceValidator func(string) error
+	// CopyrightTagPrefixValidator is a validator for the "copyrightTagPrefix" field. It is called by the builders before save.
+	CopyrightTagPrefixValidator func(string) error
 	// LocationNameValidator is a validator for the "locationName" field. It is called by the builders before save.
 	LocationNameValidator func(string) error
 	// LocationCodeValidator is a validator for the "locationCode" field. It is called by the builders before save.

--- a/api/ent/project/project.go
+++ b/api/ent/project/project.go
@@ -30,6 +30,8 @@ const (
 	FieldCopyright = "copyright"
 	// FieldCopyrightReference holds the string denoting the copyrightreference field in the database.
 	FieldCopyrightReference = "copyright_reference"
+	// FieldCopyrightTagPrefix holds the string denoting the copyrighttagprefix field in the database.
+	FieldCopyrightTagPrefix = "copyright_tag_prefix"
 	// FieldLocationName holds the string denoting the locationname field in the database.
 	FieldLocationName = "location_name"
 	// FieldLocationCode holds the string denoting the locationcode field in the database.
@@ -122,6 +124,7 @@ var Columns = []string{
 	FieldDescription,
 	FieldCopyright,
 	FieldCopyrightReference,
+	FieldCopyrightTagPrefix,
 	FieldLocationName,
 	FieldLocationCode,
 	FieldLocationCity,
@@ -216,6 +219,11 @@ func ByCopyright(opts ...sql.OrderTermOption) OrderOption {
 // ByCopyrightReference orders the results by the copyrightReference field.
 func ByCopyrightReference(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCopyrightReference, opts...).ToFunc()
+}
+
+// ByCopyrightTagPrefix orders the results by the copyrightTagPrefix field.
+func ByCopyrightTagPrefix(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCopyrightTagPrefix, opts...).ToFunc()
 }
 
 // ByLocationName orders the results by the locationName field.

--- a/api/ent/project/where.go
+++ b/api/ent/project/where.go
@@ -106,6 +106,11 @@ func CopyrightReference(v string) predicate.Project {
 	return predicate.Project(sql.FieldEQ(FieldCopyrightReference, v))
 }
 
+// CopyrightTagPrefix applies equality check predicate on the "copyrightTagPrefix" field. It's identical to CopyrightTagPrefixEQ.
+func CopyrightTagPrefix(v string) predicate.Project {
+	return predicate.Project(sql.FieldEQ(FieldCopyrightTagPrefix, v))
+}
+
 // LocationName applies equality check predicate on the "locationName" field. It's identical to LocationNameEQ.
 func LocationName(v string) predicate.Project {
 	return predicate.Project(sql.FieldEQ(FieldLocationName, v))
@@ -579,6 +584,81 @@ func CopyrightReferenceEqualFold(v string) predicate.Project {
 // CopyrightReferenceContainsFold applies the ContainsFold predicate on the "copyrightReference" field.
 func CopyrightReferenceContainsFold(v string) predicate.Project {
 	return predicate.Project(sql.FieldContainsFold(FieldCopyrightReference, v))
+}
+
+// CopyrightTagPrefixEQ applies the EQ predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixEQ(v string) predicate.Project {
+	return predicate.Project(sql.FieldEQ(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixNEQ applies the NEQ predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixNEQ(v string) predicate.Project {
+	return predicate.Project(sql.FieldNEQ(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixIn applies the In predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixIn(vs ...string) predicate.Project {
+	return predicate.Project(sql.FieldIn(FieldCopyrightTagPrefix, vs...))
+}
+
+// CopyrightTagPrefixNotIn applies the NotIn predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixNotIn(vs ...string) predicate.Project {
+	return predicate.Project(sql.FieldNotIn(FieldCopyrightTagPrefix, vs...))
+}
+
+// CopyrightTagPrefixGT applies the GT predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixGT(v string) predicate.Project {
+	return predicate.Project(sql.FieldGT(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixGTE applies the GTE predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixGTE(v string) predicate.Project {
+	return predicate.Project(sql.FieldGTE(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixLT applies the LT predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixLT(v string) predicate.Project {
+	return predicate.Project(sql.FieldLT(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixLTE applies the LTE predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixLTE(v string) predicate.Project {
+	return predicate.Project(sql.FieldLTE(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixContains applies the Contains predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixContains(v string) predicate.Project {
+	return predicate.Project(sql.FieldContains(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixHasPrefix applies the HasPrefix predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixHasPrefix(v string) predicate.Project {
+	return predicate.Project(sql.FieldHasPrefix(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixHasSuffix applies the HasSuffix predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixHasSuffix(v string) predicate.Project {
+	return predicate.Project(sql.FieldHasSuffix(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixIsNil applies the IsNil predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixIsNil() predicate.Project {
+	return predicate.Project(sql.FieldIsNull(FieldCopyrightTagPrefix))
+}
+
+// CopyrightTagPrefixNotNil applies the NotNil predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixNotNil() predicate.Project {
+	return predicate.Project(sql.FieldNotNull(FieldCopyrightTagPrefix))
+}
+
+// CopyrightTagPrefixEqualFold applies the EqualFold predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixEqualFold(v string) predicate.Project {
+	return predicate.Project(sql.FieldEqualFold(FieldCopyrightTagPrefix, v))
+}
+
+// CopyrightTagPrefixContainsFold applies the ContainsFold predicate on the "copyrightTagPrefix" field.
+func CopyrightTagPrefixContainsFold(v string) predicate.Project {
+	return predicate.Project(sql.FieldContainsFold(FieldCopyrightTagPrefix, v))
 }
 
 // LocationNameEQ applies the EQ predicate on the "locationName" field.

--- a/api/ent/project_create.go
+++ b/api/ent/project_create.go
@@ -108,6 +108,20 @@ func (_c *ProjectCreate) SetCopyrightReference(v string) *ProjectCreate {
 	return _c
 }
 
+// SetCopyrightTagPrefix sets the "copyrightTagPrefix" field.
+func (_c *ProjectCreate) SetCopyrightTagPrefix(v string) *ProjectCreate {
+	_c.mutation.SetCopyrightTagPrefix(v)
+	return _c
+}
+
+// SetNillableCopyrightTagPrefix sets the "copyrightTagPrefix" field if the given value is not nil.
+func (_c *ProjectCreate) SetNillableCopyrightTagPrefix(v *string) *ProjectCreate {
+	if v != nil {
+		_c.SetCopyrightTagPrefix(*v)
+	}
+	return _c
+}
+
 // SetLocationName sets the "locationName" field.
 func (_c *ProjectCreate) SetLocationName(v string) *ProjectCreate {
 	_c.mutation.SetLocationName(v)
@@ -492,6 +506,10 @@ func (_c *ProjectCreate) createSpec() (*Project, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.CopyrightReference(); ok {
 		_spec.SetField(project.FieldCopyrightReference, field.TypeString, value)
 		_node.CopyrightReference = value
+	}
+	if value, ok := _c.mutation.CopyrightTagPrefix(); ok {
+		_spec.SetField(project.FieldCopyrightTagPrefix, field.TypeString, value)
+		_node.CopyrightTagPrefix = value
 	}
 	if value, ok := _c.mutation.LocationName(); ok {
 		_spec.SetField(project.FieldLocationName, field.TypeString, value)

--- a/api/ent/project_create.go
+++ b/api/ent/project_create.go
@@ -408,6 +408,11 @@ func (_c *ProjectCreate) check() error {
 			return &ValidationError{Name: "copyrightReference", err: fmt.Errorf(`ent: validator failed for field "Project.copyrightReference": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.CopyrightTagPrefix(); ok {
+		if err := project.CopyrightTagPrefixValidator(v); err != nil {
+			return &ValidationError{Name: "copyrightTagPrefix", err: fmt.Errorf(`ent: validator failed for field "Project.copyrightTagPrefix": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.LocationName(); !ok {
 		return &ValidationError{Name: "locationName", err: errors.New(`ent: missing required field "Project.locationName"`)}
 	}

--- a/api/ent/project_update.go
+++ b/api/ent/project_update.go
@@ -118,6 +118,26 @@ func (_u *ProjectUpdate) SetNillableCopyrightReference(v *string) *ProjectUpdate
 	return _u
 }
 
+// SetCopyrightTagPrefix sets the "copyrightTagPrefix" field.
+func (_u *ProjectUpdate) SetCopyrightTagPrefix(v string) *ProjectUpdate {
+	_u.mutation.SetCopyrightTagPrefix(v)
+	return _u
+}
+
+// SetNillableCopyrightTagPrefix sets the "copyrightTagPrefix" field if the given value is not nil.
+func (_u *ProjectUpdate) SetNillableCopyrightTagPrefix(v *string) *ProjectUpdate {
+	if v != nil {
+		_u.SetCopyrightTagPrefix(*v)
+	}
+	return _u
+}
+
+// ClearCopyrightTagPrefix clears the value of the "copyrightTagPrefix" field.
+func (_u *ProjectUpdate) ClearCopyrightTagPrefix() *ProjectUpdate {
+	_u.mutation.ClearCopyrightTagPrefix()
+	return _u
+}
+
 // SetLocationName sets the "locationName" field.
 func (_u *ProjectUpdate) SetLocationName(v string) *ProjectUpdate {
 	_u.mutation.SetLocationName(v)
@@ -603,6 +623,12 @@ func (_u *ProjectUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.CopyrightReference(); ok {
 		_spec.SetField(project.FieldCopyrightReference, field.TypeString, value)
 	}
+	if value, ok := _u.mutation.CopyrightTagPrefix(); ok {
+		_spec.SetField(project.FieldCopyrightTagPrefix, field.TypeString, value)
+	}
+	if _u.mutation.CopyrightTagPrefixCleared() {
+		_spec.ClearField(project.FieldCopyrightTagPrefix, field.TypeString)
+	}
 	if value, ok := _u.mutation.LocationName(); ok {
 		_spec.SetField(project.FieldLocationName, field.TypeString, value)
 	}
@@ -1047,6 +1073,26 @@ func (_u *ProjectUpdateOne) SetNillableCopyrightReference(v *string) *ProjectUpd
 	if v != nil {
 		_u.SetCopyrightReference(*v)
 	}
+	return _u
+}
+
+// SetCopyrightTagPrefix sets the "copyrightTagPrefix" field.
+func (_u *ProjectUpdateOne) SetCopyrightTagPrefix(v string) *ProjectUpdateOne {
+	_u.mutation.SetCopyrightTagPrefix(v)
+	return _u
+}
+
+// SetNillableCopyrightTagPrefix sets the "copyrightTagPrefix" field if the given value is not nil.
+func (_u *ProjectUpdateOne) SetNillableCopyrightTagPrefix(v *string) *ProjectUpdateOne {
+	if v != nil {
+		_u.SetCopyrightTagPrefix(*v)
+	}
+	return _u
+}
+
+// ClearCopyrightTagPrefix clears the value of the "copyrightTagPrefix" field.
+func (_u *ProjectUpdateOne) ClearCopyrightTagPrefix() *ProjectUpdateOne {
+	_u.mutation.ClearCopyrightTagPrefix()
 	return _u
 }
 
@@ -1564,6 +1610,12 @@ func (_u *ProjectUpdateOne) sqlSave(ctx context.Context) (_node *Project, err er
 	}
 	if value, ok := _u.mutation.CopyrightReference(); ok {
 		_spec.SetField(project.FieldCopyrightReference, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.CopyrightTagPrefix(); ok {
+		_spec.SetField(project.FieldCopyrightTagPrefix, field.TypeString, value)
+	}
+	if _u.mutation.CopyrightTagPrefixCleared() {
+		_spec.ClearField(project.FieldCopyrightTagPrefix, field.TypeString)
 	}
 	if value, ok := _u.mutation.LocationName(); ok {
 		_spec.SetField(project.FieldLocationName, field.TypeString, value)

--- a/api/ent/project_update.go
+++ b/api/ent/project_update.go
@@ -569,6 +569,11 @@ func (_u *ProjectUpdate) check() error {
 			return &ValidationError{Name: "copyrightReference", err: fmt.Errorf(`ent: validator failed for field "Project.copyrightReference": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.CopyrightTagPrefix(); ok {
+		if err := project.CopyrightTagPrefixValidator(v); err != nil {
+			return &ValidationError{Name: "copyrightTagPrefix", err: fmt.Errorf(`ent: validator failed for field "Project.copyrightTagPrefix": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.LocationName(); ok {
 		if err := project.LocationNameValidator(v); err != nil {
 			return &ValidationError{Name: "locationName", err: fmt.Errorf(`ent: validator failed for field "Project.locationName": %w`, err)}
@@ -1538,6 +1543,11 @@ func (_u *ProjectUpdateOne) check() error {
 	if v, ok := _u.mutation.CopyrightReference(); ok {
 		if err := project.CopyrightReferenceValidator(v); err != nil {
 			return &ValidationError{Name: "copyrightReference", err: fmt.Errorf(`ent: validator failed for field "Project.copyrightReference": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.CopyrightTagPrefix(); ok {
+		if err := project.CopyrightTagPrefixValidator(v); err != nil {
+			return &ValidationError{Name: "copyrightTagPrefix", err: fmt.Errorf(`ent: validator failed for field "Project.copyrightTagPrefix": %w`, err)}
 		}
 	}
 	if v, ok := _u.mutation.LocationName(); ok {

--- a/api/ent/runtime.go
+++ b/api/ent/runtime.go
@@ -360,19 +360,19 @@ func init() {
 	// project.CopyrightReferenceValidator is a validator for the "copyrightReference" field. It is called by the builders before save.
 	project.CopyrightReferenceValidator = projectDescCopyrightReference.Validators[0].(func(string) error)
 	// projectDescLocationName is the schema descriptor for locationName field.
-	projectDescLocationName := projectFields[4].Descriptor()
+	projectDescLocationName := projectFields[5].Descriptor()
 	// project.LocationNameValidator is a validator for the "locationName" field. It is called by the builders before save.
 	project.LocationNameValidator = projectDescLocationName.Validators[0].(func(string) error)
 	// projectDescLocationCode is the schema descriptor for locationCode field.
-	projectDescLocationCode := projectFields[5].Descriptor()
+	projectDescLocationCode := projectFields[6].Descriptor()
 	// project.LocationCodeValidator is a validator for the "locationCode" field. It is called by the builders before save.
 	project.LocationCodeValidator = projectDescLocationCode.Validators[0].(func(string) error)
 	// projectDescLocationCity is the schema descriptor for locationCity field.
-	projectDescLocationCity := projectFields[6].Descriptor()
+	projectDescLocationCity := projectFields[7].Descriptor()
 	// project.LocationCityValidator is a validator for the "locationCity" field. It is called by the builders before save.
 	project.LocationCityValidator = projectDescLocationCity.Validators[0].(func(string) error)
 	// projectDescUploadReviewEnabled is the schema descriptor for uploadReviewEnabled field.
-	projectDescUploadReviewEnabled := projectFields[8].Descriptor()
+	projectDescUploadReviewEnabled := projectFields[9].Descriptor()
 	// project.DefaultUploadReviewEnabled holds the default value on creation for the uploadReviewEnabled field.
 	project.DefaultUploadReviewEnabled = projectDescUploadReviewEnabled.Default.(bool)
 	// projectDescID is the schema descriptor for id field.

--- a/api/ent/runtime.go
+++ b/api/ent/runtime.go
@@ -359,6 +359,10 @@ func init() {
 	projectDescCopyrightReference := projectFields[3].Descriptor()
 	// project.CopyrightReferenceValidator is a validator for the "copyrightReference" field. It is called by the builders before save.
 	project.CopyrightReferenceValidator = projectDescCopyrightReference.Validators[0].(func(string) error)
+	// projectDescCopyrightTagPrefix is the schema descriptor for copyrightTagPrefix field.
+	projectDescCopyrightTagPrefix := projectFields[4].Descriptor()
+	// project.CopyrightTagPrefixValidator is a validator for the "copyrightTagPrefix" field. It is called by the builders before save.
+	project.CopyrightTagPrefixValidator = projectDescCopyrightTagPrefix.Validators[0].(func(string) error)
 	// projectDescLocationName is the schema descriptor for locationName field.
 	projectDescLocationName := projectFields[5].Descriptor()
 	// project.LocationNameValidator is a validator for the "locationName" field. It is called by the builders before save.

--- a/api/ent/schema/project.go
+++ b/api/ent/schema/project.go
@@ -19,6 +19,9 @@ func (Project) Fields() []ent.Field {
 		field.String("description").NotEmpty().StructTag(`json:"description"`),
 		field.String("copyright").NotEmpty().StructTag(`json:"copyright"`),
 		field.String("copyrightReference").NotEmpty().StructTag(`json:"copyrightReference"`),
+		// Prepended to copyright-tag-derived values at EXIF export only (e.g. "by_");
+		// normal tag handling shows the tag without the prefix.
+		field.String("copyrightTagPrefix").Optional().StructTag(`json:"copyrightTagPrefix"`),
 		field.String("locationName").NotEmpty().StructTag(`json:"locationName"`),
 		field.String("locationCode").NotEmpty().StructTag(`json:"locationCode"`),
 		field.String("locationCity").NotEmpty().StructTag(`json:"locationCity"`),

--- a/api/ent/schema/project.go
+++ b/api/ent/schema/project.go
@@ -20,8 +20,10 @@ func (Project) Fields() []ent.Field {
 		field.String("copyright").NotEmpty().StructTag(`json:"copyright"`),
 		field.String("copyrightReference").NotEmpty().StructTag(`json:"copyrightReference"`),
 		// Prepended to copyright-tag-derived values at EXIF export only (e.g. "by_");
-		// normal tag handling shows the tag without the prefix.
-		field.String("copyrightTagPrefix").Optional().StructTag(`json:"copyrightTagPrefix"`),
+		// normal tag handling shows the tag without the prefix. MaxLen keeps the
+		// combined By-lineTitle within reach of the 32-byte IPTC-IIM cap and maps
+		// oversized input to a clean 400 (same pattern as the #90 name cap).
+		field.String("copyrightTagPrefix").MaxLen(20).Optional().StructTag(`json:"copyrightTagPrefix"`),
 		field.String("locationName").NotEmpty().StructTag(`json:"locationName"`),
 		field.String("locationCode").NotEmpty().StructTag(`json:"locationCode"`),
 		field.String("locationCity").NotEmpty().StructTag(`json:"locationCity"`),

--- a/api/internal/exif/inject.go
+++ b/api/internal/exif/inject.go
@@ -116,16 +116,36 @@ func buildMetadata(image *ent.Image) map[string]any {
 		}
 		tags = append(tags, tag)
 	}
+	// The copyright-tag prefix (e.g. "by_") is an EXIF-render-time concern only:
+	// the photographer's copyright tag lives unprefixed in the DB and UI, and only
+	// keywords derived from it (the $COPYRIGHT default tag carries the uploader's
+	// copyrightTag as its name) get prefixed here.
+	prefix := ""
+	if p := image.Edges.Project; p != nil {
+		prefix = p.CopyrightTagPrefix
+	}
+	copyrightTag := ""
+	if u := image.Edges.User; u != nil {
+		copyrightTag = u.CopyrightTag
+	}
 	keywords := make([]string, 0, len(tags))
 	for _, tag := range sortTagsByOrder(tags) {
-		keywords = append(keywords, tag.Name)
+		name := tag.Name
+		if prefix != "" && copyrightTag != "" && name == copyrightTag {
+			name = prefix + name
+		}
+		keywords = append(keywords, name)
 	}
 	m["EXIF:XPKeywords"] = keywords
 	m["IPTC:Keywords"] = keywords
 
 	if u := image.Edges.User; u != nil {
 		fullName := fmt.Sprintf("%s %s", u.FirstName, u.LastName)
-		m["IPTC:By-lineTitle"] = u.CopyrightTag
+		byLineTitle := u.CopyrightTag
+		if byLineTitle != "" {
+			byLineTitle = prefix + byLineTitle
+		}
+		m["IPTC:By-lineTitle"] = byLineTitle
 		m["IPTC:By-line"] = fullName
 		m["EXIF:Artist"] = fullName
 		m["IPTC:Writer-Editor"] = fullName

--- a/api/internal/exif/inject.go
+++ b/api/internal/exif/inject.go
@@ -142,7 +142,7 @@ func buildMetadata(image *ent.Image) map[string]any {
 	if u := image.Edges.User; u != nil {
 		fullName := fmt.Sprintf("%s %s", u.FirstName, u.LastName)
 		byLineTitle := u.CopyrightTag
-		if byLineTitle != "" {
+		if prefix != "" && byLineTitle != "" {
 			byLineTitle = prefix + byLineTitle
 		}
 		m["IPTC:By-lineTitle"] = byLineTitle

--- a/api/internal/exif/inject_test.go
+++ b/api/internal/exif/inject_test.go
@@ -76,6 +76,42 @@ func TestBuildMetadataCopyrightTagPrefix(t *testing.T) {
 	}
 }
 
+func TestBuildMetadataPrefixWithEmptyCopyrightTag(t *testing.T) {
+	image := &ent.Image{
+		Edges: ent.ImageEdges{
+			User:    &ent.User{CopyrightTag: ""},
+			Project: &ent.Project{CopyrightTagPrefix: "by_"},
+			ImageTagAssignments: []*ent.ImageTagAssignment{
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("autocross", imagetag.TypeManual, intPtr(1))}},
+			},
+		},
+	}
+	m := buildMetadata(image)
+	if !reflect.DeepEqual(m["IPTC:Keywords"], []string{"autocross"}) {
+		t.Fatalf("IPTC:Keywords = %v, want [autocross]", m["IPTC:Keywords"])
+	}
+	if m["IPTC:By-lineTitle"] != "" {
+		t.Fatalf("By-lineTitle = %v, want empty (a bare prefix must never render)", m["IPTC:By-lineTitle"])
+	}
+}
+
+func TestBuildMetadataPrefixWithoutEdges(t *testing.T) {
+	image := &ent.Image{
+		Edges: ent.ImageEdges{
+			ImageTagAssignments: []*ent.ImageTagAssignment{
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("autocross", imagetag.TypeManual, intPtr(1))}},
+			},
+		},
+	}
+	m := buildMetadata(image)
+	if !reflect.DeepEqual(m["IPTC:Keywords"], []string{"autocross"}) {
+		t.Fatalf("IPTC:Keywords = %v, want [autocross]", m["IPTC:Keywords"])
+	}
+	if _, ok := m["IPTC:By-lineTitle"]; ok {
+		t.Fatal("By-lineTitle must be absent without a User edge")
+	}
+}
+
 func TestBuildMetadataNoPrefixLeavesTagsUntouched(t *testing.T) {
 	image := &ent.Image{
 		Edges: ent.ImageEdges{

--- a/api/internal/exif/inject_test.go
+++ b/api/internal/exif/inject_test.go
@@ -54,3 +54,43 @@ func TestBuildMetadataKeywordsRespectOrder(t *testing.T) {
 		t.Fatalf("IPTC:Keywords = %v, want %v", m["IPTC:Keywords"], want)
 	}
 }
+
+func TestBuildMetadataCopyrightTagPrefix(t *testing.T) {
+	image := &ent.Image{
+		Edges: ent.ImageEdges{
+			User:    &ent.User{FirstName: "Max", LastName: "Mustermann", CopyrightTag: "mm"},
+			Project: &ent.Project{CopyrightTagPrefix: "by_"},
+			ImageTagAssignments: []*ent.ImageTagAssignment{
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("mm", imagetag.TypeDefault, intPtr(1))}},
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("autocross", imagetag.TypeManual, intPtr(2))}},
+			},
+		},
+	}
+	m := buildMetadata(image)
+	want := []string{"by_mm", "autocross"}
+	if !reflect.DeepEqual(m["IPTC:Keywords"], want) {
+		t.Fatalf("IPTC:Keywords = %v, want %v", m["IPTC:Keywords"], want)
+	}
+	if m["IPTC:By-lineTitle"] != "by_mm" {
+		t.Fatalf("By-lineTitle = %v, want by_mm", m["IPTC:By-lineTitle"])
+	}
+}
+
+func TestBuildMetadataNoPrefixLeavesTagsUntouched(t *testing.T) {
+	image := &ent.Image{
+		Edges: ent.ImageEdges{
+			User:    &ent.User{CopyrightTag: "mm"},
+			Project: &ent.Project{},
+			ImageTagAssignments: []*ent.ImageTagAssignment{
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("mm", imagetag.TypeDefault, intPtr(1))}},
+			},
+		},
+	}
+	m := buildMetadata(image)
+	if !reflect.DeepEqual(m["IPTC:Keywords"], []string{"mm"}) {
+		t.Fatalf("IPTC:Keywords = %v, want [mm]", m["IPTC:Keywords"])
+	}
+	if m["IPTC:By-lineTitle"] != "mm" {
+		t.Fatalf("By-lineTitle = %v, want mm", m["IPTC:By-lineTitle"])
+	}
+}

--- a/api/internal/repository/project.go
+++ b/api/internal/repository/project.go
@@ -85,6 +85,7 @@ type CreateProjectParameters struct {
 	Description         string
 	Copyright           string
 	CopyrightReference  string
+	CopyrightTagPrefix  *string
 	LocationName        string
 	LocationCode        string
 	LocationCity        string
@@ -113,6 +114,9 @@ func (r *Repository) CreateProject(ctx context.Context, parameters *CreateProjec
 	if parameters.AiSystemMessage != nil {
 		create = create.SetAiSystemMessage(*parameters.AiSystemMessage)
 	}
+	if parameters.CopyrightTagPrefix != nil {
+		create = create.SetCopyrightTagPrefix(*parameters.CopyrightTagPrefix)
+	}
 	if parameters.StartAt != nil && !parameters.StartAt.IsZero() {
 		create = create.SetStartAt(*parameters.StartAt)
 	}
@@ -138,6 +142,7 @@ type UpdateProjectParameters struct {
 	Description         *string
 	Copyright           *string
 	CopyrightReference  *string
+	CopyrightTagPrefix  *string
 	LocationName        *string
 	LocationCode        *string
 	LocationCity        *string
@@ -180,6 +185,10 @@ func (r *Repository) UpdateProject(ctx context.Context, id string, parameters *U
 	if parameters.CopyrightReference != nil && item.CopyrightReference != *parameters.CopyrightReference {
 		update.SetCopyrightReference(*parameters.CopyrightReference)
 		st.SetFieldChanged(project.FieldCopyrightReference, item.CopyrightReference, *parameters.CopyrightReference)
+	}
+	if parameters.CopyrightTagPrefix != nil && item.CopyrightTagPrefix != *parameters.CopyrightTagPrefix {
+		update.SetCopyrightTagPrefix(*parameters.CopyrightTagPrefix)
+		st.SetFieldChanged(project.FieldCopyrightTagPrefix, item.CopyrightTagPrefix, *parameters.CopyrightTagPrefix)
 	}
 	if parameters.LocationName != nil && item.LocationName != *parameters.LocationName {
 		update.SetLocationName(*parameters.LocationName)

--- a/api/internal/server/projects_controller.go
+++ b/api/internal/server/projects_controller.go
@@ -21,6 +21,7 @@ func projectResponse(p *ent.Project) gin.H {
 		"description":         p.Description,
 		"copyright":           p.Copyright,
 		"copyrightReference":  p.CopyrightReference,
+		"copyrightTagPrefix":  p.CopyrightTagPrefix,
 		"locationName":        p.LocationName,
 		"locationCode":        p.LocationCode,
 		"locationCity":        p.LocationCity,
@@ -105,6 +106,7 @@ type createProjectPayload struct {
 	Description         string  `json:"description" binding:"required"`
 	Copyright           string  `json:"copyright" binding:"required"`
 	CopyrightReference  string  `json:"copyrightReference" binding:"required"`
+	CopyrightTagPrefix  *string `json:"copyrightTagPrefix"`
 	LocationName        string  `json:"locationName" binding:"required"`
 	LocationCode        string  `json:"locationCode" binding:"required"`
 	LocationCity        string  `json:"locationCity" binding:"required"`
@@ -132,6 +134,7 @@ func (s *Server) createProject(c *gin.Context) {
 		Description:         payload.Description,
 		Copyright:           payload.Copyright,
 		CopyrightReference:  payload.CopyrightReference,
+		CopyrightTagPrefix:  payload.CopyrightTagPrefix,
 		LocationName:        payload.LocationName,
 		LocationCode:        payload.LocationCode,
 		LocationCity:        payload.LocationCity,
@@ -151,6 +154,7 @@ type updateProjectPayload struct {
 	Description         *string `json:"description"`
 	Copyright           *string `json:"copyright"`
 	CopyrightReference  *string `json:"copyrightReference"`
+	CopyrightTagPrefix  *string `json:"copyrightTagPrefix"`
 	LocationName        *string `json:"locationName"`
 	LocationCode        *string `json:"locationCode"`
 	LocationCity        *string `json:"locationCity"`
@@ -197,6 +201,7 @@ func (s *Server) updateProject(c *gin.Context) {
 		Description:         payload.Description,
 		Copyright:           payload.Copyright,
 		CopyrightReference:  payload.CopyrightReference,
+		CopyrightTagPrefix:  payload.CopyrightTagPrefix,
 		LocationName:        payload.LocationName,
 		LocationCode:        payload.LocationCode,
 		LocationCity:        payload.LocationCity,

--- a/ui/src/pages/project/ProjectCreate.vue
+++ b/ui/src/pages/project/ProjectCreate.vue
@@ -66,6 +66,7 @@ const aiFields: Field<ProjectsResponse>[] = [{ key: "aiSystemMessage", label: "A
 const copyrightFields: Field<ProjectsResponse>[] = [
   { key: "copyright", label: "Copyright", type: FieldType.TEXT },
   { key: "copyrightReference", label: "Copyright reference", type: FieldType.TEXT },
+  { key: "copyrightTagPrefix", label: "Copyright tag prefix", type: FieldType.TEXT },
   { key: "locationName", label: "Location name", type: FieldType.TEXT },
   { key: "locationCode", label: "Location code", type: FieldType.TEXT },
   { key: "locationCity", label: "Location city", type: FieldType.TEXT },

--- a/ui/src/pages/project/ProjectGeneral.vue
+++ b/ui/src/pages/project/ProjectGeneral.vue
@@ -267,6 +267,7 @@ const reviewFields: Field<ITEM_TYPE>[] = [{ key: "uploadReviewEnabled", label: "
 const copyrightFields: Field<ITEM_TYPE>[] = [
   { key: "copyright", label: "Copyright", type: FieldType.TEXT },
   { key: "copyrightReference", label: "Copyright reference", type: FieldType.TEXT },
+  { key: "copyrightTagPrefix", label: "Copyright tag prefix", type: FieldType.TEXT, hint: "Prepended to the photographer's copyright tag in exported EXIF only, e.g. by_" },
   { key: "locationName", label: "Location name", type: FieldType.TEXT },
   { key: "locationCode", label: "Location code", type: FieldType.TEXT },
   { key: "locationCity", label: "Location city", type: FieldType.TEXT },

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -126,6 +126,7 @@ export interface Project {
   description: string;
   copyright: string;
   copyrightReference: string;
+  copyrightTagPrefix?: string;
   locationName: string;
   locationCode: string;
   locationCity: string;


### PR DESCRIPTION
## What

New project setting **`copyrightTagPrefix`** (e.g. `by_`). At EXIF export time (the `/download/:id/:res` exiftool injection), the prefix is prepended to every copyright-tag-derived value:

- the keyword whose name equals the image owner's `copyrightTag` (the tag the `$COPYRIGHT` template derives on upload)
- `IPTC:By-lineTitle` (which carries the copyright tag)

Everywhere else — DB, tag lists, UI — the tag stays unprefixed.

## How

- ent: new optional `Project.copyrightTagPrefix` string field (auto-migrate adds the column)
- API: field wired through create/update payloads, repository params, and `projectResponse`
- EXIF: `buildMetadata` prefixes matching keywords and By-lineTitle; empty prefix or empty copyright tag → no change
- UI: text field in Copyright Data on project settings + create page

## Tests

`go test ./internal/exif/` — new cases: prefixing of the derived keyword + By-lineTitle, and no-prefix passthrough. Existing server/repository suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)