### PR TITLE
feat(images): configurable slideshow over the filtered image grid

### DIFF
--- a/ui/src/components/image/ImagesHeader.vue
+++ b/ui/src/components/image/ImagesHeader.vue
@@ -23,6 +23,19 @@
           <QuestionMarkCircleIcon class="h-5 w-5" />
         </button>
 
+        <!-- slideshow over the current (filtered) view -->
+        <button
+          v-if="showFilter && totalImageCount > 0"
+          type="button"
+          title="Start slideshow"
+          data-testid="start-slideshow"
+          class="hidden sm:inline-flex h-8 w-8 items-center justify-center rounded-md text-primary-400 transition-colors hover:bg-primary-100 hover:text-primary-700 dark:text-primary-500 dark:hover:bg-primary-800 dark:hover:text-primary-200"
+          @click="emit('slideshow')"
+        >
+          <span class="sr-only">Start slideshow</span>
+          <PlayIcon class="h-5 w-5" />
+        </button>
+
         <!-- density / view -->
         <div v-if="showFilter" class="hidden sm:flex rounded-lg border border-primary-200 dark:border-primary-700 bg-surface dark:bg-surface-dark p-0.5">
           <button
@@ -251,6 +264,7 @@ import {
   RectangleStackIcon,
   SparklesIcon,
   ArrowUpTrayIcon,
+  PlayIcon,
 } from "@heroicons/vue/24/outline";
 import { Popover, PopoverButton, PopoverPanel, Listbox, ListboxButton, ListboxOptions, ListboxOption } from "@headlessui/vue";
 import { storeToRefs } from "pinia";
@@ -285,6 +299,7 @@ const emit = defineEmits<{
   "update:density": [Density];
   rerunAi: [];
   uploadFilter: [string | null];
+  slideshow: [];
 }>();
 
 const { activeProject, preferredImageSortOrder, projectTags } = storeToRefs(useUserStore());

