### PR TITLE
feat(tags): add optional display name shown across the UI

### DIFF
--- a/api/ent/imagetag.go
+++ b/api/ent/imagetag.go
@@ -29,6 +29,8 @@ type ImageTag struct {
 	UpdatedBy *uuid.UUID `json:"updatedBy,omitempty"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name"`
+	// DisplayName holds the value of the "displayName" field.
+	DisplayName string `json:"displayName,omitempty"`
 	// Description holds the value of the "description" field.
 	Description string `json:"description"`
 	// IsAlbum holds the value of the "isAlbum" field.
@@ -98,7 +100,7 @@ func (*ImageTag) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case imagetag.FieldOrder:
 			values[i] = new(sql.NullInt64)
-		case imagetag.FieldID, imagetag.FieldName, imagetag.FieldDescription, imagetag.FieldType, imagetag.FieldProjectID:
+		case imagetag.FieldID, imagetag.FieldName, imagetag.FieldDisplayName, imagetag.FieldDescription, imagetag.FieldType, imagetag.FieldProjectID:
 			values[i] = new(sql.NullString)
 		case imagetag.FieldCreatedAt, imagetag.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -154,6 +156,12 @@ func (_m *ImageTag) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field name", values[i])
 			} else if value.Valid {
 				_m.Name = value.String
+			}
+		case imagetag.FieldDisplayName:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field displayName", values[i])
+			} else if value.Valid {
+				_m.DisplayName = value.String
 			}
 		case imagetag.FieldDescription:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -255,6 +263,9 @@ func (_m *ImageTag) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(_m.Name)
+	builder.WriteString(", ")
+	builder.WriteString("displayName=")
+	builder.WriteString(_m.DisplayName)
 	builder.WriteString(", ")
 	builder.WriteString("description=")
 	builder.WriteString(_m.Description)

--- a/api/ent/imagetag/imagetag.go
+++ b/api/ent/imagetag/imagetag.go
@@ -25,6 +25,8 @@ const (
 	FieldUpdatedBy = "updated_by"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
+	// FieldDisplayName holds the string denoting the displayname field in the database.
+	FieldDisplayName = "display_name"
 	// FieldDescription holds the string denoting the description field in the database.
 	FieldDescription = "description"
 	// FieldIsAlbum holds the string denoting the isalbum field in the database.
@@ -72,6 +74,7 @@ var Columns = []string{
 	FieldCreatedBy,
 	FieldUpdatedBy,
 	FieldName,
+	FieldDisplayName,
 	FieldDescription,
 	FieldIsAlbum,
 	FieldOrder,
@@ -172,6 +175,11 @@ func ByUpdatedBy(opts ...sql.OrderTermOption) OrderOption {
 // ByName orders the results by the name field.
 func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
+}
+
+// ByDisplayName orders the results by the displayName field.
+func ByDisplayName(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDisplayName, opts...).ToFunc()
 }
 
 // ByDescription orders the results by the description field.

--- a/api/ent/imagetag/where.go
+++ b/api/ent/imagetag/where.go
@@ -91,6 +91,11 @@ func Name(v string) predicate.ImageTag {
 	return predicate.ImageTag(sql.FieldEQ(FieldName, v))
 }
 
+// DisplayName applies equality check predicate on the "displayName" field. It's identical to DisplayNameEQ.
+func DisplayName(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldEQ(FieldDisplayName, v))
+}
+
 // Description applies equality check predicate on the "description" field. It's identical to DescriptionEQ.
 func Description(v string) predicate.ImageTag {
 	return predicate.ImageTag(sql.FieldEQ(FieldDescription, v))
@@ -354,6 +359,81 @@ func NameEqualFold(v string) predicate.ImageTag {
 // NameContainsFold applies the ContainsFold predicate on the "name" field.
 func NameContainsFold(v string) predicate.ImageTag {
 	return predicate.ImageTag(sql.FieldContainsFold(FieldName, v))
+}
+
+// DisplayNameEQ applies the EQ predicate on the "displayName" field.
+func DisplayNameEQ(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldEQ(FieldDisplayName, v))
+}
+
+// DisplayNameNEQ applies the NEQ predicate on the "displayName" field.
+func DisplayNameNEQ(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldNEQ(FieldDisplayName, v))
+}
+
+// DisplayNameIn applies the In predicate on the "displayName" field.
+func DisplayNameIn(vs ...string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldIn(FieldDisplayName, vs...))
+}
+
+// DisplayNameNotIn applies the NotIn predicate on the "displayName" field.
+func DisplayNameNotIn(vs ...string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldNotIn(FieldDisplayName, vs...))
+}
+
+// DisplayNameGT applies the GT predicate on the "displayName" field.
+func DisplayNameGT(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldGT(FieldDisplayName, v))
+}
+
+// DisplayNameGTE applies the GTE predicate on the "displayName" field.
+func DisplayNameGTE(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldGTE(FieldDisplayName, v))
+}
+
+// DisplayNameLT applies the LT predicate on the "displayName" field.
+func DisplayNameLT(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldLT(FieldDisplayName, v))
+}
+
+// DisplayNameLTE applies the LTE predicate on the "displayName" field.
+func DisplayNameLTE(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldLTE(FieldDisplayName, v))
+}
+
+// DisplayNameContains applies the Contains predicate on the "displayName" field.
+func DisplayNameContains(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldContains(FieldDisplayName, v))
+}
+
+// DisplayNameHasPrefix applies the HasPrefix predicate on the "displayName" field.
+func DisplayNameHasPrefix(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldHasPrefix(FieldDisplayName, v))
+}
+
+// DisplayNameHasSuffix applies the HasSuffix predicate on the "displayName" field.
+func DisplayNameHasSuffix(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldHasSuffix(FieldDisplayName, v))
+}
+
+// DisplayNameIsNil applies the IsNil predicate on the "displayName" field.
+func DisplayNameIsNil() predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldIsNull(FieldDisplayName))
+}
+
+// DisplayNameNotNil applies the NotNil predicate on the "displayName" field.
+func DisplayNameNotNil() predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldNotNull(FieldDisplayName))
+}
+
+// DisplayNameEqualFold applies the EqualFold predicate on the "displayName" field.
+func DisplayNameEqualFold(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldEqualFold(FieldDisplayName, v))
+}
+
+// DisplayNameContainsFold applies the ContainsFold predicate on the "displayName" field.
+func DisplayNameContainsFold(v string) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldContainsFold(FieldDisplayName, v))
 }
 
 // DescriptionEQ applies the EQ predicate on the "description" field.

