### PR TITLE
fix(tags): derived default tags inherit the template tag's order

### DIFF
--- a/api/internal/service/image_service.go
+++ b/api/internal/service/image_service.go
@@ -219,7 +219,7 @@ func (s *ImageService) addDefaultTags(ctx context.Context, image *ent.Image, pro
 		if name == "" {
 			continue // unrenderable (e.g. $DATE with no capture time, or malformed) — skip.
 		}
-		tag, err := s.findOrCreateDefaultTag(ctx, project.ID, name)
+		tag, err := s.findOrCreateDefaultTag(ctx, project.ID, name, tmpl.Order)
 		if err != nil {
 			return err
 		}
@@ -274,11 +274,24 @@ func (s *ImageService) shiftedCapture(corrected *time.Time) (time.Time, bool) {
 	return corrected.In(s.location()).Add(time.Duration(s.dateTagHourOffset) * time.Hour), true
 }
 
-func (s *ImageService) findOrCreateDefaultTag(ctx context.Context, projectID, name string) (*ent.ImageTag, error) {
+// findOrCreateDefaultTag keeps the derived tag's order mirroring its template's
+// (nil ≡ 0 ≡ unranked), so re-ranking a template propagates on the next upload.
+func (s *ImageService) findOrCreateDefaultTag(ctx context.Context, projectID, name string, order *int) (*ent.ImageTag, error) {
 	existing, err := s.repo.Client.ImageTag.Query().
 		Where(imagetag.ProjectID(projectID), imagetag.TypeEQ(imagetag.TypeDefault), imagetag.NameEQ(name)).
 		Only(ctx)
 	if err == nil {
+		want, have := 0, 0
+		if order != nil {
+			want = *order
+		}
+		if existing.Order != nil {
+			have = *existing.Order
+		}
+		if want != have {
+			// UpdateImageTag's Order convention: pointer to 0 clears the rank.
+			return s.repo.UpdateImageTag(ctx, existing.ID, &repository.UpdateImageTagParameters{Order: &want})
+		}
 		return existing, nil
 	}
 	if !ent.IsNotFound(err) {
@@ -289,6 +302,7 @@ func (s *ImageService) findOrCreateDefaultTag(ctx context.Context, projectID, na
 		Description: fmt.Sprintf("default tag %q", name),
 		Type:        imagetag.TypeDefault,
 		ProjectID:   projectID,
+		Order:       order,
 	})
 }
 

--- a/api/internal/service/image_service_test.go
+++ b/api/internal/service/image_service_test.go
@@ -152,6 +152,40 @@ func TestDateTagHourOffsetRollover(t *testing.T) {
 	assert.NotContains(t, tags, "20250613", "must not tag the literal capture day")
 }
 
+// Derived default tags mirror their template's order: inherited on create, and
+// re-synced on reuse when the template has been re-ranked since.
+func TestDefaultTagsInheritTemplateOrder(t *testing.T) {
+	ctx := context.Background()
+	svc, _, m, repo := newImageSvc(t)
+
+	tmpl, err := repo.Client.ImageTag.Create().
+		SetName("$PROJECT").SetDescription("tmpl").SetType(imagetag.TypeTemplate).
+		SetProjectID(m.Project).SetOrder(3).
+		Save(ctx)
+	require.NoError(t, err)
+
+	svc.createForTest(t, m, "DSC_0001.jpg", capturedNoon(t))
+	tag := defaultTagNames(t, repo, m.Project)["Formula Student Test"]
+	require.NotNil(t, tag)
+	require.NotNil(t, tag.Order)
+	assert.Equal(t, 3, *tag.Order, "created derived tag inherits template order")
+
+	// Re-rank the template; the existing derived tag syncs on the next image.
+	_, err = tmpl.Update().SetOrder(7).Save(ctx)
+	require.NoError(t, err)
+	svc.createForTest(t, m, "DSC_0002.jpg", capturedNoon(t))
+	tag = defaultTagNames(t, repo, m.Project)["Formula Student Test"]
+	require.NotNil(t, tag.Order)
+	assert.Equal(t, 7, *tag.Order, "derived tag re-synced to template order")
+
+	// Clearing the template's order clears the derived tag's too.
+	_, err = tmpl.Update().ClearOrder().Save(ctx)
+	require.NoError(t, err)
+	svc.createForTest(t, m, "DSC_0003.jpg", capturedNoon(t))
+	tag = defaultTagNames(t, repo, m.Project)["Formula Student Test"]
+	assert.Nil(t, tag.Order, "derived tag order cleared with template")
+}
+
 // Found-or-create: a second image on the same project/day reuses the same default
 // tag rows rather than creating duplicates.
 // The reported bug: a photo shot at 10:30 in Berlin was named "..._08-30-00_..."


### PR DESCRIPTION
Rendered template tags ($PROJECT/$DATE/$WEEKDAY/$COPYRIGHT/$X) previously
created their default tags without an order, so exported keywords fell back
to alphabetical sorting. The derived tag now mirrors its template's order on
create and re-syncs on reuse, so re-ranking a template propagates on the
next upload.
