### PR TITLE
feat(tags): per-tag aiEnabled flag controls the AI vocabulary

### DIFF
--- a/api/ent/imagetag.go
+++ b/api/ent/imagetag.go
@@ -35,6 +35,8 @@ type ImageTag struct {
 	Description string `json:"description"`
 	// IsAlbum holds the value of the "isAlbum" field.
 	IsAlbum bool `json:"isAlbum"`
+	// AiEnabled holds the value of the "aiEnabled" field.
+	AiEnabled bool `json:"aiEnabled"`
 	// Order holds the value of the "order" field.
 	Order *int `json:"order,omitempty"`
 	// Type holds the value of the "type" field.
@@ -96,7 +98,7 @@ func (*ImageTag) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case imagetag.FieldCreatedBy, imagetag.FieldUpdatedBy:
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
-		case imagetag.FieldIsAlbum:
+		case imagetag.FieldIsAlbum, imagetag.FieldAiEnabled:
 			values[i] = new(sql.NullBool)
 		case imagetag.FieldOrder:
 			values[i] = new(sql.NullInt64)
@@ -174,6 +176,12 @@ func (_m *ImageTag) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field isAlbum", values[i])
 			} else if value.Valid {
 				_m.IsAlbum = value.Bool
+			}
+		case imagetag.FieldAiEnabled:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field aiEnabled", values[i])
+			} else if value.Valid {
+				_m.AiEnabled = value.Bool
 			}
 		case imagetag.FieldOrder:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -272,6 +280,9 @@ func (_m *ImageTag) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("isAlbum=")
 	builder.WriteString(fmt.Sprintf("%v", _m.IsAlbum))
+	builder.WriteString(", ")
+	builder.WriteString("aiEnabled=")
+	builder.WriteString(fmt.Sprintf("%v", _m.AiEnabled))
 	builder.WriteString(", ")
 	if v := _m.Order; v != nil {
 		builder.WriteString("order=")

--- a/api/ent/imagetag/imagetag.go
+++ b/api/ent/imagetag/imagetag.go
@@ -31,6 +31,8 @@ const (
 	FieldDescription = "description"
 	// FieldIsAlbum holds the string denoting the isalbum field in the database.
 	FieldIsAlbum = "is_album"
+	// FieldAiEnabled holds the string denoting the aienabled field in the database.
+	FieldAiEnabled = "ai_enabled"
 	// FieldOrder holds the string denoting the order field in the database.
 	FieldOrder = "order"
 	// FieldType holds the string denoting the type field in the database.
@@ -77,6 +79,7 @@ var Columns = []string{
 	FieldDisplayName,
 	FieldDescription,
 	FieldIsAlbum,
+	FieldAiEnabled,
 	FieldOrder,
 	FieldType,
 	FieldProjectID,
@@ -111,6 +114,8 @@ var (
 	DescriptionValidator func(string) error
 	// DefaultIsAlbum holds the default value on creation for the "isAlbum" field.
 	DefaultIsAlbum bool
+	// DefaultAiEnabled holds the default value on creation for the "aiEnabled" field.
+	DefaultAiEnabled bool
 	// OrderValidator is a validator for the "order" field. It is called by the builders before save.
 	OrderValidator func(int) error
 	// DefaultID holds the default value on creation for the "id" field.
@@ -190,6 +195,11 @@ func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 // ByIsAlbum orders the results by the isAlbum field.
 func ByIsAlbum(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIsAlbum, opts...).ToFunc()
+}
+
+// ByAiEnabled orders the results by the aiEnabled field.
+func ByAiEnabled(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldAiEnabled, opts...).ToFunc()
 }
 
 // ByOrder orders the results by the order field.

--- a/api/ent/imagetag/where.go
+++ b/api/ent/imagetag/where.go
@@ -106,6 +106,11 @@ func IsAlbum(v bool) predicate.ImageTag {
 	return predicate.ImageTag(sql.FieldEQ(FieldIsAlbum, v))
 }
 
+// AiEnabled applies equality check predicate on the "aiEnabled" field. It's identical to AiEnabledEQ.
+func AiEnabled(v bool) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldEQ(FieldAiEnabled, v))
+}
+
 // Order applies equality check predicate on the "order" field. It's identical to OrderEQ.
 func Order(v int) predicate.ImageTag {
 	return predicate.ImageTag(sql.FieldEQ(FieldOrder, v))
@@ -509,6 +514,16 @@ func IsAlbumEQ(v bool) predicate.ImageTag {
 // IsAlbumNEQ applies the NEQ predicate on the "isAlbum" field.
 func IsAlbumNEQ(v bool) predicate.ImageTag {
 	return predicate.ImageTag(sql.FieldNEQ(FieldIsAlbum, v))
+}
+
+// AiEnabledEQ applies the EQ predicate on the "aiEnabled" field.
+func AiEnabledEQ(v bool) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldEQ(FieldAiEnabled, v))
+}
+
+// AiEnabledNEQ applies the NEQ predicate on the "aiEnabled" field.
+func AiEnabledNEQ(v bool) predicate.ImageTag {
+	return predicate.ImageTag(sql.FieldNEQ(FieldAiEnabled, v))
 }
 
 // OrderEQ applies the EQ predicate on the "order" field.