--- a/api/ent/imagetag_create.go
+++ b/api/ent/imagetag_create.go
@@ -86,6 +86,20 @@ func (_c *ImageTagCreate) SetName(v string) *ImageTagCreate {
 	return _c
 }
 
+// SetDisplayName sets the "displayName" field.
+func (_c *ImageTagCreate) SetDisplayName(v string) *ImageTagCreate {
+	_c.mutation.SetDisplayName(v)
+	return _c
+}
+
+// SetNillableDisplayName sets the "displayName" field if the given value is not nil.
+func (_c *ImageTagCreate) SetNillableDisplayName(v *string) *ImageTagCreate {
+	if v != nil {
+		_c.SetDisplayName(*v)
+	}
+	return _c
+}
+
 // SetDescription sets the "description" field.
 func (_c *ImageTagCreate) SetDescription(v string) *ImageTagCreate {
 	_c.mutation.SetDescription(v)
@@ -339,6 +353,10 @@ func (_c *ImageTagCreate) createSpec() (*ImageTag, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.Name(); ok {
 		_spec.SetField(imagetag.FieldName, field.TypeString, value)
 		_node.Name = value
+	}
+	if value, ok := _c.mutation.DisplayName(); ok {
+		_spec.SetField(imagetag.FieldDisplayName, field.TypeString, value)
+		_node.DisplayName = value
 	}
 	if value, ok := _c.mutation.Description(); ok {
 		_spec.SetField(imagetag.FieldDescription, field.TypeString, value)

--- a/api/ent/imagetag_update.go
+++ b/api/ent/imagetag_update.go
@@ -72,6 +72,26 @@ func (_u *ImageTagUpdate) SetNillableName(v *string) *ImageTagUpdate {
 	return _u
 }
 
+// SetDisplayName sets the "displayName" field.
+func (_u *ImageTagUpdate) SetDisplayName(v string) *ImageTagUpdate {
+	_u.mutation.SetDisplayName(v)
+	return _u
+}
+
+// SetNillableDisplayName sets the "displayName" field if the given value is not nil.
+func (_u *ImageTagUpdate) SetNillableDisplayName(v *string) *ImageTagUpdate {
+	if v != nil {
+		_u.SetDisplayName(*v)
+	}
+	return _u
+}
+
+// ClearDisplayName clears the value of the "displayName" field.
+func (_u *ImageTagUpdate) ClearDisplayName() *ImageTagUpdate {
+	_u.mutation.ClearDisplayName()
+	return _u
+}
+
 // SetDescription sets the "description" field.
 func (_u *ImageTagUpdate) SetDescription(v string) *ImageTagUpdate {
 	_u.mutation.SetDescription(v)
@@ -334,6 +354,12 @@ func (_u *ImageTagUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(imagetag.FieldName, field.TypeString, value)
 	}
+	if value, ok := _u.mutation.DisplayName(); ok {
+		_spec.SetField(imagetag.FieldDisplayName, field.TypeString, value)
+	}
+	if _u.mutation.DisplayNameCleared() {
+		_spec.ClearField(imagetag.FieldDisplayName, field.TypeString)
+	}
 	if value, ok := _u.mutation.Description(); ok {
 		_spec.SetField(imagetag.FieldDescription, field.TypeString, value)
 	}
@@ -528,6 +554,26 @@ func (_u *ImageTagUpdateOne) SetNillableName(v *string) *ImageTagUpdateOne {
 	if v != nil {
 		_u.SetName(*v)
 	}
+	return _u
+}
+
+// SetDisplayName sets the "displayName" field.
+func (_u *ImageTagUpdateOne) SetDisplayName(v string) *ImageTagUpdateOne {
+	_u.mutation.SetDisplayName(v)
+	return _u
+}
+
+// SetNillableDisplayName sets the "displayName" field if the given value is not nil.
+func (_u *ImageTagUpdateOne) SetNillableDisplayName(v *string) *ImageTagUpdateOne {
+	if v != nil {
+		_u.SetDisplayName(*v)
+	}
+	return _u
+}
+
+// ClearDisplayName clears the value of the "displayName" field.
+func (_u *ImageTagUpdateOne) ClearDisplayName() *ImageTagUpdateOne {
+	_u.mutation.ClearDisplayName()
 	return _u
 }
 
@@ -822,6 +868,12 @@ func (_u *ImageTagUpdateOne) sqlSave(ctx context.Context) (_node *ImageTag, err 
 	}
 	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(imagetag.FieldName, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.DisplayName(); ok {
+		_spec.SetField(imagetag.FieldDisplayName, field.TypeString, value)
+	}
+	if _u.mutation.DisplayNameCleared() {
+		_spec.ClearField(imagetag.FieldDisplayName, field.TypeString)
 	}
 	if value, ok := _u.mutation.Description(); ok {
 		_spec.SetField(imagetag.FieldDescription, field.TypeString, value)

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -282,6 +282,7 @@ var (
 		{Name: "created_by", Type: field.TypeUUID, Nullable: true},
 		{Name: "updated_by", Type: field.TypeUUID, Nullable: true},
 		{Name: "name", Type: field.TypeString},
+		{Name: "display_name", Type: field.TypeString, Nullable: true},
 		{Name: "description", Type: field.TypeString},
 		{Name: "is_album", Type: field.TypeBool, Default: false},
 		{Name: "order", Type: field.TypeInt, Nullable: true},
@@ -296,7 +297,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "image_tags_projects_imageTags",
-				Columns:    []*schema.Column{ImageTagsColumns[10]},
+				Columns:    []*schema.Column{ImageTagsColumns[11]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -305,12 +306,12 @@ var (
 			{
 				Name:    "imagetag_project_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImageTagsColumns[10]},
+				Columns: []*schema.Column{ImageTagsColumns[11]},
 			},
 			{
 				Name:    "imagetag_name_project_id",
 				Unique:  true,
-				Columns: []*schema.Column{ImageTagsColumns[5], ImageTagsColumns[10]},
+				Columns: []*schema.Column{ImageTagsColumns[5], ImageTagsColumns[11]},
 			},
 		},
 	}

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -6569,6 +6569,7 @@ type ImageTagMutation struct {
 	createdBy             *uuid.UUID
 	updatedBy             *uuid.UUID
 	name                  *string
+	displayName           *string
 	description           *string
 	isAlbum               *bool
 	_order                *int
@@ -6896,6 +6897,55 @@ func (m *ImageTagMutation) OldName(ctx context.Context) (v string, err error) {
 // ResetName resets all changes to the "name" field.
 func (m *ImageTagMutation) ResetName() {
 	m.name = nil
+}
+
+// SetDisplayName sets the "displayName" field.
+func (m *ImageTagMutation) SetDisplayName(s string) {
+	m.displayName = &s
+}
+
+// DisplayName returns the value of the "displayName" field in the mutation.
+func (m *ImageTagMutation) DisplayName() (r string, exists bool) {
+	v := m.displayName
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDisplayName returns the old "displayName" field's value of the ImageTag entity.
+// If the ImageTag object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ImageTagMutation) OldDisplayName(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDisplayName is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDisplayName requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDisplayName: %w", err)
+	}
+	return oldValue.DisplayName, nil
+}
+
+// ClearDisplayName clears the value of the "displayName" field.
+func (m *ImageTagMutation) ClearDisplayName() {
+	m.displayName = nil
+	m.clearedFields[imagetag.FieldDisplayName] = struct{}{}
+}
+
+// DisplayNameCleared returns if the "displayName" field was cleared in this mutation.
+func (m *ImageTagMutation) DisplayNameCleared() bool {
+	_, ok := m.clearedFields[imagetag.FieldDisplayName]
+	return ok
+}
+
+// ResetDisplayName resets all changes to the "displayName" field.
+func (m *ImageTagMutation) ResetDisplayName() {
+	m.displayName = nil
+	delete(m.clearedFields, imagetag.FieldDisplayName)
 }
 
 // SetDescription sets the "description" field.
@@ -7281,7 +7331,7 @@ func (m *ImageTagMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ImageTagMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.createdAt != nil {
 		fields = append(fields, imagetag.FieldCreatedAt)
 	}
@@ -7296,6 +7346,9 @@ func (m *ImageTagMutation) Fields() []string {
 	}
 	if m.name != nil {
 		fields = append(fields, imagetag.FieldName)
+	}
+	if m.displayName != nil {
+		fields = append(fields, imagetag.FieldDisplayName)
 	}
 	if m.description != nil {
 		fields = append(fields, imagetag.FieldDescription)
@@ -7330,6 +7383,8 @@ func (m *ImageTagMutation) Field(name string) (ent.Value, bool) {
 		return m.UpdatedBy()
 	case imagetag.FieldName:
 		return m.Name()
+	case imagetag.FieldDisplayName:
+		return m.DisplayName()
 	case imagetag.FieldDescription:
 		return m.Description()
 	case imagetag.FieldIsAlbum:
@@ -7359,6 +7414,8 @@ func (m *ImageTagMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldUpdatedBy(ctx)
 	case imagetag.FieldName:
 		return m.OldName(ctx)
+	case imagetag.FieldDisplayName:
+		return m.OldDisplayName(ctx)
 	case imagetag.FieldDescription:
 		return m.OldDescription(ctx)
 	case imagetag.FieldIsAlbum:
@@ -7412,6 +7469,13 @@ func (m *ImageTagMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetName(v)
+		return nil
+	case imagetag.FieldDisplayName:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDisplayName(v)
 		return nil
 	case imagetag.FieldDescription:
 		v, ok := value.(string)
@@ -7499,6 +7563,9 @@ func (m *ImageTagMutation) ClearedFields() []string {
 	if m.FieldCleared(imagetag.FieldUpdatedBy) {
 		fields = append(fields, imagetag.FieldUpdatedBy)
 	}
+	if m.FieldCleared(imagetag.FieldDisplayName) {
+		fields = append(fields, imagetag.FieldDisplayName)
+	}
 	if m.FieldCleared(imagetag.FieldOrder) {
 		fields = append(fields, imagetag.FieldOrder)
 	}
@@ -7521,6 +7588,9 @@ func (m *ImageTagMutation) ClearField(name string) error {
 		return nil
 	case imagetag.FieldUpdatedBy:
 		m.ClearUpdatedBy()
+		return nil
+	case imagetag.FieldDisplayName:
+		m.ClearDisplayName()
 		return nil
 	case imagetag.FieldOrder:
 		m.ClearOrder()
@@ -7547,6 +7617,9 @@ func (m *ImageTagMutation) ResetField(name string) error {
 		return nil
 	case imagetag.FieldName:
 		m.ResetName()
+		return nil
+	case imagetag.FieldDisplayName:
+		m.ResetDisplayName()
 		return nil
 	case imagetag.FieldDescription:
 		m.ResetDescription()

--- a/api/ent/runtime.go
+++ b/api/ent/runtime.go
@@ -255,15 +255,15 @@ func init() {
 	// imagetag.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	imagetag.NameValidator = imagetagDescName.Validators[0].(func(string) error)
 	// imagetagDescDescription is the schema descriptor for description field.
-	imagetagDescDescription := imagetagFields[1].Descriptor()
+	imagetagDescDescription := imagetagFields[2].Descriptor()
 	// imagetag.DescriptionValidator is a validator for the "description" field. It is called by the builders before save.
 	imagetag.DescriptionValidator = imagetagDescDescription.Validators[0].(func(string) error)
 	// imagetagDescIsAlbum is the schema descriptor for isAlbum field.
-	imagetagDescIsAlbum := imagetagFields[2].Descriptor()
+	imagetagDescIsAlbum := imagetagFields[3].Descriptor()
 	// imagetag.DefaultIsAlbum holds the default value on creation for the isAlbum field.
 	imagetag.DefaultIsAlbum = imagetagDescIsAlbum.Default.(bool)
 	// imagetagDescOrder is the schema descriptor for order field.
-	imagetagDescOrder := imagetagFields[3].Descriptor()
+	imagetagDescOrder := imagetagFields[4].Descriptor()
 	// imagetag.OrderValidator is a validator for the "order" field. It is called by the builders before save.
 	imagetag.OrderValidator = imagetagDescOrder.Validators[0].(func(int) error)
 	// imagetagDescID is the schema descriptor for id field.

--- a/api/ent/schema/image_tag.go
+++ b/api/ent/schema/image_tag.go
@@ -16,6 +16,9 @@ func (ImageTag) Mixin() []ent.Mixin {
 func (ImageTag) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("name").NotEmpty().StructTag(`json:"name"`),
+		// Optional UI label; empty means "display the name". Exports and the
+		// review error tag always match on name.
+		field.String("displayName").Optional().StructTag(`json:"displayName,omitempty"`),
 		field.String("description").NotEmpty().StructTag(`json:"description"`),
 		field.Bool("isAlbum").Default(false).StructTag(`json:"isAlbum"`),
 		// Sort rank for tag application/display: lower first, ties and unset

--- a/api/internal/exif/inject_test.go
+++ b/api/internal/exif/inject_test.go
@@ -76,6 +76,25 @@ func TestBuildMetadataComboTagsSplitAtExport(t *testing.T) {
 	}
 }
 
+// The displayName is a UI-only label: export always splits the NAME's segments,
+// no matter what the display name says.
+func TestBuildMetadataComboTagIgnoresDisplayName(t *testing.T) {
+	combo := tag("autocross|DV", imagetag.TypeManual, intPtr(1))
+	combo.DisplayName = "Autocross (Driverless)"
+	image := &ent.Image{
+		Edges: ent.ImageEdges{
+			ImageTagAssignments: []*ent.ImageTagAssignment{
+				{Edges: ent.ImageTagAssignmentEdges{ImageTag: combo}},
+			},
+		},
+	}
+	m := buildMetadata(image)
+	want := []string{"autocross", "DV"}
+	if !reflect.DeepEqual(m["IPTC:Keywords"], want) {
+		t.Fatalf("IPTC:Keywords = %v, want %v (displayName must never reach the export)", m["IPTC:Keywords"], want)
+	}
+}
+
 func TestBuildMetadataComboTagCannotSmuggleInternal(t *testing.T) {
 	image := &ent.Image{
 		Edges: ent.ImageEdges{

--- a/api/internal/repository/image.go
+++ b/api/internal/repository/image.go
@@ -141,6 +141,7 @@ func (r *Repository) GetImages(ctx context.Context, parameters *GetImageParamete
 type TagStatistic struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
 	Description string `json:"description"`
 	Type        string `json:"type"`
 	Count       int    `json:"count"`
@@ -172,7 +173,7 @@ func (r *Repository) GetProjectTagStatistics(ctx context.Context, projectID stri
 			return nil, err
 		}
 		stats = append(stats, TagStatistic{
-			ID: t.ID, Name: t.Name, Description: t.Description, Type: t.Type.String(), Count: count,
+			ID: t.ID, Name: t.Name, DisplayName: t.DisplayName, Description: t.Description, Type: t.Type.String(), Count: count,
 		})
 	}
 	return stats, nil

--- a/api/internal/repository/image_tag.go
+++ b/api/internal/repository/image_tag.go
@@ -83,6 +83,7 @@ func (r *Repository) EnsureImageTag(ctx context.Context, projectID, name, descri
 
 type CreateImageTagParameters struct {
 	Name        string
+	DisplayName string
 	Description string
 	IsAlbum     *bool
 	Order       *int
@@ -93,6 +94,7 @@ type CreateImageTagParameters struct {
 func (r *Repository) CreateImageTag(ctx context.Context, parameters *CreateImageTagParameters) (*ent.ImageTag, error) {
 	create := r.Client.ImageTag.Create().
 		SetName(parameters.Name).
+		SetDisplayName(parameters.DisplayName).
 		SetDescription(parameters.Description).
 		SetType(parameters.Type).
 		SetProjectID(parameters.ProjectID).
@@ -118,6 +120,7 @@ func (r *Repository) CreateImageTag(ctx context.Context, parameters *CreateImage
 
 type UpdateImageTagParameters struct {
 	Name        *string
+	DisplayName *string
 	Description *string
 	IsAlbum     *bool
 	// Order: nil = untouched; pointer to 0 = clear (0 is not a valid rank).
@@ -144,6 +147,10 @@ func (r *Repository) UpdateImageTag(ctx context.Context, id string, parameters *
 	if parameters.Name != nil && item.Name != *parameters.Name {
 		update.SetName(*parameters.Name)
 		st.SetFieldChanged(imagetag.FieldName, item.Name, *parameters.Name)
+	}
+	if parameters.DisplayName != nil && item.DisplayName != *parameters.DisplayName {
+		update.SetDisplayName(*parameters.DisplayName)
+		st.SetFieldChanged(imagetag.FieldDisplayName, item.DisplayName, *parameters.DisplayName)
 	}
 	if parameters.Description != nil && item.Description != *parameters.Description {
 		update.SetDescription(*parameters.Description)

--- a/api/internal/server/image_response.go
+++ b/api/internal/server/image_response.go
@@ -58,6 +58,7 @@ type namedRef struct {
 type tagRef struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
 	Description string `json:"description"`
 	IsAlbum     bool   `json:"isAlbum"`
 	Order       *int   `json:"order,omitempty"`
@@ -172,7 +173,7 @@ func ToImageResponse(ctx context.Context, img *ent.Image, signer DownloadURLSign
 	for _, a := range img.Edges.ImageTagAssignments {
 		ref := assignmentRef{ID: a.ID, Type: a.Type.String()}
 		if t := a.Edges.ImageTag; t != nil {
-			ref.Tag = &tagRef{ID: t.ID, Name: t.Name, Description: t.Description, IsAlbum: t.IsAlbum, Order: t.Order, Type: t.Type.String()}
+			ref.Tag = &tagRef{ID: t.ID, Name: t.Name, DisplayName: t.DisplayName, Description: t.Description, IsAlbum: t.IsAlbum, Order: t.Order, Type: t.Type.String()}
 		}
 		resp.Tags = append(resp.Tags, ref)
 	}

--- a/api/internal/server/image_tag_assignments_controller.go
+++ b/api/internal/server/image_tag_assignments_controller.go
@@ -24,7 +24,7 @@ func (s *Server) imageTagAssignmentResponse(ctx context.Context, a *ent.ImageTag
 		"updatedAt": a.UpdatedAt,
 	}
 	if t, err := s.Repository.GetImageTag(ctx, a.ImageTagID); err == nil {
-		out["tag"] = gin.H{"id": t.ID, "name": t.Name, "type": t.Type, "isAlbum": t.IsAlbum, "order": t.Order}
+		out["tag"] = gin.H{"id": t.ID, "name": t.Name, "displayName": t.DisplayName, "type": t.Type, "isAlbum": t.IsAlbum, "order": t.Order}
 	}
 	return out
 }

--- a/api/internal/server/image_tags_controller.go
+++ b/api/internal/server/image_tags_controller.go
@@ -18,6 +18,7 @@ func (s *Server) imageTagResponse(ctx context.Context, t *ent.ImageTag) gin.H {
 	return gin.H{
 		"id":          t.ID,
 		"name":        t.Name,
+		"displayName": t.DisplayName,
 		"description": t.Description,
 		"isAlbum":     t.IsAlbum,
 		"order":       t.Order,
@@ -101,6 +102,7 @@ func validTemplateName(t imagetag.Type, name string) bool {
 
 type createImageTagPayload struct {
 	Name        string `json:"name" binding:"required"`
+	DisplayName string `json:"displayName"`
 	Description string `json:"description"`
 	IsAlbum     *bool  `json:"isAlbum"`
 	Order       *int   `json:"order"`
@@ -148,6 +150,7 @@ func (s *Server) createImageTag(c *gin.Context) {
 	}
 	item, err := s.Repository.CreateImageTag(c.Request.Context(), &repository.CreateImageTagParameters{
 		Name:        payload.Name,
+		DisplayName: payload.DisplayName,
 		Description: payload.Description,
 		IsAlbum:     payload.IsAlbum,
 		Order:       payload.Order,
@@ -168,6 +171,7 @@ func (s *Server) updateImageTag(c *gin.Context) {
 	}
 	var payload struct {
 		Name        *string `json:"name"`
+		DisplayName *string `json:"displayName"`
 		Description *string `json:"description"`
 		IsAlbum     *bool   `json:"isAlbum"`
 		Order       *int    `json:"order"`
@@ -184,7 +188,7 @@ func (s *Server) updateImageTag(c *gin.Context) {
 	if abortGetError(c, err) {
 		return
 	}
-	params := &repository.UpdateImageTagParameters{Name: payload.Name, Description: payload.Description, IsAlbum: payload.IsAlbum, Order: payload.Order}
+	params := &repository.UpdateImageTagParameters{Name: payload.Name, DisplayName: payload.DisplayName, Description: payload.Description, IsAlbum: payload.IsAlbum, Order: payload.Order}
 	resultingType := string(existing.Type)
 	if payload.Type != nil {
 		t := imagetag.Type(*payload.Type)

--- a/api/internal/server/schedule_items_controller.go
+++ b/api/internal/server/schedule_items_controller.go
@@ -35,7 +35,7 @@ func (s *Server) scheduleItemResponse(ctx context.Context, it *ent.ScheduleItem)
 	}
 	tags := make([]gin.H, 0, len(it.Edges.Tags))
 	for _, t := range it.Edges.Tags {
-		tags = append(tags, gin.H{"id": t.ID, "name": t.Name, "type": t.Type})
+		tags = append(tags, gin.H{"id": t.ID, "name": t.Name, "displayName": t.DisplayName, "type": t.Type})
 	}
 	resp := gin.H{
 		"id":          it.ID,

--- a/ui/src/api/imageTags.ts
+++ b/ui/src/api/imageTags.ts
@@ -13,6 +13,7 @@ export interface ImageTagListParams {
 
 export interface ImageTagCreate {
   name: string;
+  displayName?: string;
   description?: string;
   isAlbum?: boolean;
   order?: number; // positive rank; omit for unranked
@@ -22,6 +23,7 @@ export interface ImageTagCreate {
 
 export interface ImageTagUpdate {
   name?: string;
+  displayName?: string; // "" clears, omit leaves untouched
   description?: string;
   isAlbum?: boolean;
   order?: number; // positive rank; 0 clears, omit leaves untouched

--- a/ui/src/api/statistics.ts
+++ b/ui/src/api/statistics.ts
@@ -3,6 +3,7 @@ import { http } from "src/boot/axios";
 export interface TagStatistic {
   id: string;
   name: string;
+  displayName?: string;
   description: string;
   type: string;
   count: number;

--- a/ui/src/components/HotkeyHelpDialog.vue
+++ b/ui/src/components/HotkeyHelpDialog.vue
@@ -80,6 +80,7 @@ import { useRouter } from "vue-router";
 import { emitter } from "src/boot/mitt";
 import { useUserStore } from "src/stores/user-store";
 import { CONTEXT_LABELS, HOTKEY_ACTIONS, HotkeyContext, actionKeys, effectiveTagBindings, formatCombo, pushHotkeyContext, useHotkeyAction } from "src/util/hotkeys";
+import { tagLabel } from "src/util/tagOrder";
 
 const router = useRouter();
 const userStore = useUserStore();
@@ -126,7 +127,14 @@ const sections = computed(() => {
   })).filter((section) => section.entries.length > 0);
 });
 
-const tagEntries = computed(() => Object.entries(effectiveTagBindings(userStore.user?.hotkeys)).map(([combo, tagName]) => ({ combo, tagName })));
+// Bindings are stored by tag name; render the tag's display label when the
+// project tag is loaded, the stored name otherwise.
+const tagEntries = computed(() =>
+  Object.entries(effectiveTagBindings(userStore.user?.hotkeys)).map(([combo, tagName]) => {
+    const tag = userStore.projectTags?.find((t) => t.name === tagName);
+    return { combo, tagName: tag ? tagLabel(tag) : tagName };
+  }),
+);
 
 function goToSettings() {
   open.value = false;

--- a/ui/src/components/download/DownloadConfigDialog.vue
+++ b/ui/src/components/download/DownloadConfigDialog.vue
@@ -181,6 +181,7 @@ import { ArrowDownTrayIcon, TrashIcon, XMarkIcon } from "@heroicons/vue/24/outli
 import { ref, watch } from "vue";
 import SearchSelect, { SearchSelectOption } from "src/components/SearchSelect.vue";
 import { DownloadConfig, ImageTag } from "src/types/api";
+import { tagLabel } from "src/util/tagOrder";
 import { DownloadConfigCreate, DownloadConfigUpdate } from "src/api/downloadConfigs";
 
 interface Props {
@@ -251,7 +252,8 @@ watch(blacklistPick, (id) => {
 });
 
 function tagName(id: string): string {
-  return props.projectTags.find((t) => t.id === id)?.name ?? id;
+  const tag = props.projectTags.find((t) => t.id === id);
+  return tag ? tagLabel(tag) : id;
 }
 
 function save() {

--- a/ui/src/components/image/ImageTagBadge.vue
+++ b/ui/src/components/image/ImageTagBadge.vue
@@ -6,11 +6,12 @@
     :role="removable ? 'button' : undefined"
     :tabindex="removable ? 0 : undefined"
     :class="[`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset`, tagColor, removableClasses()]"
-    >{{ tagAssignment.tag.name }}</span
+    >{{ tagLabel(tagAssignment.tag) }}</span
   >
 </template>
 <script lang="ts" setup>
 import { ImageTagAssignmentType } from "src/types/custom";
+import { tagLabel } from "src/util/tagOrder";
 import { computed } from "vue";
 
 interface Props {

--- a/ui/src/components/image/ImagesHeader.vue
+++ b/ui/src/components/image/ImagesHeader.vue
@@ -141,7 +141,7 @@
                 >
                   <CheckIcon v-if="isSelected(tag)" class="h-3 w-3" />
                 </span>
-                <span class="truncate">{{ tag.name }}</span>
+                <span class="truncate">{{ tagLabel(tag) }}</span>
               </button>
               <p v-if="!filteredTags.length" class="px-2.5 py-6 text-center text-sm text-primary-400">No tags found</p>
             </div>
@@ -272,6 +272,7 @@ import { useUserStore } from "src/stores/user-store";
 import { emitter } from "src/boot/mitt";
 import { computed, h, ref, watch } from "vue";
 import { ImageTag, Upload } from "src/types/api";
+import { tagLabel } from "src/util/tagOrder";
 import { api } from "src/api";
 
 type Density = "gallery" | "comfortable" | "dense";
@@ -352,7 +353,7 @@ watch(selectedTags, () => emit("filterTags", selectedTags.value), { deep: true }
 const selectableTags = computed(() => projectTags.value.filter((t: ImageTag) => t.type !== "template"));
 const filteredTags = computed(() => {
   const q = tagQuery.value.toLowerCase();
-  return selectableTags.value.filter((t: ImageTag) => t.name.toLowerCase().includes(q));
+  return selectableTags.value.filter((t: ImageTag) => t.name.toLowerCase().includes(q) || tagLabel(t).toLowerCase().includes(q));
 });
 const isSelected = (tag: ImageTag) => selectedTags.value.some((t) => t.id === tag.id);
 function toggleTag(tag: ImageTag) {

--- a/ui/src/components/image/TaggingDialog.vue
+++ b/ui/src/components/image/TaggingDialog.vue
@@ -74,7 +74,7 @@
                   >
                 </div>
                 <div class="ml-10 flex-auto truncate">
-                  <p class="text-sm font-medium text-primary-800 dark:text-primary-100 truncate">{{ tag.name }}</p>
+                  <p class="text-sm font-medium text-primary-800 dark:text-primary-100 truncate">{{ tagLabel(tag) }}</p>
                   <p class="text-sm text-primary-500 dark:text-primary-400 truncate">{{ tag.description }}</p>
                 </div>
               </li>
@@ -107,7 +107,7 @@
                 </div>
                 <TagIcon v-else class="h-6 w-6 text-primary-400 dark:text-primary-500" />
                 <div class="ml-10 flex-auto truncate">
-                  <p class="text-sm font-medium text-primary-800 dark:text-primary-100 truncate">{{ tag.name }}</p>
+                  <p class="text-sm font-medium text-primary-800 dark:text-primary-100 truncate">{{ tagLabel(tag) }}</p>
                   <p class="text-sm text-primary-500 dark:text-primary-400 truncate">{{ tag.description }}</p>
                 </div>
               </li>
@@ -149,6 +149,7 @@ import { actionKeys, formatCombo, pushHotkeyContext, useHotkeyAction } from "src
 import { Image } from "src/util/fileProcessor";
 import { ImageTagsResponse } from "src/types/pocketbase";
 import { tagStack } from "src/pages/image/imageQueryLogic";
+import { tagLabel } from "src/util/tagOrder";
 import { api } from "src/api";
 
 interface Props {
@@ -186,6 +187,9 @@ const filteredTags = computed(() => {
       return false;
     }
     if (tag.name.toLowerCase().includes(searchText.value.toLowerCase())) {
+      return true;
+    }
+    if (tagLabel(tag).toLowerCase().includes(searchText.value.toLowerCase())) {
       return true;
     }
     if (tag.description.toLowerCase().includes(searchText.value.toLowerCase())) {

--- a/ui/src/components/project/TagDialog.vue
+++ b/ui/src/components/project/TagDialog.vue
@@ -148,6 +148,7 @@ function saveTag() {
 
 const createTagFields: CreateField<ImageTagsResponse>[] = [
   { key: "name", label: "Name", type: CreateFieldType.TEXT },
+  { key: "displayName", label: "Display name (optional, shown instead of the name)", type: CreateFieldType.TEXT },
   { key: "description", label: "Description", type: CreateFieldType.TEXT },
   { key: "order", label: "Order (lower first, empty = last)", type: CreateFieldType.TEXT },
   { key: "type", label: "Type", type: CreateFieldType.SELECT, options: ["template", "default", "manual", "custom"], optionsDefault: "manual" },
@@ -155,6 +156,7 @@ const createTagFields: CreateField<ImageTagsResponse>[] = [
 
 const editTagFields: EditField<ImageTagsResponse>[] = [
   { key: "name", label: "Name", type: EditFieldType.TEXT },
+  { key: "displayName", label: "Display name (optional, shown instead of the name)", type: EditFieldType.TEXT },
   { key: "description", label: "Description", type: EditFieldType.TEXT },
   { key: "order", label: "Order (lower first, empty = last)", type: EditFieldType.TEXT },
   { key: "type", label: "Type", type: EditFieldType.SELECT, options: ["template", "default", "manual", "custom"] },

--- a/ui/src/components/schedule/ScheduleItemDialog.vue
+++ b/ui/src/components/schedule/ScheduleItemDialog.vue
@@ -150,6 +150,7 @@ import { DateTime } from "luxon";
 import { computed, ref, watch } from "vue";
 import SearchSelect, { SearchSelectOption } from "src/components/SearchSelect.vue";
 import { ImageTag, ScheduleItem } from "src/types/api";
+import { tagLabel } from "src/util/tagOrder";
 import { ScheduleItemCreate, ScheduleItemUpdate } from "src/api/scheduleItems";
 
 interface Props {
@@ -230,7 +231,8 @@ watch(tagPick, (id) => {
 // tag that fell out of the selectable set (e.g. type changed) — fall back to
 // the item's own embedded tag names.
 function tagName(id: string): string {
-  return props.projectTags.find((t) => t.id === id)?.name ?? props.item?.tags.find((t) => t.id === id)?.name ?? id;
+  const tag = props.projectTags.find((t) => t.id === id) ?? props.item?.tags.find((t) => t.id === id);
+  return tag ? tagLabel(tag) : id;
 }
 
 function removeTag(id: string) {

--- a/ui/src/components/upload/UploadTimeline.vue
+++ b/ui/src/components/upload/UploadTimeline.vue
@@ -170,6 +170,7 @@ import { api } from "src/api";
 import { showNotificationToast } from "src/boot/mitt";
 import { ImageTag, ScheduleItem, Upload } from "src/types/api";
 import { Image } from "src/util/fileProcessor";
+import { tagLabel } from "src/util/tagOrder";
 import {
   EditorTrack,
   TimedImage,
@@ -239,7 +240,10 @@ const imageById = computed(() => {
 
 const labels = {
   scheduleItem: (id: string) => allItems.value.find((i) => i.id === id)?.title ?? "Schedule item",
-  tag: (id: string) => projectTags.value.find((t) => t.id === id)?.name ?? "Tag",
+  tag: (id: string) => {
+    const t = projectTags.value.find((t) => t.id === id);
+    return t ? tagLabel(t) : "Tag";
+  },
 };
 
 // Seed once: persisted timeline wins; otherwise pre-populate my items when the
@@ -301,7 +305,7 @@ const itemOptions = computed<SearchSelectOption[]>(() =>
   })),
 );
 const tagLaneOptions = computed<SearchSelectOption[]>(() =>
-  addableTags.value.map((t) => ({ value: t.id, label: t.name, hint: t.type })).sort((a, b) => a.label.localeCompare(b.label)),
+  addableTags.value.map((t) => ({ value: t.id, label: tagLabel(t), hint: t.type })).sort((a, b) => a.label.localeCompare(b.label)),
 );
 watch(itemPick, (id) => {
   if (!id) return;

--- a/ui/src/pages/download/Download.vue
+++ b/ui/src/pages/download/Download.vue
@@ -286,6 +286,7 @@ import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
 import { DownloadConfigCreate, DownloadConfigUpdate } from "src/api/downloadConfigs";
 import { useUserStore } from "src/stores/user-store";
 import { DownloadConfig, Image, ImageTag } from "src/types/api";
+import { tagLabel } from "src/util/tagOrder";
 import { ensurePermission, getStoredDirHandle, storeDirHandle } from "src/util/dirHandleStore";
 import {
   collectExistingFiles,
@@ -370,7 +371,8 @@ async function loadCardMeta(list: DownloadConfig[]) {
 }
 
 function tagName(id: string): string {
-  return projectTags.value.find((t) => t.id === id)?.name ?? id;
+  const tag = projectTags.value.find((t) => t.id === id);
+  return tag ? tagLabel(tag) : id;
 }
 const formatDateTime = (iso: string) => DateTime.fromISO(iso).toLocaleString(DateTime.DATETIME_SHORT);
 // Overall data progress = completed files + everything the workers have

--- a/ui/src/pages/image/imageQueryLogic.ts
+++ b/ui/src/pages/image/imageQueryLogic.ts
@@ -8,6 +8,7 @@ import { buildImageListParams } from "src/pages/image/imageListParams";
 import { emitter, showNotificationToast } from "src/boot/mitt";
 import { canEditImageTag } from "src/pages/upload/uploadUtil";
 import { isReviewErrorTag } from "src/util/uploadReview";
+import { tagLabel } from "src/util/tagOrder";
 
 export { buildImageListParams };
 
@@ -181,7 +182,7 @@ export async function addImageTag(image: ImageWithTagsType, tag: ImageTag) {
   // this is the one place the review freeze has to be honored client-side.
   if (!canEditImageTag(image, tag)) {
     showNotificationToast({
-      headline: isReviewErrorTag(tag.name) ? `Only a project admin can set '${tag.name}'` : `'${tag.name}' is frozen while the upload is in review`,
+      headline: isReviewErrorTag(tag.name) ? `Only a project admin can set '${tagLabel(tag)}'` : `'${tagLabel(tag)}' is frozen while the upload is in review`,
       type: "warning",
     });
     return;

--- a/ui/src/pages/project/ProjectStatistics.vue
+++ b/ui/src/pages/project/ProjectStatistics.vue
@@ -16,6 +16,7 @@ import { useRoute } from "vue-router";
 import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
 import { ImageTagsResponse } from "src/types/pocketbase";
 import Table, { TableColumn, TableRowActionType } from "src/components/Table.vue";
+import { tagLabel } from "src/util/tagOrder";
 
 import { api } from "src/api";
 const route = useRoute();
@@ -57,6 +58,7 @@ function trimTagDescription(tag: ImageTagWithCount): ImageTagWithCount {
   }
   return {
     ...tag,
+    name: tagLabel(tag),
     description: description,
   };
 }

--- a/ui/src/pages/project/ProjectTags.vue
+++ b/ui/src/pages/project/ProjectTags.vue
@@ -74,6 +74,7 @@ async function addTag(input: ImageTagsResponse) {
 
     const response = await api.imageTags.create({
       name: input.name,
+      displayName: input.displayName,
       description: input.description,
       isAlbum: input.isAlbum,
       order: toTagOrder(input.order) || undefined,
@@ -151,6 +152,7 @@ async function editTag(input: ImageTagsResponse) {
     console.log(`Editing tag ${input.name} in project ${item.value.name}`);
     const response = await api.imageTags.update(input.id, {
       name: input.name,
+      displayName: input.displayName ?? "",
       description: input.description,
       isAlbum: input.isAlbum,
       order: toTagOrder(input.order),
@@ -199,6 +201,7 @@ function showTagEdit() {
 
 const imageTagColumns: TableColumn<ImageTagsResponse>[] = [
   { key: "name", label: "Name" },
+  { key: "displayName", label: "Display name" },
   { key: "description", label: "Description" },
   { key: "order", label: "Order" },
   { key: "type", label: "Type" },

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -57,6 +57,7 @@ export interface EmbeddedUpload {
 export interface EmbeddedTag {
   id: string;
   name: string;
+  displayName?: string;
   type: string;
   isAlbum?: boolean;
   order?: number | null;
@@ -111,6 +112,7 @@ export type AiStatus = "pending" | "processing" | "done" | "error";
 export interface ImageTag {
   id: string;
   name: string;
+  displayName?: string; // optional UI label; empty = display the name
   description: string;
   isAlbum: boolean;
   order?: number | null; // positive rank; lower = applied/shown first, unset = last

--- a/ui/src/util/imageTags.ts
+++ b/ui/src/util/imageTags.ts
@@ -3,6 +3,7 @@ import { api } from "src/api";
 import { emitter } from "src/boot/mitt";
 import { useUserStore } from "src/stores/user-store";
 import { canEditImageTag } from "src/pages/upload/uploadUtil";
+import { tagLabel } from "src/util/tagOrder";
 
 // Tag-removal permission and mutation, shared by the sidebar badge list and
 // the zen-mode tag bar so both mirror the server rules and never offer a 403.
@@ -30,7 +31,7 @@ export async function removeTagAssignment(item: ImageWithTagsType | null, tagAss
   try {
     await api.imageTagAssignments.remove(tagAssignment.id);
     emitter.emit(`notification`, {
-      headline: `Tag ${tagAssignment.tag.name} removed`,
+      headline: `Tag ${tagLabel(tagAssignment.tag)} removed`,
       type: "success",
     });
     if (item) {
@@ -42,7 +43,7 @@ export async function removeTagAssignment(item: ImageWithTagsType | null, tagAss
     }
   } catch (error: any) {
     emitter.emit(`notification`, {
-      headline: `Error removing tag ${tagAssignment.tag.name}`,
+      headline: `Error removing tag ${tagLabel(tagAssignment.tag)}`,
       type: "error",
     });
   }

--- a/ui/src/util/tagOrder.ts
+++ b/ui/src/util/tagOrder.ts
@@ -6,6 +6,13 @@ import { EmbeddedTag, ImageTagAssignment } from "src/types/api";
 export type TagCategory = "template" | "manual" | "custom" | "ai";
 export const TAG_CATEGORIES: TagCategory[] = ["template", "manual", "custom", "ai"];
 
+// tagLabel is what the UI renders for a tag: the optional displayName when
+// set, otherwise the name. Matching, exports, and hotkey bindings always use
+// the name itself.
+export function tagLabel(tag: { name: string; displayName?: string }): string {
+  return tag.displayName || tag.name;
+}
+
 export function tagCategory(assignment: ImageTagAssignment): TagCategory {
   if (assignment.type === "inferred") return "ai";
   switch (assignment.tag.type) {

--- a/ui/tests/e2e/project-tags.spec.ts
+++ b/ui/tests/e2e/project-tags.spec.ts
@@ -46,6 +46,47 @@ test.describe.serial("project tags CRUD", () => {
     expect(errors, errors.join("\n")).toHaveLength(0);
   });
 
+  // Display name: shown wherever the tag is rendered, name is the fallback.
+  // Create with one, see it in the table; clear it via edit, see the name again.
+  test("create a tag with a display name, clear it, see the name fallback (admin)", async ({ page }) => {
+    const errors = collectJsErrors(page);
+    const NAME = "e2e-displayname-tag";
+    const DISPLAY = "E2E Pretty Label";
+    const project = await loginAs(page, "admin");
+    expect(project, "seed project should be active").not.toBeNull();
+
+    await page.goto(`/projects/${project!.id}/tags`);
+    await page.getByRole("button", { name: /Add Project Tag/i }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("Name", { exact: true }).fill(NAME);
+    await dialog.getByLabel(/^Display name/).fill(DISPLAY);
+    await dialog.getByLabel("Description", { exact: true }).fill("created by e2e");
+    await dialog.getByRole("button", { name: "Save tag" }).click();
+    await expect(dialog).toBeHidden();
+
+    await page.reload();
+    const row = page.getByRole("row").filter({ hasText: NAME });
+    await expect(row, "display name must persist after reload").toContainText(DISPLAY);
+
+    // --- clear the display name ---
+    await row.getByRole("button", { name: "Edit" }).click();
+    await dialog.getByLabel(/^Display name/).fill("");
+    await dialog.getByRole("button", { name: "Save tag" }).click();
+    await expect(dialog).toBeHidden();
+    await page.reload();
+    await expect(page.getByRole("row").filter({ hasText: NAME }), "cleared display name must be gone").not.toContainText(DISPLAY);
+
+    await page
+      .getByRole("row")
+      .filter({ hasText: NAME })
+      .getByRole("button", { name: "Delete" })
+      .click();
+    await page.reload();
+    await expect(page.getByRole("row").filter({ hasText: NAME })).toHaveCount(0);
+
+    expect(errors, errors.join("\n")).toHaveLength(0);
+  });
+
   // Regression: the dialog offered type=template while the API refused it
   // outright ("template tags are not creatable via the API"), so a project admin
   // could never add $COPYRIGHT/$WEEKDAY — the "$" prefix IS how a template tag is

--- a/ui/tests/tagOrder.spec.ts
+++ b/ui/tests/tagOrder.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compareTagOrder, exifKeywordAssignments, groupTagAssignments, tagCategory, toTagOrder } from "src/util/tagOrder";
+import { compareTagOrder, exifKeywordAssignments, groupTagAssignments, tagCategory, tagLabel, toTagOrder } from "src/util/tagOrder";
 import { ImageTagAssignment } from "src/types/api";
 
 function assignment(id: string, assignmentType: string, tagType: string, name: string, order?: number | null): ImageTagAssignment {
@@ -15,6 +15,14 @@ describe("tagCategory", () => {
     expect(tagCategory(assignment("2", "scheduled", "default", "quali"))).toBe("template");
     expect(tagCategory(assignment("3", "manual", "manual", "podium"))).toBe("manual");
     expect(tagCategory(assignment("4", "manual", "custom", "review"))).toBe("custom");
+  });
+});
+
+describe("tagLabel", () => {
+  it("prefers displayName, falls back to name when unset or empty", () => {
+    expect(tagLabel({ name: "20240817", displayName: "Race day" })).toBe("Race day");
+    expect(tagLabel({ name: "20240817", displayName: "" })).toBe("20240817");
+    expect(tagLabel({ name: "20240817" })).toBe("20240817");
   });
 });
 


### PR DESCRIPTION
Tags get an optional displayName column (ent auto-migrate). Every UI
surface renders it through a single tagLabel() fallback (displayName ||
name): badges, tagging dialog, gallery filter, timeline lanes,
statistics, hotkey help, schedule/download chips, notifications. Tag
search matches both names. The name stays the machine-readable
identity: EXIF keyword export (incl. combo pipe-splitting), the
reserved error tag, and hotkey bindings are untouched, locked by a
regression test.
