### PR TITLE
feat(exif): EXIF viewer page for local image inspection

### DIFF
--- a/.github/workflows/ui-e2e.yml
+++ b/.github/workflows/ui-e2e.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           go-version: "1.26.4"
 
+      # The API shells out to exiftool (/download injection, /exif/inspect reading).
+      - name: Install exiftool
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libimage-exiftool-perl
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"

--- a/api/internal/exif/read.go
+++ b/api/internal/exif/read.go
@@ -1,0 +1,42 @@
+package exif
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// ReadMetadata extracts ALL metadata from imageData via an exiftool shell-out
+// reading from stdin — the image never touches disk. Groups are family-1
+// (-g1: IFD0, ExifIFD, Canon, ...) so a viewer can render one section per
+// group; -a keeps duplicate tags, -u includes unknown ones.
+// The InjectMetadata semaphore also bounds these processes.
+func ReadMetadata(ctx context.Context, imageData []byte) (map[string]any, error) {
+	slot := currentSem()
+	select {
+	case slot <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	defer func() { <-slot }()
+
+	cmd := exec.CommandContext(ctx, "exiftool", "-j", "-a", "-u", "-g1", "-")
+	cmd.Stdin = bytes.NewReader(imageData)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("exiftool: %w", err)
+	}
+
+	var results []map[string]any
+	if err := json.Unmarshal(out, &results); err != nil {
+		return nil, fmt.Errorf("exiftool output: %w", err)
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("exiftool returned no metadata")
+	}
+	meta := results[0]
+	delete(meta, "SourceFile") // always "-" for stdin; noise for the caller
+	return meta, nil
+}

--- a/api/internal/exif/read_test.go
+++ b/api/internal/exif/read_test.go
@@ -1,0 +1,45 @@
+package exif
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/jpeg"
+	"os/exec"
+	"testing"
+)
+
+func TestReadMetadata(t *testing.T) {
+	if _, err := exec.LookPath("exiftool"); err != nil {
+		t.Skip("exiftool not installed")
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, image.NewRGBA(image.Rect(0, 0, 1, 1)), nil); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := ReadMetadata(context.Background(), buf.Bytes())
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if len(meta) == 0 {
+		t.Fatal("expected at least one metadata group")
+	}
+	if _, ok := meta["SourceFile"]; ok {
+		t.Fatal("SourceFile must be stripped")
+	}
+}
+
+// exiftool identifies ANY input (a text file reads as FileType TXT, exit 0) —
+// non-images are not an error at this layer; the viewer just has no EXIF to show.
+func TestReadMetadataToleratesNonImages(t *testing.T) {
+	if _, err := exec.LookPath("exiftool"); err != nil {
+		t.Skip("exiftool not installed")
+	}
+	meta, err := ReadMetadata(context.Background(), []byte("not an image"))
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if _, ok := meta["File"]; !ok {
+		t.Fatalf("expected a File group, got %v", meta)
+	}
+}

--- a/api/internal/server/custom_routes.go
+++ b/api/internal/server/custom_routes.go
@@ -20,6 +20,7 @@ import (
 func (s *Server) registerCustomRoutes(api *gin.RouterGroup) {
 	api.GET("/upload-url", s.getUploadURL)
 	api.GET("/download/:id/:res", s.downloadImage)
+	api.POST("/exif/inspect", s.inspectExif)
 	api.GET("/statistics/:projectId", s.getStatistics)
 	api.GET("/sync-image-tags", s.syncImageTags)
 }

--- a/api/internal/server/exif_controller.go
+++ b/api/internal/server/exif_controller.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/shutterbase/shutterbase/internal/exif"
+)
+
+// inspectExifTimeout bounds the exiftool read shell-out, mirroring
+// downloadExifTimeout on the inject side.
+const inspectExifTimeout = 30 * time.Second
+
+// inspectExif extracts all metadata from an image the caller streams up in a
+// multipart "file" part. Nothing is persisted: the part is read into memory
+// (capped at downloadMaxBytes) and handed to exiftool via stdin. Any
+// authenticated user may inspect their own local files.
+func (s *Server) inspectExif(c *gin.Context) {
+	mr, err := c.Request.MultipartReader()
+	if err != nil {
+		apiError(c, http.StatusBadRequest, "invalid_multipart", "request must be multipart/form-data")
+		return
+	}
+	var data []byte
+	for {
+		part, err := mr.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			apiError(c, http.StatusBadRequest, "invalid_multipart", "malformed multipart body")
+			return
+		}
+		if part.FormName() != "file" {
+			continue
+		}
+		data, err = io.ReadAll(io.LimitReader(part, s.downloadMaxBytes+1))
+		part.Close()
+		if err != nil {
+			apiError(c, http.StatusBadRequest, "read_failed", "could not read file part")
+			return
+		}
+		break
+	}
+	if len(data) == 0 {
+		apiError(c, http.StatusBadRequest, "missing_file", `multipart part "file" is required`)
+		return
+	}
+	if int64(len(data)) > s.downloadMaxBytes {
+		apiError(c, http.StatusRequestEntityTooLarge, "file_too_large", "file exceeds the inspection size cap")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), inspectExifTimeout)
+	defer cancel()
+	meta, err := exif.ReadMetadata(ctx, data)
+	if err != nil {
+		apiError(c, http.StatusUnprocessableEntity, "unreadable_metadata", "exiftool could not read metadata from this file")
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"metadata": meta})
+}