--- a/api/ent/imagetag_create.go
+++ b/api/ent/imagetag_create.go
@@ -120,6 +120,20 @@ func (_c *ImageTagCreate) SetNillableIsAlbum(v *bool) *ImageTagCreate {
 	return _c
 }
 
+// SetAiEnabled sets the "aiEnabled" field.
+func (_c *ImageTagCreate) SetAiEnabled(v bool) *ImageTagCreate {
+	_c.mutation.SetAiEnabled(v)
+	return _c
+}
+
+// SetNillableAiEnabled sets the "aiEnabled" field if the given value is not nil.
+func (_c *ImageTagCreate) SetNillableAiEnabled(v *bool) *ImageTagCreate {
+	if v != nil {
+		_c.SetAiEnabled(*v)
+	}
+	return _c
+}
+
 // SetOrder sets the "order" field.
 func (_c *ImageTagCreate) SetOrder(v int) *ImageTagCreate {
 	_c.mutation.SetOrder(v)
@@ -242,6 +256,10 @@ func (_c *ImageTagCreate) defaults() {
 		v := imagetag.DefaultIsAlbum
 		_c.mutation.SetIsAlbum(v)
 	}
+	if _, ok := _c.mutation.AiEnabled(); !ok {
+		v := imagetag.DefaultAiEnabled
+		_c.mutation.SetAiEnabled(v)
+	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := imagetag.DefaultID()
 		_c.mutation.SetID(v)
@@ -274,6 +292,9 @@ func (_c *ImageTagCreate) check() error {
 	}
 	if _, ok := _c.mutation.IsAlbum(); !ok {
 		return &ValidationError{Name: "isAlbum", err: errors.New(`ent: missing required field "ImageTag.isAlbum"`)}
+	}
+	if _, ok := _c.mutation.AiEnabled(); !ok {
+		return &ValidationError{Name: "aiEnabled", err: errors.New(`ent: missing required field "ImageTag.aiEnabled"`)}
 	}
 	if v, ok := _c.mutation.Order(); ok {
 		if err := imagetag.OrderValidator(v); err != nil {
@@ -365,6 +386,10 @@ func (_c *ImageTagCreate) createSpec() (*ImageTag, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.IsAlbum(); ok {
 		_spec.SetField(imagetag.FieldIsAlbum, field.TypeBool, value)
 		_node.IsAlbum = value
+	}
+	if value, ok := _c.mutation.AiEnabled(); ok {
+		_spec.SetField(imagetag.FieldAiEnabled, field.TypeBool, value)
+		_node.AiEnabled = value
 	}
 	if value, ok := _c.mutation.Order(); ok {
 		_spec.SetField(imagetag.FieldOrder, field.TypeInt, value)

--- a/api/ent/imagetag_update.go
+++ b/api/ent/imagetag_update.go
@@ -120,6 +120,20 @@ func (_u *ImageTagUpdate) SetNillableIsAlbum(v *bool) *ImageTagUpdate {
 	return _u
 }
 
+// SetAiEnabled sets the "aiEnabled" field.
+func (_u *ImageTagUpdate) SetAiEnabled(v bool) *ImageTagUpdate {
+	_u.mutation.SetAiEnabled(v)
+	return _u
+}
+
+// SetNillableAiEnabled sets the "aiEnabled" field if the given value is not nil.
+func (_u *ImageTagUpdate) SetNillableAiEnabled(v *bool) *ImageTagUpdate {
+	if v != nil {
+		_u.SetAiEnabled(*v)
+	}
+	return _u
+}
+
 // SetOrder sets the "order" field.
 func (_u *ImageTagUpdate) SetOrder(v int) *ImageTagUpdate {
 	_u.mutation.ResetOrder()
@@ -366,6 +380,9 @@ func (_u *ImageTagUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.IsAlbum(); ok {
 		_spec.SetField(imagetag.FieldIsAlbum, field.TypeBool, value)
 	}
+	if value, ok := _u.mutation.AiEnabled(); ok {
+		_spec.SetField(imagetag.FieldAiEnabled, field.TypeBool, value)
+	}
 	if value, ok := _u.mutation.Order(); ok {
 		_spec.SetField(imagetag.FieldOrder, field.TypeInt, value)
 	}
@@ -601,6 +618,20 @@ func (_u *ImageTagUpdateOne) SetIsAlbum(v bool) *ImageTagUpdateOne {
 func (_u *ImageTagUpdateOne) SetNillableIsAlbum(v *bool) *ImageTagUpdateOne {
 	if v != nil {
 		_u.SetIsAlbum(*v)
+	}
+	return _u
+}
+
+// SetAiEnabled sets the "aiEnabled" field.
+func (_u *ImageTagUpdateOne) SetAiEnabled(v bool) *ImageTagUpdateOne {
+	_u.mutation.SetAiEnabled(v)
+	return _u
+}
+
+// SetNillableAiEnabled sets the "aiEnabled" field if the given value is not nil.
+func (_u *ImageTagUpdateOne) SetNillableAiEnabled(v *bool) *ImageTagUpdateOne {
+	if v != nil {
+		_u.SetAiEnabled(*v)
 	}
 	return _u
 }
@@ -880,6 +911,9 @@ func (_u *ImageTagUpdateOne) sqlSave(ctx context.Context) (_node *ImageTag, err 
 	}
 	if value, ok := _u.mutation.IsAlbum(); ok {
 		_spec.SetField(imagetag.FieldIsAlbum, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.AiEnabled(); ok {
+		_spec.SetField(imagetag.FieldAiEnabled, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.Order(); ok {
 		_spec.SetField(imagetag.FieldOrder, field.TypeInt, value)

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -285,6 +285,7 @@ var (
 		{Name: "display_name", Type: field.TypeString, Nullable: true},
 		{Name: "description", Type: field.TypeString},
 		{Name: "is_album", Type: field.TypeBool, Default: false},
+		{Name: "ai_enabled", Type: field.TypeBool, Default: true},
 		{Name: "order", Type: field.TypeInt, Nullable: true},
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"template", "default", "manual", "custom"}},
 		{Name: "project_id", Type: field.TypeString, Size: 15},
@@ -297,7 +298,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "image_tags_projects_imageTags",
-				Columns:    []*schema.Column{ImageTagsColumns[11]},
+				Columns:    []*schema.Column{ImageTagsColumns[12]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -306,12 +307,12 @@ var (
 			{
 				Name:    "imagetag_project_id",
 				Unique:  false,
-				Columns: []*schema.Column{ImageTagsColumns[11]},
+				Columns: []*schema.Column{ImageTagsColumns[12]},
 			},
 			{
 				Name:    "imagetag_name_project_id",
 				Unique:  true,
-				Columns: []*schema.Column{ImageTagsColumns[5], ImageTagsColumns[11]},
+				Columns: []*schema.Column{ImageTagsColumns[5], ImageTagsColumns[12]},
 			},
 		},
 	}

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -6572,6 +6572,7 @@ type ImageTagMutation struct {
 	displayName           *string
 	description           *string
 	isAlbum               *bool
+	aiEnabled             *bool
 	_order                *int
 	add_order             *int
 	_type                 *imagetag.Type
@@ -7020,6 +7021,42 @@ func (m *ImageTagMutation) ResetIsAlbum() {
 	m.isAlbum = nil
 }
 
+// SetAiEnabled sets the "aiEnabled" field.
+func (m *ImageTagMutation) SetAiEnabled(b bool) {
+	m.aiEnabled = &b
+}
+
+// AiEnabled returns the value of the "aiEnabled" field in the mutation.
+func (m *ImageTagMutation) AiEnabled() (r bool, exists bool) {
+	v := m.aiEnabled
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAiEnabled returns the old "aiEnabled" field's value of the ImageTag entity.
+// If the ImageTag object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ImageTagMutation) OldAiEnabled(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAiEnabled is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAiEnabled requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAiEnabled: %w", err)
+	}
+	return oldValue.AiEnabled, nil
+}
+
+// ResetAiEnabled resets all changes to the "aiEnabled" field.
+func (m *ImageTagMutation) ResetAiEnabled() {
+	m.aiEnabled = nil
+}
+
 // SetOrder sets the "order" field.
 func (m *ImageTagMutation) SetOrder(i int) {
 	m._order = &i
@@ -7331,7 +7368,7 @@ func (m *ImageTagMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ImageTagMutation) Fields() []string {
-	fields := make([]string, 0, 11)
+	fields := make([]string, 0, 12)
 	if m.createdAt != nil {
 		fields = append(fields, imagetag.FieldCreatedAt)
 	}
@@ -7355,6 +7392,9 @@ func (m *ImageTagMutation) Fields() []string {
 	}
 	if m.isAlbum != nil {
 		fields = append(fields, imagetag.FieldIsAlbum)
+	}
+	if m.aiEnabled != nil {
+		fields = append(fields, imagetag.FieldAiEnabled)
 	}
 	if m._order != nil {
 		fields = append(fields, imagetag.FieldOrder)
@@ -7389,6 +7429,8 @@ func (m *ImageTagMutation) Field(name string) (ent.Value, bool) {
 		return m.Description()
 	case imagetag.FieldIsAlbum:
 		return m.IsAlbum()
+	case imagetag.FieldAiEnabled:
+		return m.AiEnabled()
 	case imagetag.FieldOrder:
 		return m.Order()
 	case imagetag.FieldType:
@@ -7420,6 +7462,8 @@ func (m *ImageTagMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldDescription(ctx)
 	case imagetag.FieldIsAlbum:
 		return m.OldIsAlbum(ctx)
+	case imagetag.FieldAiEnabled:
+		return m.OldAiEnabled(ctx)
 	case imagetag.FieldOrder:
 		return m.OldOrder(ctx)
 	case imagetag.FieldType:
@@ -7490,6 +7534,13 @@ func (m *ImageTagMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetIsAlbum(v)
+		return nil
+	case imagetag.FieldAiEnabled:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAiEnabled(v)
 		return nil
 	case imagetag.FieldOrder:
 		v, ok := value.(int)
@@ -7626,6 +7677,9 @@ func (m *ImageTagMutation) ResetField(name string) error {
 		return nil
 	case imagetag.FieldIsAlbum:
 		m.ResetIsAlbum()
+		return nil
+	case imagetag.FieldAiEnabled:
+		m.ResetAiEnabled()
 		return nil
 	case imagetag.FieldOrder:
 		m.ResetOrder()

--- a/api/ent/runtime.go
+++ b/api/ent/runtime.go
@@ -262,8 +262,12 @@ func init() {
 	imagetagDescIsAlbum := imagetagFields[3].Descriptor()
 	// imagetag.DefaultIsAlbum holds the default value on creation for the isAlbum field.
 	imagetag.DefaultIsAlbum = imagetagDescIsAlbum.Default.(bool)
+	// imagetagDescAiEnabled is the schema descriptor for aiEnabled field.
+	imagetagDescAiEnabled := imagetagFields[4].Descriptor()
+	// imagetag.DefaultAiEnabled holds the default value on creation for the aiEnabled field.
+	imagetag.DefaultAiEnabled = imagetagDescAiEnabled.Default.(bool)
 	// imagetagDescOrder is the schema descriptor for order field.
-	imagetagDescOrder := imagetagFields[4].Descriptor()
+	imagetagDescOrder := imagetagFields[5].Descriptor()
 	// imagetag.OrderValidator is a validator for the "order" field. It is called by the builders before save.
 	imagetag.OrderValidator = imagetagDescOrder.Validators[0].(func(int) error)
 	// imagetagDescID is the schema descriptor for id field.

--- a/api/ent/schema/image_tag.go
+++ b/api/ent/schema/image_tag.go
@@ -21,6 +21,9 @@ func (ImageTag) Fields() []ent.Field {
 		field.String("displayName").Optional().StructTag(`json:"displayName,omitempty"`),
 		field.String("description").NotEmpty().StructTag(`json:"description"`),
 		field.Bool("isAlbum").Default(false).StructTag(`json:"isAlbum"`),
+		// Part of the vocabulary sent to the AI server; off = the model may not
+		// assign this tag (see service.AvailableTagNames).
+		field.Bool("aiEnabled").Default(true).StructTag(`json:"aiEnabled"`),
 		// Sort rank for tag application/display: lower first, ties and unset
 		// tags alphabetical, unset after all ranked tags.
 		field.Int("order").Optional().Nillable().Positive().StructTag(`json:"order,omitempty"`),

--- a/api/internal/repository/image_tag.go
+++ b/api/internal/repository/image_tag.go
@@ -86,6 +86,7 @@ type CreateImageTagParameters struct {
 	DisplayName string
 	Description string
 	IsAlbum     *bool
+	AiEnabled   *bool
 	Order       *int
 	Type        imagetag.Type
 	ProjectID   string
@@ -103,6 +104,9 @@ func (r *Repository) CreateImageTag(ctx context.Context, parameters *CreateImage
 		SetNillableOrder(parameters.Order)
 	if parameters.IsAlbum != nil {
 		create = create.SetIsAlbum(*parameters.IsAlbum)
+	}
+	if parameters.AiEnabled != nil {
+		create = create.SetAiEnabled(*parameters.AiEnabled)
 	}
 	item, err := create.Save(ctx)
 	if err != nil {
@@ -123,6 +127,7 @@ type UpdateImageTagParameters struct {
 	DisplayName *string
 	Description *string
 	IsAlbum     *bool
+	AiEnabled   *bool
 	// Order: nil = untouched; pointer to 0 = clear (0 is not a valid rank).
 	Order *int
 	Type  *imagetag.Type
@@ -159,6 +164,10 @@ func (r *Repository) UpdateImageTag(ctx context.Context, id string, parameters *
 	if parameters.IsAlbum != nil && item.IsAlbum != *parameters.IsAlbum {
 		update.SetIsAlbum(*parameters.IsAlbum)
 		st.SetFieldChanged(imagetag.FieldIsAlbum, item.IsAlbum, *parameters.IsAlbum)
+	}
+	if parameters.AiEnabled != nil && item.AiEnabled != *parameters.AiEnabled {
+		update.SetAiEnabled(*parameters.AiEnabled)
+		st.SetFieldChanged(imagetag.FieldAiEnabled, item.AiEnabled, *parameters.AiEnabled)
 	}
 	if parameters.Order != nil {
 		current := 0

--- a/api/internal/server/image_tags_controller.go
+++ b/api/internal/server/image_tags_controller.go
@@ -21,6 +21,7 @@ func (s *Server) imageTagResponse(ctx context.Context, t *ent.ImageTag) gin.H {
 		"displayName": t.DisplayName,
 		"description": t.Description,
 		"isAlbum":     t.IsAlbum,
+		"aiEnabled":   t.AiEnabled,
 		"order":       t.Order,
 		"type":        t.Type,
 		"project":     projectRefByID(ctx, s.Repository, t.ProjectID),
@@ -105,6 +106,7 @@ type createImageTagPayload struct {
 	DisplayName string `json:"displayName"`
 	Description string `json:"description"`
 	IsAlbum     *bool  `json:"isAlbum"`
+	AiEnabled   *bool  `json:"aiEnabled"`
 	Order       *int   `json:"order"`
 	Type        string `json:"type" binding:"required"`
 	ProjectID   string `json:"projectId" binding:"required"`
@@ -153,6 +155,7 @@ func (s *Server) createImageTag(c *gin.Context) {
 		DisplayName: payload.DisplayName,
 		Description: payload.Description,
 		IsAlbum:     payload.IsAlbum,
+		AiEnabled:   payload.AiEnabled,
 		Order:       payload.Order,
 		Type:        t,
 		ProjectID:   payload.ProjectID,
@@ -174,6 +177,7 @@ func (s *Server) updateImageTag(c *gin.Context) {
 		DisplayName *string `json:"displayName"`
 		Description *string `json:"description"`
 		IsAlbum     *bool   `json:"isAlbum"`
+		AiEnabled   *bool   `json:"aiEnabled"`
 		Order       *int    `json:"order"`
 		Type        *string `json:"type"`
 	}
@@ -188,7 +192,7 @@ func (s *Server) updateImageTag(c *gin.Context) {
 	if abortGetError(c, err) {
 		return
 	}
-	params := &repository.UpdateImageTagParameters{Name: payload.Name, DisplayName: payload.DisplayName, Description: payload.Description, IsAlbum: payload.IsAlbum, Order: payload.Order}
+	params := &repository.UpdateImageTagParameters{Name: payload.Name, DisplayName: payload.DisplayName, Description: payload.Description, IsAlbum: payload.IsAlbum, AiEnabled: payload.AiEnabled, Order: payload.Order}
 	resultingType := string(existing.Type)
 	if payload.Type != nil {
 		t := imagetag.Type(*payload.Type)

--- a/api/internal/service/ai_service.go
+++ b/api/internal/service/ai_service.go
@@ -424,12 +424,13 @@ func (s *AIService) processWith(ctx context.Context, imageID string, inference I
 	return nil
 }
 
-// AvailableTagNames is the vocabulary sent to the AI server: every project tag
-// except templates (unrendered "$X" patterns are not assignable). Shared by the
-// per-ingest request and the project prime hook so both stay in sync.
+// AvailableTagNames is the vocabulary sent to the AI server: every aiEnabled
+// project tag except templates (unrendered "$X" patterns are not assignable).
+// Shared by the per-ingest request and the project prime hook so both stay in
+// sync.
 func AvailableTagNames(ctx context.Context, repo *repository.Repository, projectID string) []string {
 	tags, err := repo.Client.ImageTag.Query().
-		Where(imagetag.ProjectID(projectID), imagetag.TypeNEQ(imagetag.TypeTemplate)).
+		Where(imagetag.ProjectID(projectID), imagetag.TypeNEQ(imagetag.TypeTemplate), imagetag.AiEnabled(true)).
 		All(ctx)
 	if err != nil {
 		log.Error().Err(err).Str("project", projectID).Msg("AI: loading project tags failed")

--- a/api/internal/service/ai_service_test.go
+++ b/api/internal/service/ai_service_test.go
@@ -416,3 +416,19 @@ func TestBootRecovery(t *testing.T) {
 	assert.Equal(t, "pending", aiStatus(t, svc, stale), "stale processing row must be re-queued")
 	assert.Equal(t, "processing", aiStatus(t, svc, fresh), "fresh processing row must be left to its replica")
 }
+
+// aiEnabled=false removes a tag from the AI vocabulary; everything else stays.
+func TestAvailableTagNamesExcludesAiDisabled(t *testing.T) {
+	svc, m := newSvc(t, &StubInference{})
+	ctx := context.Background()
+
+	before := AvailableTagNames(ctx, svc.repo, m.Project)
+	require.NotEmpty(t, before)
+	disabled := before[0]
+
+	svc.repo.Client.ImageTag.UpdateOneID(m.Tags[disabled]).SetAiEnabled(false).SaveX(ctx)
+
+	after := AvailableTagNames(ctx, svc.repo, m.Project)
+	assert.NotContains(t, after, disabled)
+	assert.Len(t, after, len(before)-1)
+}

--- a/ui/src/api/imageTags.ts
+++ b/ui/src/api/imageTags.ts
@@ -16,6 +16,7 @@ export interface ImageTagCreate {
   displayName?: string;
   description?: string;
   isAlbum?: boolean;
+  aiEnabled?: boolean; // omit = true (AI may assign the tag)
   order?: number; // positive rank; omit for unranked
   type: string;
   projectId: string;
@@ -26,6 +27,7 @@ export interface ImageTagUpdate {
   displayName?: string; // "" clears, omit leaves untouched
   description?: string;
   isAlbum?: boolean;
+  aiEnabled?: boolean;
   order?: number; // positive rank; 0 clears, omit leaves untouched
   type?: string;
 }

--- a/ui/src/components/project/TagDialog.vue
+++ b/ui/src/components/project/TagDialog.vue
@@ -160,5 +160,6 @@ const editTagFields: EditField<ImageTagsResponse>[] = [
   { key: "description", label: "Description", type: EditFieldType.TEXT },
   { key: "order", label: "Order (lower first, empty = last)", type: EditFieldType.TEXT },
   { key: "type", label: "Type", type: EditFieldType.SELECT, options: ["template", "default", "manual", "custom"] },
+  { key: "aiEnabled", label: "AI tagging", type: EditFieldType.BOOLEAN, hint: "AI may assign this tag" },
 ];
 </script>

--- a/ui/src/pages/project/ProjectTags.vue
+++ b/ui/src/pages/project/ProjectTags.vue
@@ -155,6 +155,7 @@ async function editTag(input: ImageTagsResponse) {
       displayName: input.displayName ?? "",
       description: input.description,
       isAlbum: input.isAlbum,
+      aiEnabled: input.aiEnabled,
       order: toTagOrder(input.order),
       type: input.type,
     });

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -115,6 +115,7 @@ export interface ImageTag {
   displayName?: string; // optional UI label; empty = display the name
   description: string;
   isAlbum: boolean;
+  aiEnabled: boolean; // part of the AI vocabulary; false = model may not assign it
   order?: number | null; // positive rank; lower = applied/shown first, unset = last
   type: string; // template | default | manual | custom
   project: EmbeddedProject;

--- a/ui/tests/e2e/project-tags.spec.ts
+++ b/ui/tests/e2e/project-tags.spec.ts
@@ -116,4 +116,40 @@ test.describe.serial("project tags CRUD", () => {
 
     expect(errors, errors.join("\n")).toHaveLength(0);
   });
+
+  // aiEnabled: the per-tag switch that keeps a tag out of the AI vocabulary.
+  // New tags default to on; switching it off must survive a reload.
+  test("toggle a tag's AI flag off and see it persist (admin)", async ({ page }) => {
+    const errors = collectJsErrors(page);
+    const NAME = "e2e-ai-flag-tag";
+    const project = await loginAs(page, "admin");
+    expect(project, "seed project should be active").not.toBeNull();
+
+    await page.goto(`/projects/${project!.id}/tags`);
+    await page.getByRole("button", { name: /Add Project Tag/i }).click();
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("Name", { exact: true }).fill(NAME);
+    await dialog.getByLabel("Description", { exact: true }).fill("created by e2e");
+    await dialog.getByRole("button", { name: "Save tag" }).click();
+    await expect(dialog).toBeHidden();
+
+    const row = page.getByRole("row").filter({ hasText: NAME });
+    await row.getByRole("button", { name: "Edit" }).click();
+    const aiCheckbox = dialog.getByLabel("AI tagging", { exact: true });
+    await expect(aiCheckbox, "a new tag must default to AI-enabled").toBeChecked();
+    await aiCheckbox.uncheck();
+    await dialog.getByRole("button", { name: "Save tag" }).click();
+    await expect(dialog).toBeHidden();
+
+    await page.reload();
+    await page.getByRole("row").filter({ hasText: NAME }).getByRole("button", { name: "Edit" }).click();
+    await expect(dialog.getByLabel("AI tagging", { exact: true }), "AI-off must persist after reload").not.toBeChecked();
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+
+    await page.getByRole("row").filter({ hasText: NAME }).getByRole("button", { name: "Delete" }).click();
+    await page.reload();
+    await expect(page.getByRole("row").filter({ hasText: NAME })).toHaveCount(0);
+
+    expect(errors, errors.join("\n")).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Every non-template project tag was sent to the AI server as an assignable
tag. aiEnabled (default true, auto-migrated) lets a projectAdmin curate
which tags the model may assign — e.g. exclude false-positive-prone
dynamic-event tags. Filtered centrally in AvailableTagNames, so the
per-ingest request and the prime hook stay in sync; exposed in the tag
create/update API and as an 'AI tagging' checkbox in the tag edit dialog.
