### PR TITLE
feat(exif): combo tags split at every pipe into separate EXIF keywords

### DIFF
--- a/api/internal/exif/inject.go
+++ b/api/internal/exif/inject.go
@@ -112,9 +112,6 @@ func buildMetadata(image *ent.Image) map[string]any {
 		if typ != "default" && typ != "manual" {
 			continue
 		}
-		if tag.Name == "internal" {
-			continue
-		}
 		tags = append(tags, tag)
 	}
 	// The copyright-tag prefix (e.g. "by_") is an EXIF-render-time concern only:
@@ -140,6 +137,11 @@ func buildMetadata(image *ent.Image) map[string]any {
 		for _, part := range strings.Split(tag.Name, "|") {
 			part = strings.TrimSpace(part)
 			if part == "" {
+				continue
+			}
+			// The reserved management tag stays out of exports even when smuggled
+			// in as a combo part ("trip|internal") — checked per part, post-split.
+			if part == "internal" {
 				continue
 			}
 			if prefix != "" && copyrightTag != "" && part == copyrightTag {

--- a/api/internal/exif/inject.go
+++ b/api/internal/exif/inject.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/shutterbase/shutterbase/ent"
@@ -128,13 +129,28 @@ func buildMetadata(image *ent.Image) map[string]any {
 	if u := image.Edges.User; u != nil {
 		copyrightTag = u.CopyrightTag
 	}
+	// Combo tags ("autocross|DV") are applied as one tag but exported as their
+	// pipe-separated parts, so paired keywords can never be half-applied. Parts
+	// are trimmed, empties dropped, and duplicates (a part equal to another tag)
+	// deduped keeping the first occurrence. The copyright prefix applies after
+	// splitting, so a part equal to the copyright tag renders consistently.
 	keywords := make([]string, 0, len(tags))
+	seen := map[string]struct{}{}
 	for _, tag := range sortTagsByOrder(tags) {
-		name := tag.Name
-		if prefix != "" && copyrightTag != "" && name == copyrightTag {
-			name = prefix + name
+		for _, part := range strings.Split(tag.Name, "|") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if prefix != "" && copyrightTag != "" && part == copyrightTag {
+				part = prefix + part
+			}
+			if _, dup := seen[part]; dup {
+				continue
+			}
+			seen[part] = struct{}{}
+			keywords = append(keywords, part)
 		}
-		keywords = append(keywords, name)
 	}
 	m["EXIF:XPKeywords"] = keywords
 	m["IPTC:Keywords"] = keywords

--- a/api/internal/exif/inject_test.go
+++ b/api/internal/exif/inject_test.go
@@ -55,6 +55,44 @@ func TestBuildMetadataKeywordsRespectOrder(t *testing.T) {
 	}
 }
 
+func TestBuildMetadataComboTagsSplitAtExport(t *testing.T) {
+	image := &ent.Image{
+		Edges: ent.ImageEdges{
+			ImageTagAssignments: []*ent.ImageTagAssignment{
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("autocross|DV", imagetag.TypeManual, intPtr(1))}},
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("autocross", imagetag.TypeManual, intPtr(2))}},
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag(" a | b ||c ", imagetag.TypeManual, intPtr(3))}},
+			},
+		},
+	}
+	m := buildMetadata(image)
+	// combo split in tag order, duplicate "autocross" deduped, parts trimmed, empties dropped
+	want := []string{"autocross", "DV", "a", "b", "c"}
+	if !reflect.DeepEqual(m["IPTC:Keywords"], want) {
+		t.Fatalf("IPTC:Keywords = %v, want %v", m["IPTC:Keywords"], want)
+	}
+	if !reflect.DeepEqual(m["EXIF:XPKeywords"], want) {
+		t.Fatalf("EXIF:XPKeywords = %v, want %v", m["EXIF:XPKeywords"], want)
+	}
+}
+
+func TestBuildMetadataComboTagPartGetsCopyrightPrefix(t *testing.T) {
+	image := &ent.Image{
+		Edges: ent.ImageEdges{
+			User:    &ent.User{CopyrightTag: "mm"},
+			Project: &ent.Project{CopyrightTagPrefix: "by_"},
+			ImageTagAssignments: []*ent.ImageTagAssignment{
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("autocross|mm", imagetag.TypeManual, intPtr(1))}},
+			},
+		},
+	}
+	m := buildMetadata(image)
+	want := []string{"autocross", "by_mm"}
+	if !reflect.DeepEqual(m["IPTC:Keywords"], want) {
+		t.Fatalf("IPTC:Keywords = %v, want %v", m["IPTC:Keywords"], want)
+	}
+}
+
 func TestBuildMetadataCopyrightTagPrefix(t *testing.T) {
 	image := &ent.Image{
 		Edges: ent.ImageEdges{

--- a/api/internal/exif/inject_test.go
+++ b/api/internal/exif/inject_test.go
@@ -76,6 +76,22 @@ func TestBuildMetadataComboTagsSplitAtExport(t *testing.T) {
 	}
 }
 
+func TestBuildMetadataComboTagCannotSmuggleInternal(t *testing.T) {
+	image := &ent.Image{
+		Edges: ent.ImageEdges{
+			ImageTagAssignments: []*ent.ImageTagAssignment{
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("trip|internal", imagetag.TypeManual, intPtr(1))}},
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: tag("internal", imagetag.TypeDefault, intPtr(2))}},
+			},
+		},
+	}
+	m := buildMetadata(image)
+	want := []string{"trip"}
+	if !reflect.DeepEqual(m["IPTC:Keywords"], want) {
+		t.Fatalf("IPTC:Keywords = %v, want %v (reserved internal tag must never export)", m["IPTC:Keywords"], want)
+	}
+}
+
 func TestBuildMetadataComboTagPartGetsCopyrightPrefix(t *testing.T) {
 	image := &ent.Image{
 		Edges: ent.ImageEdges{


### PR DESCRIPTION
Supersedes #93 (auto-closed when its stacked base branch was deleted on the #92 merge). Rebased onto main; codex review complete — the one finding (reserved `internal` tag leaking through the combo split) is fixed and reviewer-confirmed.

## What

**Combo tags**: a tag whose name contains pipes (e.g. `autocross|DV`) behaves like any other tag in the UI and DB, but at EXIF export time it is split at every pipe into separate keywords — so keyword pairs that must always travel together can't be half-applied by a photographer.

## How

- `buildMetadata` (api/internal/exif/inject.go): each keyword name is split at `|`, parts trimmed, empties dropped, duplicates deduped keeping first occurrence in tag order
- The reserved `internal` management tag is excluded **per part, post-split** — `trip|internal` can't smuggle it into exports (codex finding, fixed + regression test)
- The copyright-tag prefix (#92) applies after splitting, so a part equal to the photographer's copyright tag renders consistently
- Side effect (intended): keyword dedup is now global — two tags rendering to the same final string export once

## Tests

`go test ./internal/exif/` — split order/trim/dedup, combo-part-with-prefix, and internal-smuggling regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)