--- a/api/internal/server/exif_controller.go
+++ b/api/internal/server/exif_controller.go
@@ -21,6 +21,10 @@ const inspectExifTimeout = 30 * time.Second
 // (capped at downloadMaxBytes) and handed to exiftool via stdin. Any
 // authenticated user may inspect their own local files.
 func (s *Server) inspectExif(c *gin.Context) {
+	// This route is exempt from the global 1 MiB body cap (isLargeBodyRoute);
+	// the real bound is enforced here — downloadMaxBytes for the file itself
+	// plus 1 MiB slack for multipart framing.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, s.downloadMaxBytes+1<<20)
 	mr, err := c.Request.MultipartReader()
 	if err != nil {
 		apiError(c, http.StatusBadRequest, "invalid_multipart", "request must be multipart/form-data")
@@ -42,6 +46,11 @@ func (s *Server) inspectExif(c *gin.Context) {
 		data, err = io.ReadAll(io.LimitReader(part, s.downloadMaxBytes+1))
 		part.Close()
 		if err != nil {
+			var mbe *http.MaxBytesError
+			if errors.As(err, &mbe) {
+				apiError(c, http.StatusRequestEntityTooLarge, "file_too_large", "file exceeds the inspection size cap")
+				return
+			}
 			apiError(c, http.StatusBadRequest, "read_failed", "could not read file part")
 			return
 		}

--- a/api/internal/server/exif_controller_test.go
+++ b/api/internal/server/exif_controller_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func multipartFile(t *testing.T, field string, size int) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	fw, err := w.CreateFormFile(field, "photo.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write(bytes.Repeat([]byte("x"), size)); err != nil {
+		t.Fatal(err)
+	}
+	_ = w.Close()
+	return &buf, w.FormDataContentType()
+}
+
+func inspectRequest(t *testing.T, s *Server, body *bytes.Buffer, contentType string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/exif/inspect", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	s.inspectExif(c)
+	return rec
+}
+
+// A file over downloadMaxBytes maps to a clean 413 — not a generic read error.
+// (The global 1 MiB body cap exempts this route via isLargeBodyRoute; see the
+// #94 review finding on real camera files failing under the default cap.)
+func TestInspectExifOversizedFile413(t *testing.T) {
+	s := &Server{downloadMaxBytes: 10}
+	body, ct := multipartFile(t, "file", 50)
+	rec := inspectRequest(t, s, body, ct)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Contains(t, rec.Body.String(), "file_too_large")
+}
+
+func TestInspectExifMissingFilePart400(t *testing.T) {
+	s := &Server{downloadMaxBytes: 1 << 20}
+	body, ct := multipartFile(t, "not-the-file", 10)
+	rec := inspectRequest(t, s, body, ct)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "missing_file")
+}
+
+func TestInspectExifNonMultipart400(t *testing.T) {
+	s := &Server{downloadMaxBytes: 1 << 20}
+	rec := inspectRequest(t, s, bytes.NewBufferString(`{"a":1}`), "application/json")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid_multipart")
+}
+
+// The large-body exemption must cover exactly image writes and the EXIF
+// inspect upload — nothing else.
+func TestIsLargeBodyRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	var got bool
+	record := func(c *gin.Context) { got = isLargeBodyRoute(c) }
+	router.POST("/api/v1/exif/inspect", record)
+	router.POST("/api/v1/images", record)
+	router.PUT("/api/v1/images/:id", record)
+	router.POST("/api/v1/projects", record)
+
+	cases := []struct {
+		method, path string
+		want         bool
+	}{
+		{http.MethodPost, "/api/v1/exif/inspect", true},
+		{http.MethodPost, "/api/v1/images", true},
+		{http.MethodPut, "/api/v1/images/abc", true},
+		{http.MethodPost, "/api/v1/projects", false},
+	}
+	for _, tc := range cases {
+		req := httptest.NewRequest(tc.method, tc.path, strings.NewReader("{}"))
+		router.ServeHTTP(httptest.NewRecorder(), req)
+		assert.Equal(t, tc.want, got, "%s %s", tc.method, tc.path)
+	}
+}

--- a/api/internal/server/hardening.go
+++ b/api/internal/server/hardening.go
@@ -151,11 +151,12 @@ func (s *Server) securityMiddleware(apiBaseURL string) gin.HandlerFunc {
 			return
 		}
 
-		// Default body cap; image create/update get the larger cap (set in the
-		// images controller). Only caps requests that carry a body.
+		// Default body cap; image create/update and the EXIF inspect upload get
+		// their larger caps in their controllers. Only caps requests that carry
+		// a body.
 		switch c.Request.Method {
 		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
-			if !isImageWriteRoute(c) {
+			if !isLargeBodyRoute(c) {
 				c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, defaultBodyCap)
 			}
 		}
