### PR TITLE
feat(cameras): soft delete + surfaced upload and time-sync errors

### DIFF
--- a/api/ent/camera.go
+++ b/api/ent/camera.go
@@ -31,6 +31,8 @@ type Camera struct {
 	Name string `json:"name"`
 	// UserID holds the value of the "user_id" field.
 	UserID uuid.UUID `json:"-"`
+	// DeletedAt holds the value of the "deletedAt" field.
+	DeletedAt *time.Time `json:"-"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CameraQuery when eager-loading is set.
 	Edges        CameraEdges `json:"edges"`
@@ -99,7 +101,7 @@ func (*Camera) scanValues(columns []string) ([]any, error) {
 			values[i] = &sql.NullScanner{S: new(uuid.UUID)}
 		case camera.FieldID, camera.FieldName:
 			values[i] = new(sql.NullString)
-		case camera.FieldCreatedAt, camera.FieldUpdatedAt:
+		case camera.FieldCreatedAt, camera.FieldUpdatedAt, camera.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
 		case camera.FieldUserID:
 			values[i] = new(uuid.UUID)
@@ -161,6 +163,13 @@ func (_m *Camera) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field user_id", values[i])
 			} else if value != nil {
 				_m.UserID = *value
+			}
+		case camera.FieldDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field deletedAt", values[i])
+			} else if value.Valid {
+				_m.DeletedAt = new(time.Time)
+				*_m.DeletedAt = value.Time
 			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
@@ -239,6 +248,11 @@ func (_m *Camera) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("user_id=")
 	builder.WriteString(fmt.Sprintf("%v", _m.UserID))
+	builder.WriteString(", ")
+	if v := _m.DeletedAt; v != nil {
+		builder.WriteString("deletedAt=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/api/ent/camera/camera.go
+++ b/api/ent/camera/camera.go
@@ -26,6 +26,8 @@ const (
 	FieldName = "name"
 	// FieldUserID holds the string denoting the user_id field in the database.
 	FieldUserID = "user_id"
+	// FieldDeletedAt holds the string denoting the deletedat field in the database.
+	FieldDeletedAt = "deleted_at"
 	// EdgeUser holds the string denoting the user edge name in mutations.
 	EdgeUser = "user"
 	// EdgeTimeOffsets holds the string denoting the timeoffsets edge name in mutations.
@@ -75,6 +77,7 @@ var Columns = []string{
 	FieldUpdatedBy,
 	FieldName,
 	FieldUserID,
+	FieldDeletedAt,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -138,6 +141,11 @@ func ByName(opts ...sql.OrderTermOption) OrderOption {
 // ByUserID orders the results by the user_id field.
 func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deletedAt field.
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
 }
 
 // ByUserField orders the results by user field.

--- a/api/ent/camera/where.go
+++ b/api/ent/camera/where.go
@@ -96,6 +96,11 @@ func UserID(v uuid.UUID) predicate.Camera {
 	return predicate.Camera(sql.FieldEQ(FieldUserID, v))
 }
 
+// DeletedAt applies equality check predicate on the "deletedAt" field. It's identical to DeletedAtEQ.
+func DeletedAt(v time.Time) predicate.Camera {
+	return predicate.Camera(sql.FieldEQ(FieldDeletedAt, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "createdAt" field.
 func CreatedAtEQ(v time.Time) predicate.Camera {
 	return predicate.Camera(sql.FieldEQ(FieldCreatedAt, v))
@@ -359,6 +364,56 @@ func UserIDIn(vs ...uuid.UUID) predicate.Camera {
 // UserIDNotIn applies the NotIn predicate on the "user_id" field.
 func UserIDNotIn(vs ...uuid.UUID) predicate.Camera {
 	return predicate.Camera(sql.FieldNotIn(FieldUserID, vs...))
+}
+
+// DeletedAtEQ applies the EQ predicate on the "deletedAt" field.
+func DeletedAtEQ(v time.Time) predicate.Camera {
+	return predicate.Camera(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtNEQ applies the NEQ predicate on the "deletedAt" field.
+func DeletedAtNEQ(v time.Time) predicate.Camera {
+	return predicate.Camera(sql.FieldNEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtIn applies the In predicate on the "deletedAt" field.
+func DeletedAtIn(vs ...time.Time) predicate.Camera {
+	return predicate.Camera(sql.FieldIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtNotIn applies the NotIn predicate on the "deletedAt" field.
+func DeletedAtNotIn(vs ...time.Time) predicate.Camera {
+	return predicate.Camera(sql.FieldNotIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtGT applies the GT predicate on the "deletedAt" field.
+func DeletedAtGT(v time.Time) predicate.Camera {
+	return predicate.Camera(sql.FieldGT(FieldDeletedAt, v))
+}
+
+// DeletedAtGTE applies the GTE predicate on the "deletedAt" field.
+func DeletedAtGTE(v time.Time) predicate.Camera {
+	return predicate.Camera(sql.FieldGTE(FieldDeletedAt, v))
+}
+
+// DeletedAtLT applies the LT predicate on the "deletedAt" field.
+func DeletedAtLT(v time.Time) predicate.Camera {
+	return predicate.Camera(sql.FieldLT(FieldDeletedAt, v))
+}
+
+// DeletedAtLTE applies the LTE predicate on the "deletedAt" field.
+func DeletedAtLTE(v time.Time) predicate.Camera {
+	return predicate.Camera(sql.FieldLTE(FieldDeletedAt, v))
+}
+
+// DeletedAtIsNil applies the IsNil predicate on the "deletedAt" field.
+func DeletedAtIsNil() predicate.Camera {
+	return predicate.Camera(sql.FieldIsNull(FieldDeletedAt))
+}
+
+// DeletedAtNotNil applies the NotNil predicate on the "deletedAt" field.
+func DeletedAtNotNil() predicate.Camera {
+	return predicate.Camera(sql.FieldNotNull(FieldDeletedAt))
 }
 
 // HasUser applies the HasEdge predicate on the "user" edge.

--- a/api/ent/camera_create.go
+++ b/api/ent/camera_create.go
@@ -93,6 +93,20 @@ func (_c *CameraCreate) SetUserID(v uuid.UUID) *CameraCreate {
 	return _c
 }
 
+// SetDeletedAt sets the "deletedAt" field.
+func (_c *CameraCreate) SetDeletedAt(v time.Time) *CameraCreate {
+	_c.mutation.SetDeletedAt(v)
+	return _c
+}
+
+// SetNillableDeletedAt sets the "deletedAt" field if the given value is not nil.
+func (_c *CameraCreate) SetNillableDeletedAt(v *time.Time) *CameraCreate {
+	if v != nil {
+		_c.SetDeletedAt(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *CameraCreate) SetID(v string) *CameraCreate {
 	_c.mutation.SetID(v)
@@ -287,6 +301,10 @@ func (_c *CameraCreate) createSpec() (*Camera, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.Name(); ok {
 		_spec.SetField(camera.FieldName, field.TypeString, value)
 		_node.Name = value
+	}
+	if value, ok := _c.mutation.DeletedAt(); ok {
+		_spec.SetField(camera.FieldDeletedAt, field.TypeTime, value)
+		_node.DeletedAt = &value
 	}
 	if nodes := _c.mutation.UserIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/api/ent/camera_update.go
+++ b/api/ent/camera_update.go
@@ -87,6 +87,26 @@ func (_u *CameraUpdate) SetNillableUserID(v *uuid.UUID) *CameraUpdate {
 	return _u
 }
 
+// SetDeletedAt sets the "deletedAt" field.
+func (_u *CameraUpdate) SetDeletedAt(v time.Time) *CameraUpdate {
+	_u.mutation.SetDeletedAt(v)
+	return _u
+}
+
+// SetNillableDeletedAt sets the "deletedAt" field if the given value is not nil.
+func (_u *CameraUpdate) SetNillableDeletedAt(v *time.Time) *CameraUpdate {
+	if v != nil {
+		_u.SetDeletedAt(*v)
+	}
+	return _u
+}
+
+// ClearDeletedAt clears the value of the "deletedAt" field.
+func (_u *CameraUpdate) ClearDeletedAt() *CameraUpdate {
+	_u.mutation.ClearDeletedAt()
+	return _u
+}
+
 // SetUser sets the "user" edge to the User entity.
 func (_u *CameraUpdate) SetUser(v *User) *CameraUpdate {
 	return _u.SetUserID(v.ID)
@@ -286,6 +306,12 @@ func (_u *CameraUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(camera.FieldName, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.DeletedAt(); ok {
+		_spec.SetField(camera.FieldDeletedAt, field.TypeTime, value)
+	}
+	if _u.mutation.DeletedAtCleared() {
+		_spec.ClearField(camera.FieldDeletedAt, field.TypeTime)
 	}
 	if _u.mutation.UserCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -525,6 +551,26 @@ func (_u *CameraUpdateOne) SetNillableUserID(v *uuid.UUID) *CameraUpdateOne {
 	return _u
 }
 
+// SetDeletedAt sets the "deletedAt" field.
+func (_u *CameraUpdateOne) SetDeletedAt(v time.Time) *CameraUpdateOne {
+	_u.mutation.SetDeletedAt(v)
+	return _u
+}
+
+// SetNillableDeletedAt sets the "deletedAt" field if the given value is not nil.
+func (_u *CameraUpdateOne) SetNillableDeletedAt(v *time.Time) *CameraUpdateOne {
+	if v != nil {
+		_u.SetDeletedAt(*v)
+	}
+	return _u
+}
+
+// ClearDeletedAt clears the value of the "deletedAt" field.
+func (_u *CameraUpdateOne) ClearDeletedAt() *CameraUpdateOne {
+	_u.mutation.ClearDeletedAt()
+	return _u
+}
+
 // SetUser sets the "user" edge to the User entity.
 func (_u *CameraUpdateOne) SetUser(v *User) *CameraUpdateOne {
 	return _u.SetUserID(v.ID)
@@ -754,6 +800,12 @@ func (_u *CameraUpdateOne) sqlSave(ctx context.Context) (_node *Camera, err erro
 	}
 	if value, ok := _u.mutation.Name(); ok {
 		_spec.SetField(camera.FieldName, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.DeletedAt(); ok {
+		_spec.SetField(camera.FieldDeletedAt, field.TypeTime, value)
+	}
+	if _u.mutation.DeletedAtCleared() {
+		_spec.ClearField(camera.FieldDeletedAt, field.TypeTime)
 	}
 	if _u.mutation.UserCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/api/ent/migrate/schema.go
+++ b/api/ent/migrate/schema.go
@@ -89,6 +89,7 @@ var (
 		{Name: "created_by", Type: field.TypeUUID, Nullable: true},
 		{Name: "updated_by", Type: field.TypeUUID, Nullable: true},
 		{Name: "name", Type: field.TypeString},
+		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "user_id", Type: field.TypeUUID},
 	}
 	// CamerasTable holds the schema information for the "cameras" table.
@@ -99,7 +100,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "cameras_users_cameras",
-				Columns:    []*schema.Column{CamerasColumns[6]},
+				Columns:    []*schema.Column{CamerasColumns[7]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -108,12 +109,15 @@ var (
 			{
 				Name:    "camera_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{CamerasColumns[6]},
+				Columns: []*schema.Column{CamerasColumns[7]},
 			},
 			{
 				Name:    "camera_name_user_id",
 				Unique:  true,
-				Columns: []*schema.Column{CamerasColumns[5], CamerasColumns[6]},
+				Columns: []*schema.Column{CamerasColumns[5], CamerasColumns[7]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "deleted_at IS NULL",
+				},
 			},
 		},
 	}

--- a/api/ent/mutation.go
+++ b/api/ent/mutation.go
@@ -1955,6 +1955,7 @@ type CameraMutation struct {
 	createdBy          *uuid.UUID
 	updatedBy          *uuid.UUID
 	name               *string
+	deletedAt          *time.Time
 	clearedFields      map[string]struct{}
 	user               *uuid.UUID
 	cleareduser        bool
@@ -2318,6 +2319,55 @@ func (m *CameraMutation) ResetUserID() {
 	m.user = nil
 }
 
+// SetDeletedAt sets the "deletedAt" field.
+func (m *CameraMutation) SetDeletedAt(t time.Time) {
+	m.deletedAt = &t
+}
+
+// DeletedAt returns the value of the "deletedAt" field in the mutation.
+func (m *CameraMutation) DeletedAt() (r time.Time, exists bool) {
+	v := m.deletedAt
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedAt returns the old "deletedAt" field's value of the Camera entity.
+// If the Camera object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CameraMutation) OldDeletedAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedAt: %w", err)
+	}
+	return oldValue.DeletedAt, nil
+}
+
+// ClearDeletedAt clears the value of the "deletedAt" field.
+func (m *CameraMutation) ClearDeletedAt() {
+	m.deletedAt = nil
+	m.clearedFields[camera.FieldDeletedAt] = struct{}{}
+}
+
+// DeletedAtCleared returns if the "deletedAt" field was cleared in this mutation.
+func (m *CameraMutation) DeletedAtCleared() bool {
+	_, ok := m.clearedFields[camera.FieldDeletedAt]
+	return ok
+}
+
+// ResetDeletedAt resets all changes to the "deletedAt" field.
+func (m *CameraMutation) ResetDeletedAt() {
+	m.deletedAt = nil
+	delete(m.clearedFields, camera.FieldDeletedAt)
+}
+
 // ClearUser clears the "user" edge to the User entity.
 func (m *CameraMutation) ClearUser() {
 	m.cleareduser = true
@@ -2541,7 +2591,7 @@ func (m *CameraMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CameraMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.createdAt != nil {
 		fields = append(fields, camera.FieldCreatedAt)
 	}
@@ -2559,6 +2609,9 @@ func (m *CameraMutation) Fields() []string {
 	}
 	if m.user != nil {
 		fields = append(fields, camera.FieldUserID)
+	}
+	if m.deletedAt != nil {
+		fields = append(fields, camera.FieldDeletedAt)
 	}
 	return fields
 }
@@ -2580,6 +2633,8 @@ func (m *CameraMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case camera.FieldUserID:
 		return m.UserID()
+	case camera.FieldDeletedAt:
+		return m.DeletedAt()
 	}
 	return nil, false
 }
@@ -2601,6 +2656,8 @@ func (m *CameraMutation) OldField(ctx context.Context, name string) (ent.Value, 
 		return m.OldName(ctx)
 	case camera.FieldUserID:
 		return m.OldUserID(ctx)
+	case camera.FieldDeletedAt:
+		return m.OldDeletedAt(ctx)
 	}
 	return nil, fmt.Errorf("unknown Camera field %s", name)
 }
@@ -2652,6 +2709,13 @@ func (m *CameraMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetUserID(v)
 		return nil
+	case camera.FieldDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedAt(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Camera field %s", name)
 }
@@ -2688,6 +2752,9 @@ func (m *CameraMutation) ClearedFields() []string {
 	if m.FieldCleared(camera.FieldUpdatedBy) {
 		fields = append(fields, camera.FieldUpdatedBy)
 	}
+	if m.FieldCleared(camera.FieldDeletedAt) {
+		fields = append(fields, camera.FieldDeletedAt)
+	}
 	return fields
 }
 
@@ -2707,6 +2774,9 @@ func (m *CameraMutation) ClearField(name string) error {
 		return nil
 	case camera.FieldUpdatedBy:
 		m.ClearUpdatedBy()
+		return nil
+	case camera.FieldDeletedAt:
+		m.ClearDeletedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown Camera nullable field %s", name)
@@ -2733,6 +2803,9 @@ func (m *CameraMutation) ResetField(name string) error {
 		return nil
 	case camera.FieldUserID:
 		m.ResetUserID()
+		return nil
+	case camera.FieldDeletedAt:
+		m.ResetDeletedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown Camera field %s", name)

--- a/api/ent/schema/camera.go
+++ b/api/ent/schema/camera.go
@@ -21,6 +21,9 @@ func (Camera) Fields() []ent.Field {
 		// "Z6") and the old minimum rejected them with an opaque 400.
 		field.String("name").NotEmpty().StructTag(`json:"name"`),
 		field.UUID("user_id", uuid.UUID{}).StructTag(`json:"-"`),
+		// Soft delete: images/uploads keep their FK (NoAction) so history and
+		// EXIF time correction survive; deleted cameras vanish from every list.
+		field.Time("deletedAt").StorageKey("deleted_at").Optional().Nillable().StructTag(`json:"-"`),
 	}
 }
 
@@ -36,6 +39,9 @@ func (Camera) Edges() []ent.Edge {
 func (Camera) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("user_id"),
-		index.Fields("name", "user_id").Unique(),
+		// Partial: only live cameras contend for the name, so a soft-deleted
+		// "R5" frees the name for a new "R5". Existing DBs get the swap from
+		// ensureCameraSoftDeleteIndex (auto-migrate is additive-only).
+		index.Fields("name", "user_id").Unique().Annotations(entsql.IndexWhere("deleted_at IS NULL")),
 	}
 }

--- a/api/internal/database/connection.go
+++ b/api/internal/database/connection.go
@@ -103,6 +103,9 @@ func (d *Connection) initPostgres() error {
 	if err := ensureGINIndex(context.Background(), db); err != nil {
 		log.Panic().Err(err).Msg("failed to ensure images.imageTags GIN index")
 	}
+	if err := ensureCameraSoftDeleteIndex(context.Background(), db, d.Options.Schema); err != nil {
+		log.Panic().Err(err).Msg("failed to ensure partial camera name index")
+	}
 	if err := backfillScheduleItemTags(context.Background(), db, d.Options.Schema); err != nil {
 		log.Panic().Err(err).Msg("failed to backfill schedule_item_tags join table")
 	}
@@ -132,6 +135,47 @@ func ensureGINIndex(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("failed to create GIN fallback index: %w", err)
 	}
 	log.Warn().Msg("ent auto-migrate omitted jsonb_path_ops opclass; installed fallback GIN index image_image_tags")
+	return nil
+}
+
+// ensureCameraSoftDeleteIndex guarantees the (name, user_id) unique index is
+// the partial one (WHERE deleted_at IS NULL). Fresh DBs and current ent
+// versions get it from auto-migrate; this verifies the predicate, swaps a
+// pre-soft-delete strict index, and recreates a missing index (e.g. after a
+// crashed earlier swap). The swap is transactional so a failure mid-way never
+// leaves the table without uniqueness. Unqualified DDL resolves via the DSN's
+// search_path to the same schema the inspection filters on.
+func ensureCameraSoftDeleteIndex(ctx context.Context, db *sql.DB, schema string) error {
+	if schema == "" {
+		schema = "public"
+	}
+	var def string
+	err := db.QueryRowContext(ctx,
+		`SELECT indexdef FROM pg_indexes WHERE schemaname = $1 AND tablename = 'cameras' AND indexname = 'camera_name_user_id'`,
+		schema).Scan(&def)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("failed to inspect camera name index: %w", err)
+	}
+	if strings.Contains(strings.ToLower(def), "deleted_at is null") {
+		return nil
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin camera index swap: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DROP INDEX IF EXISTS camera_name_user_id`); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("failed to drop strict camera name index: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`CREATE UNIQUE INDEX camera_name_user_id ON cameras (name, user_id) WHERE deleted_at IS NULL`); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("failed to create partial camera name index: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit camera index swap: %w", err)
+	}
+	log.Info().Msg("installed soft-delete partial camera name index")
 	return nil
 }
 