--- a/ui/src/components/image/SlideshowOverlay.vue
+++ b/ui/src/components/image/SlideshowOverlay.vue
@@ -300,6 +300,7 @@ function togglePause() {
   if (paused.value) {
     clearTimer();
     navToken++; // cancel an advance that is already past its timer, mid-preload
+    waiting.value = false; // the cancelled advance can no longer clear its own chip
   } else {
     scheduleAdvance();
   }

--- a/ui/src/components/image/SlideshowOverlay.vue
+++ b/ui/src/components/image/SlideshowOverlay.vue
@@ -254,6 +254,14 @@ function show(index: number) {
 }
 
 function start() {
+  // The number inputs can yield NaN/0/negatives — clamped here, a bad show time
+  // would otherwise turn the advance timer into a busy loop.
+  const clamp = (v: unknown, min: number, max: number, fallback: number) => {
+    const n = Number(v);
+    return Number.isFinite(n) ? Math.min(max, Math.max(min, n)) : fallback;
+  };
+  config.value.showSeconds = clamp(config.value.showSeconds, 1, 300, DEFAULT_SLIDESHOW_CONFIG.showSeconds);
+  config.value.transitionSeconds = clamp(config.value.transitionSeconds, 0, 10, DEFAULT_SLIDESHOW_CONFIG.transitionSeconds);
   phase.value = "playing";
   void preload(props.images[0]);
   fillPreloadWindow();

--- a/ui/src/components/image/SlideshowOverlay.vue
+++ b/ui/src/components/image/SlideshowOverlay.vue
@@ -76,11 +76,14 @@
         class="absolute inset-0 flex items-center justify-center transition-opacity ease-linear"
         :style="{ opacity: slide.index === current ? 1 : 0, transitionDuration: `${config.transitionSeconds}s` }"
       >
+        <!-- kb class stays on the slide through its fade-out as "previous" —
+             stripping it while visible cancels the animation and snaps the
+             transform back to identity mid-crossfade -->
         <img
           :src="slideSrc(slide.image)"
           :alt="slide.image.computedFileName"
           class="h-full w-full object-contain"
-          :class="config.kenBurns !== 'off' && slide.index === current ? `kb kb-${kenBurnsVariant(slide.index)}` : ''"
+          :class="config.kenBurns !== 'off' ? `kb kb-${kenBurnsVariant(slide.index)}` : ''"
           :style="kenBurnsStyle"
           @error="onSlideError(slide.image)"
         />
@@ -229,21 +232,39 @@ function scheduleAdvance() {
   timer = setTimeout(advance, (config.value.showSeconds + config.value.transitionSeconds) * 1000);
 }
 
-async function advance() {
-  const next = nextSlideIndex(current.value, props.images.length, config.value.loop);
-  if (next === null) {
+// navToken cancels an in-flight decode-gated navigation: pause and any newer
+// navigation bump it, so a superseded advance can never land afterwards.
+let navToken = 0;
+
+// Every path onto the screen funnels through goTo: decode-gate the target,
+// then show it — auto-advance, manual next AND previous all get the same
+// "never show an undecoded slide" guarantee.
+async function goTo(index: number | null) {
+  if (index === null) {
     emit("close");
     return;
   }
-  // Stability over punctuality: never put an undecoded image on screen.
-  const target = props.images[next];
+  if (index === current.value) {
+    // single-image show (loop wraps onto itself): nothing to change, keep the
+    // timer alive. The Ken Burns run stays static here — the DOM node never
+    // remounts — which is acceptable for a one-image slideshow.
+    scheduleAdvance();
+    return;
+  }
+  const token = ++navToken;
+  const target = props.images[index];
   const src = target ? slideSrc(target) : "";
   if (src && !loaded.has(src)) {
     waiting.value = true;
     await preload(target);
-    waiting.value = false;
+    if (token === navToken) waiting.value = false;
   }
-  show(next);
+  if (token !== navToken) return; // superseded by pause or a newer navigation
+  show(index);
+}
+
+function advance() {
+  void goTo(nextSlideIndex(current.value, props.images.length, config.value.loop));
 }
 
 function show(index: number) {
@@ -253,43 +274,55 @@ function show(index: number) {
   scheduleAdvance();
 }
 
-function start() {
+async function start() {
   // The number inputs can yield NaN/0/negatives — clamped here, a bad show time
   // would otherwise turn the advance timer into a busy loop.
   const clamp = (v: unknown, min: number, max: number, fallback: number) => {
     const n = Number(v);
     return Number.isFinite(n) ? Math.min(max, Math.max(min, n)) : fallback;
   };
-  config.value.showSeconds = clamp(config.value.showSeconds, 1, 300, DEFAULT_SLIDESHOW_CONFIG.showSeconds);
+  config.value.showSeconds = clamp(config.value.showSeconds, 1, 120, DEFAULT_SLIDESHOW_CONFIG.showSeconds);
   config.value.transitionSeconds = clamp(config.value.transitionSeconds, 0, 10, DEFAULT_SLIDESHOW_CONFIG.transitionSeconds);
   phase.value = "playing";
-  void preload(props.images[0]);
-  fillPreloadWindow();
-  scheduleAdvance();
   // Best effort: a browser may reject fullscreen without a fresh user gesture.
   document.documentElement.requestFullscreen?.().catch(() => undefined);
+  // The first slide is decode-gated like every later one; the buffering chip
+  // covers the wait.
+  waiting.value = true;
+  await preload(props.images[0]);
+  waiting.value = false;
+  fillPreloadWindow();
+  scheduleAdvance();
 }
 
 function togglePause() {
   paused.value = !paused.value;
-  if (paused.value) clearTimer();
-  else scheduleAdvance();
+  if (paused.value) {
+    clearTimer();
+    navToken++; // cancel an advance that is already past its timer, mid-preload
+  } else {
+    scheduleAdvance();
+  }
 }
 
 function goNext() {
   clearTimer();
-  void advance();
+  advance();
 }
 
 function goPrevious() {
   clearTimer();
-  show(previousSlideIndex(current.value, props.images.length, config.value.loop));
+  void goTo(previousSlideIndex(current.value, props.images.length, config.value.loop));
 }
 
-// more images may have arrived while we were at the end of the loaded list
+// more images may have arrived while we were at the end of the loaded list —
+// and the list can also shrink (image deleted from the grid underneath).
 watch(
   () => props.images.length,
-  () => fillPreloadWindow(),
+  (length) => {
+    if (current.value >= length && length > 0) current.value = length - 1;
+    fillPreloadWindow();
+  },
 );
 
 // --- controls / keyboard ----------------------------------------------------

--- a/ui/src/components/image/SlideshowOverlay.vue
+++ b/ui/src/components/image/SlideshowOverlay.vue
@@ -1,0 +1,378 @@
+<template>
+  <div class="fixed inset-0 z-50 bg-black" data-testid="slideshow-overlay" @mousemove="showControls" @click="showControls">
+    <!-- setup phase: configure, then start -->
+    <div v-if="phase === 'setup'" class="flex h-full items-center justify-center px-4">
+      <div class="w-full max-w-md rounded-xl border border-primary-800 bg-primary-950 p-6" data-testid="slideshow-setup" @click.stop>
+        <h2 class="display text-xl text-white">Slideshow</h2>
+        <p class="mt-1 text-sm text-primary-400">{{ totalCount.toLocaleString() }} images in the current view</p>
+
+        <div class="mt-5 space-y-4">
+          <label class="block">
+            <span class="text-xs font-medium uppercase tracking-wide text-primary-400">Show time (seconds per image)</span>
+            <input
+              v-model.number="config.showSeconds"
+              type="number"
+              min="1"
+              max="120"
+              step="0.5"
+              data-testid="slideshow-show-seconds"
+              class="mt-1 w-full rounded-md border border-primary-700 bg-primary-900 px-3 py-2 text-sm text-white focus:border-accent-500 focus:outline-none"
+            />
+          </label>
+          <label class="block">
+            <span class="text-xs font-medium uppercase tracking-wide text-primary-400">Transition time (seconds)</span>
+            <input
+              v-model.number="config.transitionSeconds"
+              type="number"
+              min="0"
+              max="10"
+              step="0.25"
+              class="mt-1 w-full rounded-md border border-primary-700 bg-primary-900 px-3 py-2 text-sm text-white focus:border-accent-500 focus:outline-none"
+            />
+          </label>
+          <div>
+            <span class="text-xs font-medium uppercase tracking-wide text-primary-400">Pan &amp; zoom</span>
+            <div class="mt-1 flex rounded-lg border border-primary-700 p-0.5">
+              <button
+                v-for="option in kenBurnsOptions"
+                :key="option.value"
+                type="button"
+                :class="[
+                  'flex-1 rounded-md px-3 py-1.5 text-sm transition-colors',
+                  config.kenBurns === option.value ? 'bg-accent-500/20 text-accent-200' : 'text-primary-400 hover:text-primary-200',
+                ]"
+                @click="config.kenBurns = option.value"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+          </div>
+          <label class="flex items-center gap-2 text-sm text-primary-200">
+            <input v-model="config.loop" type="checkbox" class="h-4 w-4 rounded border-primary-700 bg-primary-900 accent-accent-500" />
+            Loop endlessly
+          </label>
+        </div>
+
+        <div class="mt-6 flex justify-end gap-3">
+          <button type="button" class="rounded-md px-4 py-2 text-sm text-primary-300 hover:text-white" @click="emit('close')">Cancel</button>
+          <button
+            type="button"
+            data-testid="slideshow-start"
+            class="inline-flex items-center gap-2 rounded-md bg-accent-500 px-4 py-2 text-sm font-semibold text-primary-950 hover:bg-accent-400"
+            @click="start"
+          >
+            <PlayIcon class="h-4 w-4" />
+            Start
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- playing phase: stacked slides, crossfade + optional Ken Burns -->
+    <template v-else>
+      <div
+        v-for="slide in visibleSlides"
+        :key="slide.image.id"
+        class="absolute inset-0 flex items-center justify-center transition-opacity ease-linear"
+        :style="{ opacity: slide.index === current ? 1 : 0, transitionDuration: `${config.transitionSeconds}s` }"
+      >
+        <img
+          :src="slideSrc(slide.image)"
+          :alt="slide.image.computedFileName"
+          class="h-full w-full object-contain"
+          :class="config.kenBurns !== 'off' && slide.index === current ? `kb kb-${kenBurnsVariant(slide.index)}` : ''"
+          :style="kenBurnsStyle"
+          @error="onSlideError(slide.image)"
+        />
+      </div>
+
+      <div v-if="waiting" class="absolute inset-x-0 top-4 flex justify-center" data-testid="slideshow-buffering">
+        <span class="rounded-full bg-black/60 px-3 py-1 text-xs text-primary-300">buffering…</span>
+      </div>
+
+      <!-- controls: fade with the cursor -->
+      <div
+        :class="['absolute inset-x-0 bottom-0 flex items-center gap-4 bg-black/70 px-4 py-2 transition-opacity', controlsVisible ? 'opacity-100' : 'pointer-events-none opacity-0']"
+        data-testid="slideshow-controls"
+        @click.stop
+      >
+        <button type="button" class="text-primary-300 hover:text-white" title="Previous" @click="goPrevious">
+          <BackwardIcon class="h-5 w-5" />
+        </button>
+        <button type="button" class="text-primary-300 hover:text-white" :title="paused ? 'Play' : 'Pause'" data-testid="slideshow-play-pause" @click="togglePause">
+          <PlayIcon v-if="paused" class="h-6 w-6" />
+          <PauseIcon v-else class="h-6 w-6" />
+        </button>
+        <button type="button" class="text-primary-300 hover:text-white" title="Next" @click="goNext">
+          <ForwardIcon class="h-5 w-5" />
+        </button>
+        <span class="min-w-0 flex-1 truncate text-center font-data text-sm text-primary-200">{{ images[current]?.computedFileName }}</span>
+        <span class="label-mono-sm shrink-0 text-primary-400" data-testid="slideshow-position">{{ current + 1 }} / {{ totalCount.toLocaleString() }}</span>
+        <button type="button" class="shrink-0 text-primary-300 hover:text-white" title="Exit slideshow" data-testid="slideshow-exit" @click="emit('close')">
+          <XMarkIcon class="h-6 w-6" />
+        </button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue";
+import { useStorage } from "@vueuse/core";
+import { PlayIcon, PauseIcon, ForwardIcon, BackwardIcon, XMarkIcon } from "@heroicons/vue/24/outline";
+import { ImageWithTagsType } from "src/types/custom";
+import { devPlaceholder } from "src/util/devPlaceholder";
+import { DEFAULT_SLIDESHOW_CONFIG, SlideshowConfig, kenBurnsVariant, nextSlideIndex, previousSlideIndex, preloadIndices, shouldFetchMore } from "src/util/slideshow";
+
+const props = defineProps<{
+  images: ImageWithTagsType[];
+  totalCount: number;
+}>();
+const emit = defineEmits<{ close: []; needMore: [] }>();
+
+const config = useStorage<SlideshowConfig>("slideshow-config", { ...DEFAULT_SLIDESHOW_CONFIG }, undefined, { mergeDefaults: true });
+const kenBurnsOptions = [
+  { value: "off", label: "Off" },
+  { value: "subtle", label: "Subtle" },
+  { value: "strong", label: "Strong" },
+] as const;
+
+const phase = ref<"setup" | "playing">("setup");
+const current = ref(0);
+const paused = ref(false);
+const waiting = ref(false);
+
+// Current + previous slide stay mounted so the crossfade has both layers.
+const previous = ref<number | null>(null);
+const visibleSlides = computed(() => {
+  const slides: { index: number; image: ImageWithTagsType }[] = [];
+  if (previous.value !== null && previous.value !== current.value && props.images[previous.value]) {
+    slides.push({ index: previous.value, image: props.images[previous.value] });
+  }
+  if (props.images[current.value]) {
+    slides.push({ index: current.value, image: props.images[current.value] });
+  }
+  return slides;
+});
+
+// Ken Burns runs slightly longer than the slide is on screen so it never halts visibly.
+const kenBurnsStyle = computed(() => ({
+  "--kb-duration": `${config.value.showSeconds + 2 * config.value.transitionSeconds}s`,
+  "--kb-scale": config.value.kenBurns === "strong" ? "1.14" : "1.06",
+}));
+
+// --- preloading -------------------------------------------------------------
+// A slide only goes on screen once its 2048 rendition is decoded: `loaded`
+// tracks finished URLs, `pending` the in-flight Image() handles. Broken
+// renditions fall back to the dev placeholder and count as loaded — the show
+// must go on either way.
+
+const fallbacks = reactive<Record<string, string>>({});
+const loaded = new Set<string>();
+const pending = new Map<string, Promise<void>>();
+
+function slideSrc(image: ImageWithTagsType): string {
+  return fallbacks[image.id] ?? image.downloadUrls?.["2048"] ?? "";
+}
+
+function onSlideError(image: ImageWithTagsType) {
+  const placeholder = devPlaceholder(image.id);
+  if (placeholder && fallbacks[image.id] !== placeholder) fallbacks[image.id] = placeholder;
+}
+
+function preload(image: ImageWithTagsType | undefined): Promise<void> {
+  if (!image) return Promise.resolve();
+  const src = slideSrc(image);
+  if (!src || loaded.has(src)) return Promise.resolve();
+  const inFlight = pending.get(src);
+  if (inFlight) return inFlight;
+  const promise = new Promise<void>((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      loaded.add(src);
+      resolve();
+    };
+    img.onerror = () => {
+      onSlideError(image);
+      loaded.add(src); // fallback renders instead; never stall the show
+      resolve();
+    };
+    img.src = src;
+  }).finally(() => pending.delete(src));
+  pending.set(src, promise);
+  return promise;
+}
+
+function fillPreloadWindow() {
+  for (const index of preloadIndices(current.value, props.images.length)) {
+    void preload(props.images[index]);
+  }
+  if (shouldFetchMore(current.value, props.images.length, props.totalCount)) {
+    emit("needMore");
+  }
+}
+
+// --- playback ---------------------------------------------------------------
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+function clearTimer() {
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+function scheduleAdvance() {
+  clearTimer();
+  if (paused.value) return;
+  timer = setTimeout(advance, (config.value.showSeconds + config.value.transitionSeconds) * 1000);
+}
+
+async function advance() {
+  const next = nextSlideIndex(current.value, props.images.length, config.value.loop);
+  if (next === null) {
+    emit("close");
+    return;
+  }
+  // Stability over punctuality: never put an undecoded image on screen.
+  const target = props.images[next];
+  const src = target ? slideSrc(target) : "";
+  if (src && !loaded.has(src)) {
+    waiting.value = true;
+    await preload(target);
+    waiting.value = false;
+  }
+  show(next);
+}
+
+function show(index: number) {
+  previous.value = current.value;
+  current.value = index;
+  fillPreloadWindow();
+  scheduleAdvance();
+}
+
+function start() {
+  phase.value = "playing";
+  void preload(props.images[0]);
+  fillPreloadWindow();
+  scheduleAdvance();
+  // Best effort: a browser may reject fullscreen without a fresh user gesture.
+  document.documentElement.requestFullscreen?.().catch(() => undefined);
+}
+
+function togglePause() {
+  paused.value = !paused.value;
+  if (paused.value) clearTimer();
+  else scheduleAdvance();
+}
+
+function goNext() {
+  clearTimer();
+  void advance();
+}
+
+function goPrevious() {
+  clearTimer();
+  show(previousSlideIndex(current.value, props.images.length, config.value.loop));
+}
+
+// more images may have arrived while we were at the end of the loaded list
+watch(
+  () => props.images.length,
+  () => fillPreloadWindow(),
+);
+
+// --- controls / keyboard ----------------------------------------------------
+
+const controlsVisible = ref(true);
+let controlsTimer: ReturnType<typeof setTimeout> | null = null;
+function showControls() {
+  controlsVisible.value = true;
+  if (controlsTimer) clearTimeout(controlsTimer);
+  controlsTimer = setTimeout(() => (controlsVisible.value = false), 2500);
+}
+
+function onKeydown(event: KeyboardEvent) {
+  switch (event.key) {
+    case "Escape":
+      emit("close");
+      break;
+    case " ":
+      event.preventDefault();
+      if (phase.value === "playing") togglePause();
+      break;
+    case "ArrowRight":
+      if (phase.value === "playing") goNext();
+      break;
+    case "ArrowLeft":
+      if (phase.value === "playing") goPrevious();
+      break;
+  }
+}
+
+onMounted(() => {
+  window.addEventListener("keydown", onKeydown);
+  showControls();
+});
+
+onBeforeUnmount(() => {
+  clearTimer();
+  if (controlsTimer) clearTimeout(controlsTimer);
+  window.removeEventListener("keydown", onKeydown);
+  if (document.fullscreenElement) document.exitFullscreen?.().catch(() => undefined);
+});
+</script>
+
+<style scoped>
+.kb {
+  animation-duration: var(--kb-duration);
+  animation-timing-function: ease-in-out;
+  animation-fill-mode: forwards;
+}
+.kb-0 {
+  animation-name: kb-zoom-in;
+}
+.kb-1 {
+  animation-name: kb-pan-right;
+}
+.kb-2 {
+  animation-name: kb-zoom-out;
+}
+.kb-3 {
+  animation-name: kb-pan-left;
+}
+@keyframes kb-zoom-in {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(var(--kb-scale));
+  }
+}
+@keyframes kb-zoom-out {
+  from {
+    transform: scale(var(--kb-scale));
+  }
+  to {
+    transform: scale(1);
+  }
+}
+@keyframes kb-pan-right {
+  from {
+    transform: scale(var(--kb-scale)) translateX(-1.5%);
+  }
+  to {
+    transform: scale(var(--kb-scale)) translateX(1.5%);
+  }
+}
+@keyframes kb-pan-left {
+  from {
+    transform: scale(var(--kb-scale)) translateX(1.5%);
+  }
+  to {
+    transform: scale(var(--kb-scale)) translateX(-1.5%);
+  }
+}
+</style>

--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -13,6 +13,7 @@
         @aspect-ratio-filter="updateAspectRatioFilter"
         @rerun-ai="rerunSelection"
         @upload-filter="setUploadFilter"
+        @slideshow="slideshowActive = true"
       />
       <div v-if="displayMode === DisplayMode.GRID">
         <div v-if="personFilter" class="mt-6 flex flex-wrap items-center gap-3">
@@ -139,6 +140,9 @@
       <span class="label-mono-sm shrink-0 text-primary-400">{{ imageIndex + 1 }} / {{ totalImageCount.toLocaleString() }}</span>
     </div>
   </div>
+  <!-- Slideshow: plays the current (filtered, sorted) view; images keep loading
+       page by page as the show approaches the end of the loaded list. -->
+  <SlideshowOverlay v-if="slideshowActive" :images="images" :total-count="totalImageCount" @close="slideshowActive = false" @need-more="triggerInfiniteScroll" />
   <TaggingDialog
     v-if="imageIndex !== -1"
     ref="taggingDialog"
@@ -161,6 +165,7 @@ import Sidebar from "src/components/image/Sidebar.vue";
 import TaggingDialog from "src/components/image/TaggingDialog.vue";
 import FilmStrip from "src/components/image/FilmStrip.vue";
 import ZoomableImage from "src/components/image/ZoomableImage.vue";
+import SlideshowOverlay from "src/components/image/SlideshowOverlay.vue";
 import ImageTagBadge from "src/components/image/ImageTagBadge.vue";
 import { canRemoveTagAssignment, removeTagAssignment } from "src/util/imageTags";
 import { groupTagAssignments } from "src/util/tagOrder";
@@ -380,6 +385,9 @@ function toggleGridDetail() {
     closeDetail();
   }
 }
+
+// Slideshow is an overlay like zen: the grid state underneath stays untouched.
+const slideshowActive = ref(false);
 
 // Zen mode is an overlay, not a display mode: grid/detail (and the route) stay
 // as they are underneath, so z always returns to the previously active view.

--- a/ui/src/util/slideshow.ts
+++ b/ui/src/util/slideshow.ts
@@ -1,0 +1,58 @@
+// Pure slideshow logic — SFC-free so it is trivially unit-testable.
+
+export interface SlideshowConfig {
+  /** seconds each image is fully visible */
+  showSeconds: number;
+  /** crossfade duration in seconds */
+  transitionSeconds: number;
+  /** Ken Burns pan/zoom on the visible image */
+  kenBurns: "off" | "subtle" | "strong";
+  /** restart from the first image after the last one */
+  loop: boolean;
+}
+
+export const DEFAULT_SLIDESHOW_CONFIG: SlideshowConfig = {
+  showSeconds: 6,
+  transitionSeconds: 1.5,
+  kenBurns: "subtle",
+  loop: true,
+};
+
+/** How many upcoming images are kept decoded ahead of the one on screen. */
+export const PRELOAD_HEADROOM = 5;
+
+/** Indices to have preloaded for `current` (the next `headroom` loaded images). */
+export function preloadIndices(current: number, loadedCount: number, headroom: number = PRELOAD_HEADROOM): number[] {
+  const indices: number[] = [];
+  for (let i = current + 1; i <= current + headroom && i < loadedCount; i++) {
+    indices.push(i);
+  }
+  return indices;
+}
+
+/**
+ * Fetch the next page once the preload window would run into the end of the
+ * loaded list (double headroom, so fetching starts well before display catches
+ * up) — but only while the server has more.
+ */
+export function shouldFetchMore(current: number, loadedCount: number, total: number, headroom: number = PRELOAD_HEADROOM): boolean {
+  if (loadedCount >= total) return false;
+  return current + 2 * headroom >= loadedCount;
+}
+
+/** Next slide index; null ends the show (last image, loop off). */
+export function nextSlideIndex(current: number, loadedCount: number, loop: boolean): number | null {
+  if (loadedCount === 0) return null;
+  if (current + 1 < loadedCount) return current + 1;
+  return loop ? 0 : null;
+}
+
+export function previousSlideIndex(current: number, loadedCount: number, loop: boolean): number {
+  if (current > 0) return current - 1;
+  return loop && loadedCount > 0 ? loadedCount - 1 : 0;
+}
+
+/** Deterministic Ken Burns variant (0..3) so a slide always animates the same way. */
+export function kenBurnsVariant(index: number): number {
+  return ((index % 4) + 4) % 4;
+}

--- a/ui/tests/e2e/slideshow.spec.ts
+++ b/ui/tests/e2e/slideshow.spec.ts
@@ -27,12 +27,13 @@ test.describe("slideshow", () => {
     await page.waitForTimeout(2500);
     expect(await position.textContent()).toBe(frozen);
 
-    // exit returns to the grid — wake the auto-faded controls first; force
-    // because the DEV quick-actions bubble (z-9999, dev builds only) floats
-    // over the bottom-right corner and would intercept the hit test
+    // exit returns to the grid — wake the auto-faded controls first. The DEV
+    // quick-actions bubble (z-9999, dev builds only) covers the button's hit
+    // point, so a positional click lands on the bubble; dispatch straight to
+    // the button instead — prod has no bubble.
     await page.mouse.move(300, 300);
     await expect(page.getByTestId("slideshow-controls")).toBeVisible();
-    await page.getByTestId("slideshow-exit").click({ force: true });
+    await page.getByTestId("slideshow-exit").dispatchEvent("click");
     await expect(page.getByTestId("slideshow-overlay")).toHaveCount(0);
   });
 

--- a/ui/tests/e2e/slideshow.spec.ts
+++ b/ui/tests/e2e/slideshow.spec.ts
@@ -27,7 +27,10 @@ test.describe("slideshow", () => {
     await page.waitForTimeout(2500);
     expect(await position.textContent()).toBe(frozen);
 
-    // exit returns to the grid
+    // exit returns to the grid — the controls auto-fade to pointer-events-none
+    // after 2.5s, so wake them with a mouse move before clicking
+    await page.mouse.move(300, 300);
+    await expect(page.getByTestId("slideshow-controls")).toBeVisible();
     await page.getByTestId("slideshow-exit").click();
     await expect(page.getByTestId("slideshow-overlay")).toHaveCount(0);
   });

--- a/ui/tests/e2e/slideshow.spec.ts
+++ b/ui/tests/e2e/slideshow.spec.ts
@@ -27,11 +27,12 @@ test.describe("slideshow", () => {
     await page.waitForTimeout(2500);
     expect(await position.textContent()).toBe(frozen);
 
-    // exit returns to the grid — the controls auto-fade to pointer-events-none
-    // after 2.5s, so wake them with a mouse move before clicking
+    // exit returns to the grid — wake the auto-faded controls first; force
+    // because the DEV quick-actions bubble (z-9999, dev builds only) floats
+    // over the bottom-right corner and would intercept the hit test
     await page.mouse.move(300, 300);
     await expect(page.getByTestId("slideshow-controls")).toBeVisible();
-    await page.getByTestId("slideshow-exit").click();
+    await page.getByTestId("slideshow-exit").click({ force: true });
     await expect(page.getByTestId("slideshow-overlay")).toHaveCount(0);
   });
 

--- a/ui/tests/e2e/slideshow.spec.ts
+++ b/ui/tests/e2e/slideshow.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "./helpers";
+
+// Slideshow over the current grid view: setup dialog -> playing overlay with
+// controls; images auto-advance on the configured show time.
+test.describe("slideshow", () => {
+  test("configures, plays, pauses and exits", async ({ page }) => {
+    await loginAs(page, "admin");
+    await page.goto("/images");
+    await expect(page.getByTestId("start-slideshow")).toBeVisible();
+    await page.getByTestId("start-slideshow").click();
+
+    // setup phase with config; use a short show time so auto-advance is testable
+    await expect(page.getByTestId("slideshow-setup")).toBeVisible();
+    await page.getByTestId("slideshow-show-seconds").fill("1");
+    await page.getByTestId("slideshow-start").click();
+
+    const position = page.getByTestId("slideshow-position");
+    await expect(position).toContainText("1 /");
+    // auto-advances past the first slide (1s show + transition)
+    await expect(position).not.toContainText("1 /", { timeout: 10_000 });
+
+    // pause freezes the position
+    await page.getByTestId("slideshow-overlay").hover();
+    await page.getByTestId("slideshow-play-pause").click();
+    const frozen = await position.textContent();
+    await page.waitForTimeout(2500);
+    expect(await position.textContent()).toBe(frozen);
+
+    // exit returns to the grid
+    await page.getByTestId("slideshow-exit").click();
+    await expect(page.getByTestId("slideshow-overlay")).toHaveCount(0);
+  });
+
+  test("escape closes the slideshow", async ({ page }) => {
+    await loginAs(page, "admin");
+    await page.goto("/images");
+    await page.getByTestId("start-slideshow").click();
+    await expect(page.getByTestId("slideshow-setup")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("slideshow-overlay")).toHaveCount(0);
+  });
+});

--- a/ui/tests/slideshow.spec.ts
+++ b/ui/tests/slideshow.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { kenBurnsVariant, nextSlideIndex, previousSlideIndex, preloadIndices, shouldFetchMore } from "src/util/slideshow";
+
+describe("preloadIndices (decode-ahead window)", () => {
+  it("returns the next headroom indices", () => {
+    expect(preloadIndices(0, 20, 5)).toEqual([1, 2, 3, 4, 5]);
+    expect(preloadIndices(10, 20, 3)).toEqual([11, 12, 13]);
+  });
+
+  it("clamps at the end of the loaded list", () => {
+    expect(preloadIndices(18, 20, 5)).toEqual([19]);
+    expect(preloadIndices(19, 20, 5)).toEqual([]);
+  });
+
+  it("is empty for an empty list", () => {
+    expect(preloadIndices(0, 0)).toEqual([]);
+  });
+});
+
+describe("shouldFetchMore (double headroom before the loaded end)", () => {
+  it("requests the next page well before display catches up", () => {
+    expect(shouldFetchMore(10, 20, 100, 5)).toBe(true);
+    expect(shouldFetchMore(9, 20, 100, 5)).toBe(false);
+  });
+
+  it("never fetches once everything is loaded", () => {
+    expect(shouldFetchMore(19, 20, 20, 5)).toBe(false);
+  });
+});
+
+describe("nextSlideIndex / previousSlideIndex", () => {
+  it("advances and wraps when looping", () => {
+    expect(nextSlideIndex(0, 3, true)).toBe(1);
+    expect(nextSlideIndex(2, 3, true)).toBe(0);
+    expect(previousSlideIndex(0, 3, true)).toBe(2);
+    expect(previousSlideIndex(1, 3, true)).toBe(0);
+  });
+
+  it("ends the show at the last slide when not looping", () => {
+    expect(nextSlideIndex(2, 3, false)).toBeNull();
+    expect(previousSlideIndex(0, 3, false)).toBe(0);
+  });
+
+  it("ends immediately on an empty list", () => {
+    expect(nextSlideIndex(0, 0, true)).toBeNull();
+  });
+});
+
+describe("kenBurnsVariant", () => {
+  it("cycles deterministically through 4 variants", () => {
+    expect([0, 1, 2, 3, 4, 5].map(kenBurnsVariant)).toEqual([0, 1, 2, 3, 0, 1]);
+  });
+});


### PR DESCRIPTION
## What

**Slideshow** button in the image grid header (visible whenever the view has images): plays the current **filtered + sorted** grid view (e.g. filter by `vbo`) as a fullscreen animated slideshow. Auth-gated like the whole grid — registered users only.

- Setup dialog on start: show time, transition time, Ken Burns pan/zoom (**off / subtle / strong**), loop — persisted in localStorage
- Crossfade between slides (configurable duration), 4 deterministic Ken Burns variants (zoom in/out, pan left/right)
- Controls fade in on mouse move: prev/pause/next, position, exit; Space pauses, arrows navigate, Esc exits; best-effort browser fullscreen

## Stability

- The next 5 images are **decoded ahead** (`Image()` preload set); a slide never goes on screen before its 2048 rendition finished loading — if the show catches up, it shows a "buffering…" chip and waits instead of flashing a blank frame
- The next API page is fetched at **double headroom** (10 images before the loaded end) via the existing `triggerInfiniteScroll`
- Broken renditions fall back to the dev placeholder and count as loaded — the show never stalls on a 404

## How

Pure logic (preload window, fetch-ahead, next/prev with loop, Ken Burns variant) in `ui/src/util/slideshow.ts`; overlay component `ui/src/components/image/SlideshowOverlay.vue` (an overlay like zen mode — grid state underneath stays untouched); one emit in `ImagesHeader`.

## Tests

- Vitest: `ui/tests/slideshow.spec.ts` — 9 cases on the pure logic
- Playwright: `ui/tests/e2e/slideshow.spec.ts` — configure → play → auto-advance → pause freeze → exit, plus Esc close

🤖 Generated with [Claude Code](https://claude.com/claude-code)