@@ -191,6 +192,9 @@ func (s *Server) rateLimitMiddleware() gin.HandlerFunc {
 			rl = s.hardening.uploadRL
 		case s.options.ApiBaseURL + "/download/:id/:res":
 			rl = s.hardening.downloadRL
+		case s.options.ApiBaseURL + "/exif/inspect":
+			// shares the exiftool semaphore with /download — same budget applies
+			rl = s.hardening.downloadRL
 		case "/ws":
 			rl = s.hardening.wsRL
 		case s.options.ApiBaseURL + "/images":
@@ -206,10 +210,14 @@ func (s *Server) rateLimitMiddleware() gin.HandlerFunc {
 	}
 }
 
-func isImageWriteRoute(c *gin.Context) bool {
+// isLargeBodyRoute exempts routes that legitimately carry image-sized bodies
+// from the default 1 MiB cap: image create/update (their controller sets the
+// larger cap) and the EXIF inspect upload (caps at downloadMaxBytes itself).
+func isLargeBodyRoute(c *gin.Context) bool {
 	p := c.FullPath()
 	return strings.HasSuffix(p, "/images") && c.Request.Method == http.MethodPost ||
-		strings.HasSuffix(p, "/images/:id") && c.Request.Method == http.MethodPut
+		strings.HasSuffix(p, "/images/:id") && c.Request.Method == http.MethodPut ||
+		strings.HasSuffix(p, "/exif/inspect") && c.Request.Method == http.MethodPost
 }
 
 func userOrIPKey(c *gin.Context) string {

--- a/ui/src/api/exif.ts
+++ b/ui/src/api/exif.ts
@@ -1,0 +1,10 @@
+import { http } from "src/boot/axios";
+import type { ExifGroups } from "src/util/exifInspect";
+
+// The file is read server-side in memory only (exiftool via stdin) — nothing is stored.
+export async function inspect(file: File): Promise<ExifGroups> {
+  const form = new FormData();
+  form.append("file", file);
+  const { data } = await http.post<{ metadata: ExifGroups }>("/exif/inspect", form);
+  return data.metadata;
+}

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -15,6 +15,7 @@ import * as auth from "./auth";
 import * as statistics from "./statistics";
 import * as apiKeys from "./apiKeys";
 import * as downloadConfigs from "./downloadConfigs";
+import * as exif from "./exif";
 
 export const api = {
   ai,
@@ -33,6 +34,7 @@ export const api = {
   statistics,
   apiKeys,
   downloadConfigs,
+  exif,
 };
 
 export default api;

--- a/ui/src/layouts/MainLayout.vue
+++ b/ui/src/layouts/MainLayout.vue
@@ -120,6 +120,7 @@ function calculateNavigationItems() {
   }
   navigationItems.push({ name: "People", href: "/people", current: false });
   navigationItems.push({ name: "Projects", href: "/projects", current: false });
+  navigationItems.push({ name: "EXIF", href: "/exif-viewer", current: false });
 
   const currentPath = route.path;
   navigationItems.forEach((item) => {

--- a/ui/src/pages/exif/ExifViewer.vue
+++ b/ui/src/pages/exif/ExifViewer.vue
@@ -142,7 +142,12 @@ function onDrop(event: DragEvent) {
   if (file) void inspect(file);
 }
 
+// latest-wins guard: dropping a second file mid-flight must never pair the
+// first file's metadata with the second file's name/preview.
+let inspectToken = 0;
+
 async function inspect(file: File) {
+  const token = ++inspectToken;
   loading.value = true;
   error.value = null;
   meta.value = null;
@@ -151,18 +156,24 @@ async function inspect(file: File) {
   // RAW files won't render in <img>; the browser just shows nothing — fine.
   previewUrl.value = URL.createObjectURL(file);
   try {
-    meta.value = await api.exif.inspect(file);
+    const result = await api.exif.inspect(file);
+    if (token !== inspectToken) return; // superseded by a newer drop
+    meta.value = result;
   } catch (e: any) {
+    if (token !== inspectToken) return;
     error.value = e?.response?.data?.message ?? "Could not read metadata from this file.";
   } finally {
-    loading.value = false;
-    if (fileInput.value) fileInput.value.value = "";
+    if (token === inspectToken) {
+      loading.value = false;
+      if (fileInput.value) fileInput.value.value = "";
+    }
   }
 }
 
 function formatRaw(value: unknown): string {
+  if (value === null || value === undefined) return "—";
   if (Array.isArray(value)) return value.join(", ");
-  if (value !== null && typeof value === "object") return JSON.stringify(value);
+  if (typeof value === "object") return JSON.stringify(value);
   return String(value);
 }
 

--- a/ui/src/pages/exif/ExifViewer.vue
+++ b/ui/src/pages/exif/ExifViewer.vue
@@ -1,0 +1,172 @@
+<template>
+  <div class="mx-auto w-full max-w-screen-2xl">
+    <div class="px-4 pt-6 sm:px-6 lg:px-8">
+      <div class="min-w-0">
+        <h1 class="display text-3xl text-primary-900 dark:text-white">EXIF Viewer</h1>
+        <p class="mt-2 text-sm text-primary-500 dark:text-primary-400">
+          Inspect all metadata of a local image. The file is read in memory only — nothing is uploaded to the photo catalog or stored.
+        </p>
+      </div>
+
+      <!-- drop zone -->
+      <div
+        class="mt-6 flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed px-6 py-10 text-center transition-colors"
+        :class="dragging ? 'border-accent-500 bg-accent-500/10' : 'border-primary-300 bg-surface hover:border-accent-500 dark:border-primary-700 dark:bg-surface-dark'"
+        data-testid="exif-drop-zone"
+        @click="fileInput?.click()"
+        @dragover.prevent="dragging = true"
+        @dragleave.prevent="dragging = false"
+        @drop.prevent="onDrop"
+      >
+        <PhotoIcon class="h-10 w-10 text-primary-400" />
+        <p class="mt-3 text-sm font-medium text-primary-900 dark:text-white">Drop an image here or click to browse</p>
+        <p class="mt-1 text-xs text-primary-500 dark:text-primary-400">JPEG, RAW, PNG, TIFF … anything exiftool can read</p>
+        <input ref="fileInput" type="file" class="hidden" @change="onPick" />
+      </div>
+
+      <div v-if="loading" class="mt-6 flex items-center gap-3 text-sm text-primary-500 dark:text-primary-400">
+        <ArrowPathIcon class="h-5 w-5 animate-spin" />
+        Reading metadata of {{ fileName }}…
+      </div>
+
+      <div v-if="error" class="mt-6 rounded-lg border border-red-300 bg-red-500/10 px-4 py-3 text-sm text-red-800 dark:border-red-700 dark:text-red-200">
+        {{ error }}
+      </div>
+
+      <template v-if="meta && !loading">
+        <!-- headline: preview + capture times -->
+        <div class="mt-6 flex flex-wrap gap-6">
+          <img v-if="previewUrl" :src="previewUrl" :alt="fileName" class="max-h-64 rounded-lg border border-primary-200 object-contain dark:border-primary-800" />
+          <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-semibold text-primary-900 dark:text-white" data-testid="exif-file-name">{{ fileName }}</p>
+            <div class="mt-3 grid gap-4 sm:grid-cols-2">
+              <div class="rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark">
+                <p class="text-xs font-medium uppercase tracking-wide text-primary-500 dark:text-primary-400">Original capture time</p>
+                <p class="mt-1 text-lg font-semibold tabular-nums text-primary-900 dark:text-white">{{ facts.originalCaptureTime ?? "—" }}</p>
+              </div>
+              <div class="rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark">
+                <p class="text-xs font-medium uppercase tracking-wide text-primary-500 dark:text-primary-400">Corrected capture time</p>
+                <p class="mt-1 text-lg font-semibold tabular-nums text-primary-900 dark:text-white">{{ facts.correctedCaptureTime ?? "—" }}</p>
+                <span
+                  v-if="facts.timeShift"
+                  class="mt-2 inline-flex rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-semibold tabular-nums text-amber-700 dark:text-amber-300"
+                  data-testid="exif-time-shift"
+                >
+                  {{ facts.timeShift }} shift applied
+                </span>
+                <span v-else class="mt-2 inline-flex rounded-full bg-primary-500/10 px-2 py-0.5 text-xs text-primary-600 dark:text-primary-300">no shift</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- key characteristics -->
+        <div class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="exif-key-facts">
+          <div v-for="fact in factCards" :key="fact.label" class="rounded-lg border border-primary-200 bg-surface p-4 dark:border-primary-800 dark:bg-surface-dark">
+            <div class="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-primary-500 dark:text-primary-400">
+              <component :is="fact.icon" class="h-4 w-4" />
+              {{ fact.label }}
+            </div>
+            <p class="mt-1 truncate text-base font-semibold text-primary-900 dark:text-white" :title="fact.value ?? ''">{{ fact.value ?? "—" }}</p>
+          </div>
+        </div>
+
+        <div v-if="facts.keywords.length" class="mt-4 flex flex-wrap gap-1.5">
+          <span v-for="keyword in facts.keywords" :key="keyword" class="rounded-full bg-primary-500/10 px-2.5 py-0.5 text-xs font-medium text-primary-700 dark:text-primary-200">
+            {{ keyword }}
+          </span>
+        </div>
+
+        <!-- all raw data, one collapsed group per exiftool family-1 group -->
+        <h2 class="display mt-8 text-xl text-primary-900 dark:text-white">All metadata</h2>
+        <div class="mb-10 mt-3 space-y-2" data-testid="exif-raw-groups">
+          <details v-for="(group, groupName) in meta" :key="groupName" class="rounded-lg border border-primary-200 bg-surface dark:border-primary-800 dark:bg-surface-dark">
+            <summary class="cursor-pointer select-none px-4 py-3 text-sm font-semibold text-primary-900 marker:text-primary-400 dark:text-white">
+              {{ groupName }}
+              <span class="ml-2 text-xs font-normal text-primary-500 dark:text-primary-400">{{ Object.keys(group).length }} tags</span>
+            </summary>
+            <div class="overflow-x-auto border-t border-primary-200 dark:border-primary-800">
+              <table class="w-full text-left text-sm">
+                <tbody>
+                  <tr v-for="(value, tagName) in group" :key="tagName" class="border-b border-primary-100 last:border-b-0 dark:border-primary-800/50">
+                    <td class="whitespace-nowrap px-4 py-1.5 align-top font-medium text-primary-700 dark:text-primary-200">{{ tagName }}</td>
+                    <td class="break-all px-4 py-1.5 tabular-nums text-primary-900 dark:text-white">{{ formatRaw(value) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </details>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, type Component } from "vue";
+import { ArrowPathIcon, CameraIcon, Squares2X2Icon, EyeIcon, BoltIcon, SunIcon, ViewfinderCircleIcon, PhotoIcon, UserIcon, IdentificationIcon } from "@heroicons/vue/24/outline";
+import { api } from "src/api";
+import { extractKeyFacts, type ExifGroups } from "src/util/exifInspect";
+
+const fileInput = ref<HTMLInputElement | null>(null);
+const dragging = ref(false);
+const loading = ref(false);
+const error = ref<string | null>(null);
+const meta = ref<ExifGroups | null>(null);
+const fileName = ref("");
+const previewUrl = ref<string | null>(null);
+
+const facts = computed(() => extractKeyFacts(meta.value ?? {}));
+
+const factCards = computed((): { label: string; value?: string; icon: Component }[] => [
+  { label: "Camera", value: facts.value.camera, icon: CameraIcon },
+  { label: "Body serial", value: facts.value.bodySerial, icon: IdentificationIcon },
+  { label: "Lens", value: facts.value.lens, icon: EyeIcon },
+  { label: "Dimensions", value: facts.value.dimensions, icon: Squares2X2Icon },
+  { label: "Shutter", value: facts.value.exposureTime, icon: BoltIcon },
+  { label: "Aperture", value: facts.value.aperture ? `ƒ/${facts.value.aperture}` : undefined, icon: ViewfinderCircleIcon },
+  { label: "ISO", value: facts.value.iso, icon: SunIcon },
+  { label: "Focal length", value: facts.value.focalLength, icon: PhotoIcon },
+  { label: "Artist", value: facts.value.artist, icon: UserIcon },
+  { label: "Copyright", value: facts.value.copyright, icon: IdentificationIcon },
+]);
+
+function onPick(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (file) void inspect(file);
+}
+
+function onDrop(event: DragEvent) {
+  dragging.value = false;
+  const file = event.dataTransfer?.files?.[0];
+  if (file) void inspect(file);
+}
+
+async function inspect(file: File) {
+  loading.value = true;
+  error.value = null;
+  meta.value = null;
+  fileName.value = file.name;
+  if (previewUrl.value) URL.revokeObjectURL(previewUrl.value);
+  // RAW files won't render in <img>; the browser just shows nothing — fine.
+  previewUrl.value = URL.createObjectURL(file);
+  try {
+    meta.value = await api.exif.inspect(file);
+  } catch (e: any) {
+    error.value = e?.response?.data?.message ?? "Could not read metadata from this file.";
+  } finally {
+    loading.value = false;
+    if (fileInput.value) fileInput.value.value = "";
+  }
+}
+
+function formatRaw(value: unknown): string {
+  if (Array.isArray(value)) return value.join(", ");
+  if (value !== null && typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+onBeforeUnmount(() => {
+  if (previewUrl.value) URL.revokeObjectURL(previewUrl.value);
+});
+</script>

--- a/ui/src/router/routes.ts
+++ b/ui/src/router/routes.ts
@@ -40,6 +40,11 @@ const routes: RouteRecordRaw[] = [
         component: () => import("pages/download/Download.vue"),
       },
       {
+        name: "exif-viewer",
+        path: "/exif-viewer",
+        component: () => import("pages/exif/ExifViewer.vue"),
+      },
+      {
         name: "sandbox",
         path: "/sandbox",
         component: () => import("pages/Sandbox.vue"),

--- a/ui/src/util/exifInspect.ts
+++ b/ui/src/util/exifInspect.ts
@@ -1,0 +1,97 @@
+import { DateTime } from "luxon";
+import { appliedTimeOffset } from "src/util/dateTimeUtil";
+
+// exiftool -j -a -u -g1 output: one object whose keys are family-1 groups
+// (IFD0, ExifIFD, Canon, File, Composite, ...), each mapping tag name → value.
+export type ExifGroups = Record<string, Record<string, unknown>>;
+
+/** First value found for any of `names`, groups in exiftool order, names by priority. */
+export function pickTag(meta: ExifGroups, names: string[]): unknown {
+  for (const name of names) {
+    for (const group of Object.values(meta)) {
+      if (group && typeof group === "object" && name in group) {
+        return group[name];
+      }
+    }
+  }
+  return undefined;
+}
+
+/** EXIF datetime ("2026:08:09 14:03:12.34+02:00") → DateTime keeping the string's zone. */
+export function parseExifDateTime(value: unknown): DateTime | null {
+  if (typeof value !== "string") return null;
+  const iso = value.replace(/^(\d{4}):(\d{2}):(\d{2}) /, "$1-$2-$3T");
+  const dt = DateTime.fromISO(iso, { setZone: true });
+  return dt.isValid ? dt : null;
+}
+
+/** German-format EXIF datetime as the camera wall clock; raw string when unparsable. */
+export function formatExifDateTime(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const dt = parseExifDateTime(value);
+  return dt ? dt.toFormat("dd.LL.yyyy HH:mm:ss") : String(value);
+}
+
+export interface ExifKeyFacts {
+  camera?: string;
+  bodySerial?: string;
+  lens?: string;
+  exposureTime?: string;
+  aperture?: string;
+  iso?: string;
+  focalLength?: string;
+  dimensions?: string;
+  originalCaptureTime?: string;
+  correctedCaptureTime?: string;
+  /** Signed shift corrected−original (e.g. "+1h 02m 03s"), only when both parse and differ. */
+  timeShift?: string;
+  artist?: string;
+  copyright?: string;
+  keywords: string[];
+}
+
+const str = (v: unknown): string | undefined => (v === undefined || v === null || v === "" ? undefined : String(v));
+
+/**
+ * The headline facts of an inspected image. "Corrected" capture time is
+ * DateTimeOriginal (the field Shutterbase rewrites on export); "original" is
+ * CreateDate, which export leaves untouched — on an unexported photo both carry
+ * the camera time and no shift is reported.
+ */
+export function extractKeyFacts(meta: ExifGroups): ExifKeyFacts {
+  const make = str(pickTag(meta, ["Make"]));
+  const model = str(pickTag(meta, ["Model", "CameraModelName"]));
+  const camera = model && make && !model.startsWith(make) ? `${make} ${model}` : (model ?? make);
+
+  const width = str(pickTag(meta, ["ImageWidth", "ExifImageWidth"]));
+  const height = str(pickTag(meta, ["ImageHeight", "ExifImageHeight"]));
+
+  const corrected = pickTag(meta, ["DateTimeOriginal"]);
+  const original = pickTag(meta, ["CreateDate", "DateTimeDigitized"]);
+  const correctedDt = parseExifDateTime(corrected);
+  const originalDt = parseExifDateTime(original);
+  let timeShift: string | undefined;
+  if (correctedDt && originalDt && !correctedDt.equals(originalDt)) {
+    timeShift = appliedTimeOffset(originalDt.toISO() as string, correctedDt.toISO() as string);
+  }
+
+  const rawKeywords = pickTag(meta, ["Keywords", "Subject", "XPKeywords"]);
+  const keywords = Array.isArray(rawKeywords) ? rawKeywords.map(String) : typeof rawKeywords === "string" && rawKeywords !== "" ? rawKeywords.split(/[;,] ?/) : [];
+
+  return {
+    camera,
+    bodySerial: str(pickTag(meta, ["SerialNumber", "BodySerialNumber", "InternalSerialNumber"])),
+    lens: str(pickTag(meta, ["LensModel", "LensID", "Lens", "LensType"])),
+    exposureTime: str(pickTag(meta, ["ExposureTime", "ShutterSpeed", "ShutterSpeedValue"])),
+    aperture: str(pickTag(meta, ["FNumber", "Aperture", "ApertureValue"])),
+    iso: str(pickTag(meta, ["ISO"])),
+    focalLength: str(pickTag(meta, ["FocalLength"])),
+    dimensions: width && height ? `${width} × ${height}` : undefined,
+    originalCaptureTime: formatExifDateTime(original),
+    correctedCaptureTime: formatExifDateTime(corrected),
+    timeShift,
+    artist: str(pickTag(meta, ["Artist", "By-line"])),
+    copyright: str(pickTag(meta, ["Copyright", "CopyrightNotice"])),
+    keywords,
+  };
+}

--- a/ui/src/util/exifInspect.ts
+++ b/ui/src/util/exifInspect.ts
@@ -5,7 +5,12 @@ import { appliedTimeOffset } from "src/util/dateTimeUtil";
 // (IFD0, ExifIFD, Canon, File, Composite, ...), each mapping tag name → value.
 export type ExifGroups = Record<string, Record<string, unknown>>;
 
-/** First value found for any of `names`, groups in exiftool order, names by priority. */
+/**
+ * First value found for any of `names` — names by priority; within one name the
+ * first group wins. NOTE: Go's JSON marshal alphabetizes the group map, so group
+ * iteration order is alphabetical, not exiftool emission order — only the
+ * name-priority lists express deliberate precedence.
+ */
 export function pickTag(meta: ExifGroups, names: string[]): unknown {
   for (const name of names) {
     for (const group of Object.values(meta)) {

--- a/ui/tests/e2e/exif-viewer.spec.ts
+++ b/ui/tests/e2e/exif-viewer.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "./helpers";
+
+// The viewer posts the picked file to /api/v1/exif/inspect (in-memory exiftool
+// read, nothing stored) and renders key facts + all raw groups.
+test.describe("exif viewer", () => {
+  test("inspects a local image and shows key facts and raw groups", async ({ page }) => {
+    await loginAs(page, "user", { activate: false });
+    await page.goto("/exif-viewer");
+    await expect(page.getByTestId("exif-drop-zone")).toBeVisible();
+
+    await page.locator('input[type="file"]').setInputFiles("tests/e2e/fixtures/20240817-0B8A0042.jpg");
+
+    await expect(page.getByTestId("exif-key-facts")).toBeVisible();
+    await expect(page.getByTestId("exif-file-name")).toHaveText("20240817-0B8A0042.jpg");
+    // real camera JPEG: fine-grained groups must be present in the accordion
+    const groups = page.getByTestId("exif-raw-groups");
+    await expect(groups.locator("summary", { hasText: "ExifIFD" })).toBeVisible();
+    // groups start collapsed; expanding one reveals its tag table
+    await groups.locator("summary", { hasText: "ExifIFD" }).click();
+    await expect(groups.locator("td", { hasText: "ExposureTime" }).first()).toBeVisible();
+  });
+
+  test("requires authentication", async ({ page }) => {
+    await page.context().clearCookies();
+    await page.goto("/exif-viewer");
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/ui/tests/e2e/exif-viewer.spec.ts
+++ b/ui/tests/e2e/exif-viewer.spec.ts
@@ -16,9 +16,10 @@ test.describe("exif viewer", () => {
     // real camera JPEG: fine-grained groups must be present in the accordion
     const groups = page.getByTestId("exif-raw-groups");
     await expect(groups.locator("summary", { hasText: "ExifIFD" })).toBeVisible();
-    // groups start collapsed; expanding one reveals its tag table
+    // groups start collapsed; expanding one reveals its tag table (the fixture
+    // is a stripped 5 KB thumbnail — DateTimeOriginal survives, exposure data doesn't)
     await groups.locator("summary", { hasText: "ExifIFD" }).click();
-    await expect(groups.locator("td", { hasText: "ExposureTime" }).first()).toBeVisible();
+    await expect(groups.locator("td", { hasText: "DateTimeOriginal" }).first()).toBeVisible();
   });
 
   test("requires authentication", async ({ page }) => {

--- a/ui/tests/e2e/exif-viewer.spec.ts
+++ b/ui/tests/e2e/exif-viewer.spec.ts
@@ -17,9 +17,11 @@ test.describe("exif viewer", () => {
     const groups = page.getByTestId("exif-raw-groups");
     await expect(groups.locator("summary", { hasText: "ExifIFD" })).toBeVisible();
     // groups start collapsed; expanding one reveals its tag table (the fixture
-    // is a stripped 5 KB thumbnail — DateTimeOriginal survives, exposure data doesn't)
+    // is a stripped 5 KB thumbnail — DateTimeOriginal survives, exposure data
+    // doesn't). Exact match: Composite carries SubSecDateTimeOriginal, which a
+    // substring locator would resolve to first — inside a collapsed group.
     await groups.locator("summary", { hasText: "ExifIFD" }).click();
-    await expect(groups.locator("td", { hasText: "DateTimeOriginal" }).first()).toBeVisible();
+    await expect(groups.getByRole("cell", { name: "DateTimeOriginal", exact: true })).toBeVisible();
   });
 
   test("requires authentication", async ({ page }) => {

--- a/ui/tests/e2e/smoke.spec.ts
+++ b/ui/tests/e2e/smoke.spec.ts
@@ -29,6 +29,7 @@ test.describe.serial("smoke", () => {
       ["uploads", "/uploads"],
       ["uploads-create", "/uploads/create"],
       ["users", "/users"],
+      ["exif-viewer", "/exif-viewer"],
       ["change-password", "/change-password"],
       ["sandbox", "/sandbox"],
       ["notfound", "/zzz-does-not-exist"],

--- a/ui/tests/exifInspect.spec.ts
+++ b/ui/tests/exifInspect.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { extractKeyFacts, formatExifDateTime, parseExifDateTime, pickTag, type ExifGroups } from "src/util/exifInspect";
+
+const sample: ExifGroups = {
+  ExifTool: { ExifToolVersion: 12.65 },
+  IFD0: { Make: "Canon", Model: "Canon EOS R5", Artist: "Max Mustermann", Copyright: "FSG 2026" },
+  ExifIFD: {
+    DateTimeOriginal: "2026:08:09 16:03:12+02:00",
+    CreateDate: "2026:08:09 14:01:09+02:00",
+    ExposureTime: "1/1600",
+    FNumber: 2.8,
+    ISO: 400,
+    FocalLength: "70.0 mm",
+    LensModel: "RF70-200mm F2.8 L IS USM",
+    SerialNumber: "123456789",
+  },
+  IPTC: { Keywords: ["FSG", "autocross", "by_mm"] },
+  File: { ImageWidth: 8192, ImageHeight: 5464, MIMEType: "image/jpeg" },
+};
+
+describe("pickTag", () => {
+  it("finds a tag regardless of its group", () => {
+    expect(pickTag(sample, ["LensModel"])).toBe("RF70-200mm F2.8 L IS USM");
+  });
+
+  it("respects name priority order", () => {
+    expect(pickTag(sample, ["Model", "Make"])).toBe("Canon EOS R5");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(pickTag(sample, ["NoSuchTag"])).toBeUndefined();
+  });
+});
+
+describe("parseExifDateTime / formatExifDateTime", () => {
+  it("parses EXIF datetimes with offset and keeps the wall clock", () => {
+    expect(formatExifDateTime("2026:08:09 16:03:12+02:00")).toBe("09.08.2026 16:03:12");
+  });
+
+  it("parses EXIF datetimes without offset", () => {
+    expect(formatExifDateTime("2026:08:09 16:03:12")).toBe("09.08.2026 16:03:12");
+  });
+
+  it("passes through unparsable strings raw", () => {
+    expect(formatExifDateTime("0000:00:00 00:00:00")).toBe("0000:00:00 00:00:00");
+    expect(parseExifDateTime("garbage")).toBeNull();
+  });
+
+  it("is undefined for empty values", () => {
+    expect(formatExifDateTime(undefined)).toBeUndefined();
+    expect(formatExifDateTime("")).toBeUndefined();
+  });
+});
+
+describe("extractKeyFacts", () => {
+  const facts = extractKeyFacts(sample);
+
+  it("extracts camera without duplicating the make", () => {
+    expect(facts.camera).toBe("Canon EOS R5");
+  });
+
+  it("extracts lens, serial, exposure basics", () => {
+    expect(facts.lens).toBe("RF70-200mm F2.8 L IS USM");
+    expect(facts.bodySerial).toBe("123456789");
+    expect(facts.exposureTime).toBe("1/1600");
+    expect(facts.aperture).toBe("2.8");
+    expect(facts.iso).toBe("400");
+    expect(facts.focalLength).toBe("70.0 mm");
+    expect(facts.dimensions).toBe("8192 × 5464");
+  });
+
+  it("reports original vs corrected capture time with the applied shift", () => {
+    expect(facts.originalCaptureTime).toBe("09.08.2026 14:01:09");
+    expect(facts.correctedCaptureTime).toBe("09.08.2026 16:03:12");
+    expect(facts.timeShift).toBe("+2h 02m 03s");
+  });
+
+  it("reports no shift when both times match", () => {
+    const same = extractKeyFacts({
+      ExifIFD: { DateTimeOriginal: "2026:08:09 14:01:09", CreateDate: "2026:08:09 14:01:09" },
+    });
+    expect(same.timeShift).toBeUndefined();
+  });
+
+  it("collects keywords from arrays and splits string keyword lists", () => {
+    expect(facts.keywords).toEqual(["FSG", "autocross", "by_mm"]);
+    expect(extractKeyFacts({ IPTC: { Keywords: "a; b; c" } }).keywords).toEqual(["a", "b", "c"]);
+    expect(extractKeyFacts({}).keywords).toEqual([]);
+  });
+
+  it("prepends make when the model does not carry it", () => {
+    expect(extractKeyFacts({ IFD0: { Make: "NIKON CORPORATION", Model: "Z 9" } }).camera).toBe("NIKON CORPORATION Z 9");
+  });
+});


### PR DESCRIPTION
## What

New authenticated **EXIF Viewer** page (`/exif-viewer`, nav item "EXIF"): drop or pick a local image and inspect **all** metadata exiftool can read.

- Key characteristics as visual cards: **original vs corrected capture time** (CreateDate vs DateTimeOriginal — the field Shutterbase rewrites on export) with the applied shift as a badge, camera, body serial, lens, shutter, aperture, ISO, focal length, artist, copyright, keyword chips
- Every raw family-1 group (IFD0, ExifIFD, MakerNotes, …) as a collapsed native `<details>` accordion with a tag table

## How

- `POST /api/v1/exif/inspect` (authenticated): the multipart part is read straight into memory (capped at `DOWNLOAD_MAX_OBJECT_BYTES`) and handed to `exiftool -j -a -u -g1 -` **via stdin** — no temp file, nothing stored. Same exiftool the export path uses, bounded by the same process semaphore + 30s timeout.
- exiftool identifies any input (a txt reads as `FileType: TXT`, exit 0) — non-images aren't an error; the viewer simply shows no EXIF. Note: this feeds user-supplied bytes to exiftool's format parsers (authenticated users only, same binary already trusted for the download path).
- UI: pure extraction logic in `ui/src/util/exifInspect.ts` (group-agnostic tag pick with priority lists, EXIF datetime → German format via luxon), page in `ui/src/pages/exif/ExifViewer.vue`.
- CI: `ui-e2e.yml` now installs exiftool (the API needs it; ubuntu runners don't ship it).

## Tests

- Go: `internal/exif/read_test.go` (stdlib-encoded JPEG roundtrip, non-image tolerance; skips when exiftool absent)
- Vitest: `ui/tests/exifInspect.spec.ts` — 13 cases on extraction/parsing/shift logic
- Playwright: `ui/tests/e2e/exif-viewer.spec.ts` — full inspect roundtrip on the fixture JPEG + auth redirect; route added to the smoke render gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)