--- a/api/internal/repository/camera.go
+++ b/api/internal/repository/camera.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -18,12 +19,19 @@ var cameraSortFields = map[string]string{
 	"updatedAt": camera.FieldUpdatedAt,
 }
 
+// GetCamera resolves live cameras only — soft-deleted ones read as not found.
 func (r *Repository) GetCamera(ctx context.Context, id string) (*ent.Camera, error) {
-	item, err := r.Client.Camera.Query().Where(camera.IDEQ(id)).Only(ctx)
+	item, err := r.Client.Camera.Query().Where(camera.IDEQ(id), camera.DeletedAtIsNil()).Only(ctx)
 	if err != nil && !ent.IsNotFound(err) {
 		log.Error().Err(err).Msg("error getting camera")
 	}
 	return item, err
+}
+
+// GetCameraIncludingDeleted resolves a camera even after soft deletion — image
+// and upload serialization must keep naming the camera that shot them.
+func (r *Repository) GetCameraIncludingDeleted(ctx context.Context, id string) (*ent.Camera, error) {
+	return r.Client.Camera.Get(ctx, id)
 }
 
 type GetCameraParameters struct {
@@ -33,7 +41,7 @@ type GetCameraParameters struct {
 }
 
 func (r *Repository) GetCameras(ctx context.Context, parameters *GetCameraParameters) ([]*ent.Camera, int, error) {
-	predicates := []predicate.Camera{}
+	predicates := []predicate.Camera{camera.DeletedAtIsNil()}
 	if parameters.UserID != nil {
 		predicates = append(predicates, camera.UserID(*parameters.UserID))
 	}
@@ -131,8 +139,14 @@ func (r *Repository) UpdateCamera(ctx context.Context, id string, parameters *Up
 	return item, nil
 }
 
+// DeleteCamera soft-deletes: images and uploads keep their camera reference
+// and the camera's time offsets stay live for EXIF time correction. The
+// partial unique index frees the name for reuse.
 func (r *Repository) DeleteCamera(ctx context.Context, id string) error {
-	if err := r.Client.Camera.DeleteOneID(id).Exec(ctx); err != nil {
+	if err := r.Client.Camera.UpdateOneID(id).
+		SetDeletedAt(time.Now()).
+		SetUpdatedBy(util.GetActorID(ctx)).
+		Exec(ctx); err != nil {
 		log.Error().Err(err).Msg("error deleting camera")
 		return err
 	}

--- a/api/internal/repository/repository_test.go
+++ b/api/internal/repository/repository_test.go
@@ -282,6 +282,33 @@ func TestUserCRUDUUID(t *testing.T) {
 	require.NoError(t, repo.DeleteUser(ctx, u.ID))
 }
 
+// PocketBase-hook parity: a new user without an explicit copyright tag gets
+// their last name as the default; an explicit tag always wins.
+func TestCreateUserDefaultsCopyrightTagToLastName(t *testing.T) {
+	ctx := context.Background()
+	repo := testRepo(t)
+
+	defaulted, err := repo.CreateUser(ctx, &repository.CreateUserParameters{
+		Username: "trinity", FirstName: "Trinity", LastName: "Moss",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Moss", defaulted.CopyrightTag)
+
+	emptied, err := repo.CreateUser(ctx, &repository.CreateUserParameters{
+		Username: "smith", FirstName: "Agent", LastName: "Smith",
+		CopyrightTag: util.StringPointer(""),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Smith", emptied.CopyrightTag)
+
+	explicit, err := repo.CreateUser(ctx, &repository.CreateUserParameters{
+		Username: "oracle", FirstName: "The", LastName: "Oracle",
+		CopyrightTag: util.StringPointer("ORCL"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ORCL", explicit.CopyrightTag)
+}
+
 // GetUploadMetrics runs a hand-built join through the ent SQL builder — the one
 // query in the repository that is not fully typed. This pins its behavior
 // against a real database (an aliasing bug here produced a runtime SQL error

--- a/api/internal/repository/user.go
+++ b/api/internal/repository/user.go
@@ -121,8 +121,12 @@ func (r *Repository) CreateUser(ctx context.Context, parameters *CreateUserParam
 	if parameters.PasswordHash != nil {
 		create = create.SetPasswordHash(*parameters.PasswordHash)
 	}
-	if parameters.CopyrightTag != nil {
+	if parameters.CopyrightTag != nil && *parameters.CopyrightTag != "" {
 		create = create.SetCopyrightTag(*parameters.CopyrightTag)
+	} else {
+		// PocketBase-hook parity: a new user's copyright tag defaults to their
+		// last name, so photographers can upload without touching their profile.
+		create = create.SetCopyrightTag(parameters.LastName)
 	}
 	if parameters.Email != nil {
 		create = create.SetEmail(*parameters.Email)

--- a/api/internal/server/cameras_controller.go
+++ b/api/internal/server/cameras_controller.go
@@ -140,7 +140,7 @@ func (s *Server) updateCamera(c *gin.Context) {
 }
 
 func (s *Server) deleteCamera(c *gin.Context) {
-	// authz (S8): admin or owner; cascades time_offsets.
+	// authz (S8): admin or owner. Soft delete — images/uploads keep the ref.
 	id, ok := getIdParam(c)
 	if !ok {
 		return
@@ -152,10 +152,7 @@ func (s *Server) deleteCamera(c *gin.Context) {
 	if !allow(c, authorization.CanModifyCamera(authUser(c), cam)) {
 		return
 	}
-	if err := s.Repository.DeleteCamera(c.Request.Context(), id); err != nil {
-		if abortGetError(c, err) {
-			return
-		}
+	if err := s.Repository.DeleteCamera(c.Request.Context(), id); abortMutationError(c, err) {
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/api/internal/server/refs.go
+++ b/api/internal/server/refs.go
@@ -32,7 +32,7 @@ func cameraRefByID(ctx context.Context, repo *repository.Repository, id string) 
 	if id == "" {
 		return nil
 	}
-	cam, err := repo.GetCamera(ctx, id)
+	cam, err := repo.GetCameraIncludingDeleted(ctx, id)
 	if err != nil {
 		return nil
 	}

--- a/api/test/e2e/authorization_e2e_test.go
+++ b/api/test/e2e/authorization_e2e_test.go
@@ -157,6 +157,8 @@ func TestAuthorizationMatrix(t *testing.T) {
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 		camID := decodeBody(t, resp)["id"].(string)
 		assert.Equal(t, http.StatusNoContent, status(t, editor, http.MethodDelete, "/api/v1/cameras/"+camID, nil))
+		// the API delete is a soft delete — hard-wipe the row so S2 seed counts stay green.
+		_ = c.Camera.DeleteOneID(camID).Exec(ctx)
 	})
 	t.Run("owner can delete own upload", func(t *testing.T) {
 		resp := doJSON(t, editor, http.MethodPost, "/api/v1/uploads", map[string]any{

--- a/api/test/e2e/camera_soft_delete_e2e_test.go
+++ b/api/test/e2e/camera_soft_delete_e2e_test.go
@@ -1,0 +1,73 @@
+//go:build e2e
+
+// Camera soft delete (§4.8): a camera with images can be deleted — it vanishes
+// from reads and lists and frees its name, but its existing images keep naming
+// it. Before soft delete the images FK made this a 500.
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shutterbase/shutterbase/ent/camera"
+)
+
+func TestCameraSoftDelete(t *testing.T) {
+	ctx := context.Background()
+	c := stack.DB.Client
+	m := stack.Manifest
+	editor := roleClient(t, "projectEditor")
+
+	resp := doJSON(t, editor, http.MethodPost, "/api/v1/cameras", map[string]any{"name": "softdelete-cam"})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	camID := decodeBody(t, resp)["id"].(string)
+
+	img, err := c.Image.Create().
+		SetFileName("softdelete.jpg").SetComputedFileName("SOFTDEL_0001.jpg").
+		SetStorageId("softdelstorage1").SetSize(1).
+		SetUserID(m.Users["projectEditor"]).SetUploadID(m.Upload).SetProjectID(m.Project).SetCameraID(camID).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// ISOLATION: hard-wipe the image and both cameras so seed counts stay green.
+	t.Cleanup(func() {
+		_ = c.Image.DeleteOneID(img.ID).Exec(ctx)
+		_, _ = c.Camera.Delete().Where(camera.NameEQ("softdelete-cam")).Exec(ctx)
+	})
+
+	t.Run("delete succeeds despite attached images", func(t *testing.T) {
+		assert.Equal(t, http.StatusNoContent, status(t, editor, http.MethodDelete, "/api/v1/cameras/"+camID, nil))
+	})
+
+	t.Run("gone from reads and lists", func(t *testing.T) {
+		assert.Equal(t, http.StatusNotFound, status(t, editor, http.MethodGet, "/api/v1/cameras/"+camID, nil))
+
+		listResp := doJSON(t, editor, http.MethodGet, "/api/v1/cameras", nil)
+		require.Equal(t, http.StatusOK, listResp.StatusCode)
+		for _, item := range decodeBody(t, listResp)["items"].([]any) {
+			assert.NotEqual(t, camID, item.(map[string]any)["id"], "deleted camera must not be listed")
+		}
+	})
+
+	t.Run("existing image still names the camera", func(t *testing.T) {
+		imgResp := doJSON(t, editor, http.MethodGet, "/api/v1/images/"+img.ID, nil)
+		require.Equal(t, http.StatusOK, imgResp.StatusCode)
+		camRef, ok := decodeBody(t, imgResp)["camera"].(map[string]any)
+		require.True(t, ok, "image must keep its camera ref after soft delete")
+		assert.Equal(t, "softdelete-cam", camRef["name"])
+	})
+
+	t.Run("name is freed for reuse", func(t *testing.T) {
+		assert.Equal(t, http.StatusCreated, status(t, editor, http.MethodPost, "/api/v1/cameras",
+			map[string]any{"name": "softdelete-cam"}))
+	})
+
+	t.Run("deleted camera rejects new time offsets", func(t *testing.T) {
+		assert.Equal(t, http.StatusNotFound, status(t, editor, http.MethodPost, "/api/v1/time-offsets",
+			map[string]any{"cameraId": camID, "serverTime": "2026-01-01T00:00:00Z", "cameraTime": "2026-01-01T00:00:05Z"}))
+	})
+}

--- a/image-wasm/src/qr.rs
+++ b/image-wasm/src/qr.rs
@@ -30,15 +30,21 @@ pub fn decode(image: &DynamicImage) -> Result<String> {
     let grids = prepared.detect_grids();
 
     match grids.as_slice() {
-        [] => Err(Error::msg("no QR code found")),
+        [] => Err(Error::msg(
+            "no QR code found — make sure the whole QR code is in the photo, in focus and well lit",
+        )),
         [grid] => {
-            let (_meta, content) = grid
-                .decode()
-                .map_err(|e| Error::msg(format!("QR decode failed: {e}")))?;
+            // Keep rqrr's exact error (e.g. the ECC failure on blurry shots) and
+            // append what the photographer can actually do about it.
+            let (_meta, content) = grid.decode().map_err(|e| {
+                Error::msg(format!(
+                    "QR decode failed: {e} — the photo is likely blurry, too dark, or the code too small; retake it sharper and closer"
+                ))
+            })?;
             Ok(content)
         }
         many => Err(Error::msg(format!(
-            "expected exactly one QR code, found {}",
+            "expected exactly one QR code, found {} — photograph only the QR code on this page",
             many.len()
         ))),
     }
@@ -55,6 +61,8 @@ mod tests {
         assert_eq!(decode(&image).expect("decode"), "1719500000");
     }
 
+    // The failure must name the problem — an empty message once shipped as a
+    // blank error dialog on the time-offset page.
     #[test]
     fn decode_errors_when_no_qr_present() {
         let blank = DynamicImage::ImageLuma8(image::GrayImage::from_pixel(
@@ -62,6 +70,7 @@ mod tests {
             256,
             image::Luma([255]),
         ));
-        assert!(decode(&blank).is_err());
+        let err = decode(&blank).unwrap_err().to_string();
+        assert!(err.contains("no QR code found"), "got: {err}");
     }
 }

--- a/ui/src/components/UnexpectedErrorMessage.vue
+++ b/ui/src/components/UnexpectedErrorMessage.vue
@@ -81,6 +81,7 @@
 import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from "@headlessui/vue";
 import { ExclamationTriangleIcon, XMarkIcon } from "@heroicons/vue/24/outline";
 import { computed, ref } from "vue";
+import { errorHeadline, errorDetails } from "src/util/errorDisplay";
 
 interface Props {
   show: boolean;
@@ -90,27 +91,6 @@ interface Props {
   error?: any;
 }
 
-interface ErrorResponse {
-  status: number;
-  response: {
-    code: number;
-    message: string;
-    data: Record<
-      string,
-      {
-        code: string;
-        message: string;
-      }
-    >;
-  };
-  isAbort: boolean;
-  originalError?: {
-    url: string;
-    status: number;
-    data: any;
-  };
-}
-
 const props = withDefaults(defineProps<Props>(), {
   buttonText: () => "OK",
   headline: () => "",
@@ -118,32 +98,7 @@ const props = withDefaults(defineProps<Props>(), {
   error: () => null,
 });
 
-const computedHeadline = computed(() => {
-  const e = props.error as ErrorResponse;
-  if (props.headline && props.headline !== "") {
-    return props.headline;
-  }
-  if (!e) {
-    return "Unexpected Error";
-  }
-  if (e.response?.data) {
-    if (Object.keys(e.response?.data).length === 1) {
-      return `Error on field '${Object.keys(e.response.data)[0]}': ${Object.values(e.response.data)[0].message}`;
-    }
-
-    if (Object.keys(e.response.data).length >= 1) {
-      let errorMessages = {} as Record<string, boolean>;
-      for (const [key, value] of Object.entries(e.response.data)) {
-        errorMessages[value.message] = true;
-      }
-      if (Object.keys(errorMessages).length === 1) {
-        return `Error on ${Object.keys(e.response.data).length} fields: ${Object.keys(errorMessages)[0]}`;
-      } else {
-        return `Multiple errors on ${Object.keys(e.response.data).length} fields`;
-      }
-    }
-  }
-});
+const computedHeadline = computed(() => (props.headline !== "" ? props.headline : errorHeadline(props.error)));
 
 const computedMessage = computed(() => {
   return props.message && props.message !== "" ? props.message : "Something went wrong. More details can be found below";
@@ -153,9 +108,7 @@ const emit = defineEmits<{
   closed: [];
 }>();
 
-const detailText = computed(() => {
-  return props.error ? JSON.stringify(props.error, null, 2).trim() : "No details available";
-});
+const detailText = computed(() => errorDetails(props.error));
 const showDetails = ref(false);
 
 const copyErrorText = ref("Copy error details");

--- a/ui/src/components/user/CameraEdit.vue
+++ b/ui/src/components/user/CameraEdit.vue
@@ -15,6 +15,15 @@
           Create Time Offset
         </button>
         <button
+          v-if="!edit"
+          type="button"
+          :aria-label="`Delete ${item.name}`"
+          class="inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-md border border-error-300 bg-error-50 px-4 py-2 text-sm font-medium text-error-700 transition-colors hover:bg-error-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-error-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface dark:border-error-800/70 dark:bg-error-950/40 dark:text-error-300 dark:hover:bg-error-950/70 dark:focus-visible:ring-offset-primary-950"
+          @click="emit('delete')"
+        >
+          Delete
+        </button>
+        <button
           v-if="edit"
           type="button"
           class="inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-primary-200 bg-surface px-4 py-2 text-sm font-medium text-primary-700 transition-colors hover:border-primary-300 hover:text-primary-900 dark:border-primary-700 dark:bg-surface-dark dark:text-primary-200 dark:hover:border-primary-600 dark:hover:text-white"
@@ -75,6 +84,7 @@ const emit = defineEmits<{
   editAbort: [];
   editSave: [CamerasResponse, CameraEditData];
   editStart: [];
+  delete: [];
 }>();
 
 const edit = ref(false);

--- a/ui/src/pages/user/Cameras.vue
+++ b/ui/src/pages/user/Cameras.vue
@@ -22,11 +22,20 @@
     <div class="my-8 border-t border-primary-200 dark:border-primary-800"></div>
     <div class="mx-auto max-w-2xl space-y-16 sm:space-y-20 lg:mx-0 lg:max-w-none">
       <div v-for="camera in items" :key="camera.id">
-        <CameraEdit :item="camera" @edit-save="saveItem" />
+        <CameraEdit :item="camera" @edit-save="saveItem" @delete="deleteCandidate = camera" />
         <CameraTimeOffsets :camera="camera" />
       </div>
     </div>
   </main>
+  <ModalMessage
+    :show="!!deleteCandidate"
+    :type="MessageType.CONFIRM_WARNING"
+    headline="Delete camera"
+    :message="`Delete '${deleteCandidate?.name}'? Photos taken with it and their time corrections are kept — the camera just disappears from your list.`"
+    confirmText="Delete"
+    @closed="deleteCandidate = null"
+    @confirmed="confirmDelete"
+  />
   <UnexpectedErrorMessage :show="showUnexpectedErrorMessage" :error="unexpectedError" @closed="showUnexpectedErrorMessage = false" />
 </template>
 
@@ -35,6 +44,7 @@ import { Ref, computed, onMounted, ref, watch } from "vue";
 import { api } from "src/api";
 import { CamerasResponse, TimeOffsetsResponse } from "src/types/pocketbase";
 import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
+import ModalMessage, { MessageType } from "src/components/ModalMessage.vue";
 import CameraEdit, { CameraEditData } from "src/components/user/CameraEdit.vue";
 import CameraTimeOffsets from "src/components/user/CameraTimeOffsets.vue";
 import { storeToRefs } from "pinia";
@@ -87,6 +97,23 @@ async function saveItem(item: CamerasResponse, editData: CameraEditData) {
     showNotificationToast({ headline: `${capitalize(ITEM_NAME)} saved`, type: "success" });
   } catch (error: any) {
     item = rollbackData;
+    unexpectedError.value = error;
+    showUnexpectedErrorMessage.value = true;
+  }
+}
+
+const deleteCandidate: Ref<ITEM_TYPE | null> = ref(null);
+
+async function confirmDelete() {
+  const candidate = deleteCandidate.value;
+  deleteCandidate.value = null;
+  if (!candidate) return;
+
+  try {
+    await api.cameras.remove(candidate.id);
+    items.value = items.value.filter((i) => i.id !== candidate.id);
+    showNotificationToast({ headline: `${capitalize(ITEM_NAME)} deleted`, type: "success" });
+  } catch (error: any) {
     unexpectedError.value = error;
     showUnexpectedErrorMessage.value = true;
   }

--- a/ui/src/pages/user/TimeOffsetCreate.vue
+++ b/ui/src/pages/user/TimeOffsetCreate.vue
@@ -197,18 +197,24 @@ async function getCamera() {
   }
 }
 
+function showError(error: any) {
+  unexpectedError.value = error;
+  showUnexpectedErrorMessage.value = true;
+}
+
 async function handleFiles(files: File[]) {
-  console.log(files);
   if (files.length !== 1) {
-    console.log("Only one file can be uploaded");
+    showError(new Error(`upload exactly one photo of the QR code (got ${files.length} files)`));
     return;
   }
-  const data = await fileUtil.loadFile(files[0]);
-  if (data == null) {
-    console.log("Failed to load file");
+  // loadFile rejects on failure (it never resolves null) — catch, don't null-check.
+  let data: ArrayBuffer;
+  try {
+    data = await fileUtil.loadFile(files[0]);
+  } catch {
+    showError(new Error(`could not read the file '${files[0].name}' — it may be corrupt or unreadable`));
     return;
   }
-  console.log(data);
   try {
     await init();
     const imageMetadata = await get_image_metadata(data);
@@ -228,10 +234,10 @@ async function handleFiles(files: File[]) {
       showBigOffsetWarning.value = true;
     }
   } catch (error: any) {
-    console.log("Failed to get image metadata");
-    console.log(error);
-    unexpectedError.value = error;
-    showUnexpectedErrorMessage.value = true;
+    // WASM errors (unreadable image, no/blurry QR, ECC failure, missing EXIF
+    // time) arrive as js Errors whose message names the failure — show it.
+    console.error(error);
+    showError(error);
     return;
   }
 }

--- a/ui/src/util/errorDisplay.ts
+++ b/ui/src/util/errorDisplay.ts
@@ -1,0 +1,46 @@
+// Maps any thrown value to the copy shown by UnexpectedErrorMessage. Pure so
+// every failure shape stays unit-tested: axios/API errors, WASM js Errors
+// (whose message/stack are non-enumerable and vanish in JSON.stringify),
+// PocketBase-style field maps, plain strings.
+
+type FieldError = { code?: string; message?: string };
+
+export function errorHeadline(error: any): string {
+  const data = error?.response?.data;
+  if (data && typeof data === "object") {
+    // Go API shape: { error: "conflict", message: "…" }
+    if (typeof data.message === "string" && data.message !== "") {
+      return data.message;
+    }
+    // Legacy PB shape: { field: { code, message } }
+    const fields = Object.entries(data).filter(([, v]) => typeof (v as FieldError)?.message === "string");
+    if (fields.length === 1) {
+      return `Error on field '${fields[0][0]}': ${(fields[0][1] as FieldError).message}`;
+    }
+    if (fields.length > 1) {
+      const messages = new Set(fields.map(([, v]) => (v as FieldError).message));
+      return messages.size === 1 ? `Error on ${fields.length} fields: ${[...messages][0]}` : `Multiple errors on ${fields.length} fields`;
+    }
+  }
+  // WASM and other native errors: the message is the whole story.
+  if (typeof error?.message === "string" && error.message !== "") {
+    return error.message;
+  }
+  if (typeof error === "string" && error !== "") {
+    return error;
+  }
+  return "Unexpected Error";
+}
+
+export function errorDetails(error: any): string {
+  if (error == null) {
+    return "No details available";
+  }
+  if (error?.response) {
+    return JSON.stringify({ message: error.message, status: error.response.status, data: error.response.data }, null, 2);
+  }
+  if (error instanceof Error) {
+    return error.stack || `${error.name}: ${error.message}`;
+  }
+  return JSON.stringify(error, null, 2)?.trim() || String(error);
+}

--- a/ui/src/util/fileProcessor.ts
+++ b/ui/src/util/fileProcessor.ts
@@ -6,6 +6,7 @@ import { API_BASE } from "src/boot/axios";
 import { api } from "src/api";
 import { useUserStore } from "src/stores/user-store";
 import { getLogLevelString, debug, info, error } from "./logger";
+import { errorHeadline } from "./errorDisplay";
 import { showNotificationToast } from "src/boot/mitt";
 import { Upload, Image as BackendImage } from "src/types/api";
 import { parseBackendTime } from "src/util/dateTimeUtil";
@@ -109,8 +110,8 @@ export class FileProcessor {
         this.setState(image, ImageStatus.LOADED);
         this.processLoadedImage(image);
       })
-      .catch(() => {
-        this.setState(image, ImageStatus.ERROR);
+      .catch((err) => {
+        this.fail(image, err);
       });
   };
 
@@ -121,8 +122,8 @@ export class FileProcessor {
         this.setState(image, ImageStatus.UPLOADED);
         this.processUploadedImage(image);
       })
-      .catch(() => {
-        this.setState(image, ImageStatus.ERROR);
+      .catch((err) => {
+        this.fail(image, err);
       });
   };
 
@@ -132,9 +133,26 @@ export class FileProcessor {
       .then(() => {
         this.setState(image, ImageStatus.DONE);
       })
-      .catch(() => {
-        this.setState(image, ImageStatus.ERROR);
+      .catch((err) => {
+        this.fail(image, err);
       });
+  };
+
+  // Every failure funnels through here: the tile shows the reason, the log
+  // keeps it, and the first image failing for a given reason raises a toast —
+  // batch-wide problems (no copyright tag, no time offset) toast once, not
+  // once per file.
+  private toastedReasons = new Set<string>();
+
+  private fail = (image: Image, err: any): void => {
+    const reason = String(err?.message ?? err ?? "unknown error").replace(/^Error:\s*/, "");
+    image.errorMessage = reason;
+    error(`${image.originalFileName}: ${reason}`);
+    if (!this.toastedReasons.has(reason)) {
+      this.toastedReasons.add(reason);
+      showNotificationToast({ headline: `${image.originalFileName}: ${reason}`, type: "error" });
+    }
+    this.setState(image, ImageStatus.ERROR);
   };
 
   private getNextImage = (status: ImageStatus): Image | null => {
@@ -160,34 +178,26 @@ export class FileProcessor {
     info(`Image ${image.originalFileName} - ${oldStatus} => ${status}`);
   };
 
-  private loadImage = (image: Image): Promise<void> => {
-    return new Promise(async (resolve, reject) => {
-      if (image.file == null) {
-        error(`File object of ${image.originalFileName} is null`);
-        reject();
-        return;
-      }
-      const data = await fileUtil.loadFile(image.file);
-      if (data == null) {
-        error("Failed to load file");
-        reject();
-      }
-      image.data = data;
-      resolve();
+  // Plain async (no Promise executor): a rejection from loadFile must reach the
+  // caller's .catch — inside an async executor it would strand the tile in LOADING.
+  private loadImage = async (image: Image): Promise<void> => {
+    if (image.file == null) {
+      throw new Error("file handle is gone — remove the tile and add the file again");
+    }
+    image.data = await fileUtil.loadFile(image.file).catch(() => {
+      throw new Error("could not read the file — it may have moved or be unreadable");
     });
   };
 
   private processImage = (image: Image): Promise<void> => {
     return new Promise(async (resolve, reject) => {
       if (image.data == null) {
-        error(`Data of ${image.originalFileName} is null`);
-        reject();
+        reject(new Error("file data is missing — remove the tile and add the file again"));
         return;
       }
 
       if (this.timeOffsets.value.length == 0) {
-        error("No time offsets available");
-        reject();
+        reject(new Error("this camera has no time offset yet — photograph the time-sync QR code first"));
         return;
       }
 
@@ -196,8 +206,7 @@ export class FileProcessor {
       // still worth refusing here rather than after the S3 upload.
       const copyrightTag = useUserStore().user?.copyrightTag;
       if (copyrightTag == null || copyrightTag == "") {
-        error("No copyright tag available");
-        reject();
+        reject(new Error("your profile has no copyright tag — add one in your profile settings, then retry the upload"));
         return;
       }
 
@@ -227,13 +236,9 @@ export class FileProcessor {
 
         resolve();
       } catch (err: any) {
-        // surface the reason to the human, not just the console — e.g. the
-        // hard timestamp rule: "image has no EXIF capture time"
-        const reason = String(err?.message ?? err).replace(/^Error:\s*/, "");
-        image.errorMessage = reason;
-        showNotificationToast({ headline: `${image.originalFileName}: ${reason}`, type: "error" });
-        error(`Failed to process image: ${err}`);
-        reject();
+        // WASM errors name their failure mode (e.g. the hard timestamp rule:
+        // "image has no EXIF capture time") — fail() shows them verbatim.
+        reject(err);
         return;
       }
     });
@@ -264,8 +269,9 @@ export class FileProcessor {
           resolve();
         })
         .catch((err) => {
-          error(`Failed to create image in backend: ${err}`);
-          reject();
+          // API failures (duplicate image, upload no longer accepts images, …)
+          // surface with the server's message, not a bare error tile.
+          reject(new Error(errorHeadline(err)));
         });
     });
   };

--- a/ui/tests/e2e/cameras.spec.ts
+++ b/ui/tests/e2e/cameras.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+import { loginAs, meId, collectJsErrors } from "./helpers";
+
+// Cameras are soft-deleted on the server (photos keep their camera ref), so the
+// page must offer Delete on every camera, gate it behind a confirm dialog, and
+// the freed name must be usable again immediately.
+test.describe.serial("cameras", () => {
+  const CAM_NAME = "e2e soft-delete cam";
+
+  test("create a camera, delete it, reuse the name (plain user)", async ({ page }) => {
+    const errors = collectJsErrors(page);
+    await loginAs(page, "user", { activate: false });
+    const userId = await meId(page);
+    expect(userId, "logged-in user id").toBeTruthy();
+
+    // --- create ---
+    await page.goto(`/users/${userId}/cameras`);
+    await page.getByRole("button", { name: "Add Camera" }).click();
+    await page.getByLabel("Name").fill(CAM_NAME);
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page.getByRole("heading", { name: CAM_NAME }), "created camera must appear").toBeVisible();
+
+    // --- delete: cancel keeps it, confirm removes it ---
+    await page.getByRole("button", { name: `Delete ${CAM_NAME}` }).click();
+    await expect(page.getByText("Delete camera")).toBeVisible();
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByRole("heading", { name: CAM_NAME }), "cancel must keep the camera").toBeVisible();
+
+    await page.getByRole("button", { name: `Delete ${CAM_NAME}` }).click();
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    await expect(page.getByRole("heading", { name: CAM_NAME })).toHaveCount(0);
+
+    // server-side, not just optimistic UI
+    await page.reload();
+    await expect(page.getByRole("heading", { name: CAM_NAME })).toHaveCount(0);
+
+    // --- the name is freed by the soft delete ---
+    await page.getByRole("button", { name: "Add Camera" }).click();
+    await page.getByLabel("Name").fill(CAM_NAME);
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page.getByRole("heading", { name: CAM_NAME }), "freed name must be reusable").toBeVisible();
+
+    // cleanup so reruns start from a clean list
+    await page.getByRole("button", { name: `Delete ${CAM_NAME}` }).click();
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    await expect(page.getByRole("heading", { name: CAM_NAME })).toHaveCount(0);
+
+    expect(errors, errors.join("\n")).toHaveLength(0);
+  });
+});

--- a/ui/tests/e2e/upload.spec.ts
+++ b/ui/tests/e2e/upload.spec.ts
@@ -163,10 +163,10 @@ test.describe("browser upload pipeline", () => {
     try {
       await page.goto(`/uploads/${result.uploadId}/edit`);
       await page.setInputFiles("#dropzoneFile", FIXTURE);
-      // Scope to this image's own tile and match the status text exactly — a loose
-      // page-wide "error" match would pass on any unrelated copy.
+      // Scope to this image's own tile. The tile must not just error — it must
+      // name the reason (an unexplained red tile was the original bug).
       const tile = page.locator("figure").filter({ hasText: FIXTURE_NAME });
-      await expect(tile.getByText("error", { exact: true })).toBeVisible({ timeout: 30_000 });
+      await expect(tile.getByText(/no copyright tag/)).toBeVisible({ timeout: 30_000 });
     } finally {
       await page.evaluate(
         async ({ userId, restore }) => {

--- a/ui/tests/errorDisplay.spec.ts
+++ b/ui/tests/errorDisplay.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { errorHeadline, errorDetails } from "src/util/errorDisplay";
+
+// The regression this guards: WASM QR failures (e.g. the rqrr ECC error) are
+// plain js Errors — no response.data, message/stack non-enumerable — and the
+// old modal showed an empty headline and "{}" details for them.
+describe("errorHeadline", () => {
+  it("uses the message of a plain Error (WASM failure mode)", () => {
+    const e = new Error("QR decode failed: could not correct errors in data (ECC) — the photo is likely blurry");
+    expect(errorHeadline(e)).toContain("QR decode failed");
+    expect(errorHeadline(e)).toContain("ECC");
+  });
+
+  it("uses the Go API error body message", () => {
+    expect(errorHeadline({ message: "Request failed with status code 409", response: { data: { error: "conflict", message: "resource already exists" } } })).toBe(
+      "resource already exists",
+    );
+  });
+
+  it("maps legacy field errors", () => {
+    expect(errorHeadline({ response: { data: { name: { code: "required", message: "cannot be empty" } } } })).toBe("Error on field 'name': cannot be empty");
+  });
+
+  it("falls back to the axios message when the body has no message", () => {
+    expect(errorHeadline({ message: "Network Error", response: { data: {} } })).toBe("Network Error");
+  });
+
+  it("accepts plain strings and never returns empty", () => {
+    expect(errorHeadline("boom")).toBe("boom");
+    expect(errorHeadline(null)).toBe("Unexpected Error");
+    expect(errorHeadline({})).toBe("Unexpected Error");
+  });
+});
+
+describe("errorDetails", () => {
+  it("shows stack or name+message for a plain Error, never '{}'", () => {
+    const details = errorDetails(new Error("no QR code found"));
+    expect(details).toContain("no QR code found");
+    expect(details).not.toBe("{}");
+  });
+
+  it("shows status and body for API errors", () => {
+    const details = errorDetails({ message: "Request failed", response: { status: 409, data: { error: "conflict" } } });
+    expect(details).toContain("409");
+    expect(details).toContain("conflict");
+  });
+
+  it("handles null and plain objects", () => {
+    expect(errorDetails(null)).toBe("No details available");
+    expect(errorDetails({ a: 1 })).toContain('"a": 1');
+  });
+});


### PR DESCRIPTION
Cameras: DELETE is now a soft delete (deleted_at), so photographers can
remove cameras that already have images — history, uploads and EXIF time
correction keep their camera reference. The (name, user_id) unique index
becomes partial (WHERE deleted_at IS NULL) so a deleted camera frees its
name; ensureCameraSoftDeleteIndex swaps/repairs the index on existing DBs
transactionally. Cameras page gets a Delete button behind a confirm dialog.

Error propagation: UnexpectedErrorMessage rendered a blank dialog for
non-API errors (js Error message/stack are non-enumerable) — WASM QR
failures like the rqrr ECC error died silently. errorDisplay.ts maps every
failure shape (WASM Errors, Go API bodies, legacy PB field maps) to
headline + details; qr.rs appends actionable hints while keeping the exact
decoder error. fileProcessor funnels all upload rejections through fail():
tile message + reason-deduped toast (no copyright tag, no time offset,
unreadable file, API errors). Fixes a stranded-LOADING bug from the async
promise executor in loadImage.

Copyright tag: repository.CreateUser now defaults copyrightTag to the
user's last name (PocketBase-hook parity); importer untouched.
