### PR TITLE
feat(slideshow): never play internal images, never grow a scrollbar

### DIFF
--- a/api/internal/repository/repository_test.go
+++ b/api/internal/repository/repository_test.go
@@ -326,9 +326,10 @@ func TestGetUploadMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, metrics, up.ID)
 	assert.Equal(t, len(m.Images), metrics[up.ID].ImageCount, "every seeded image counts")
-	assert.Equal(t, 0, metrics[up.ID].TagCount, "seed applies no manual tags")
+	baseline := metrics[up.ID].TagCount
+	assert.Equal(t, 1, baseline, "the seed applies one manual tag: internal, on the last image")
 
-	// One manual assignment on one image -> counted, and the derived rate follows.
+	// One more manual assignment on one image -> counted, and the derived rate follows.
 	_, _, err = repo.CreateImageTagAssignment(ctx, &repository.CreateImageTagAssignmentParameters{
 		ImageID: m.Images[0], ImageTagID: m.Tags["Podium"], Type: imagetagassignment.TypeManual,
 	})
@@ -336,8 +337,8 @@ func TestGetUploadMetrics(t *testing.T) {
 
 	metrics, err = repo.GetUploadMetrics(ctx, []*ent.Upload{up})
 	require.NoError(t, err)
-	assert.Equal(t, 1, metrics[up.ID].TagCount)
-	assert.InDelta(t, 1.0/float64(len(m.Images)), metrics[up.ID].TagsPerImage, 0.0001)
+	assert.Equal(t, baseline+1, metrics[up.ID].TagCount)
+	assert.InDelta(t, float64(baseline+1)/float64(len(m.Images)), metrics[up.ID].TagsPerImage, 0.0001)
 
 	// errorCount / rejectedCount are live state: they follow the reserved review
 	// tags on and off, and are counted independently of each other.

--- a/api/internal/seed/seed.go
+++ b/api/internal/seed/seed.go
@@ -183,7 +183,8 @@ func Seed(ctx context.Context, client *ent.Client, referenceNow time.Time) (*Man
 	}
 	m.Offsets["stale"] = staleOffset.ID
 
-	// Image tags: template + manual + default.
+	// Image tags: template + manual + default + the reserved "internal" marker
+	// (kept out of EXIF exports and of the slideshow).
 	for _, spec := range []struct {
 		name, desc string
 		typ        imagetag.Type
@@ -191,6 +192,7 @@ func Seed(ctx context.Context, client *ent.Client, referenceNow time.Time) (*Man
 		{"$DATE", "date template tag", imagetag.TypeTemplate},
 		{"Podium", "manual tag", imagetag.TypeManual},
 		{"Default", "auto-applied tag", imagetag.TypeDefault},
+		{"internal", "reserved management tag", imagetag.TypeManual},
 	} {
 		t, err := client.ImageTag.Create().
 			SetName(spec.name).
@@ -250,6 +252,19 @@ func Seed(ctx context.Context, client *ent.Client, referenceNow time.Time) (*Man
 			SetImageTagID(defaultTag).
 			Save(ctx); err != nil {
 			return nil, fmt.Errorf("assign default tag to image %d: %w", i, err)
+		}
+
+		// The last image is internal: it stays in the gallery but never reaches
+		// a slideshow or an EXIF export. The LAST one on purpose — Images[0] is
+		// the fixture the repository tests pin exact tag lists on.
+		if i == 2 {
+			if _, err := client.ImageTagAssignment.Create().
+				SetType(imagetagassignment.TypeManual).
+				SetImageID(img.ID).
+				SetImageTagID(m.Tags["internal"]).
+				Save(ctx); err != nil {
+				return nil, fmt.Errorf("assign internal tag to image %d: %w", i, err)
+			}
 		}
 	}
 

--- a/api/internal/seed/seed_test.go
+++ b/api/internal/seed/seed_test.go
@@ -87,7 +87,7 @@ func TestSeedManifestAndOffsets(t *testing.T) {
 	assert.Len(t, m.Users, 5)   // admin, user, projectAdmin/Editor/Viewer
 	assert.Len(t, m.Roles, 3)   // projectAdmin/Editor/Viewer
 	assert.Len(t, m.Cameras, 2) // fresh + stale
-	assert.Len(t, m.Tags, 3)    // template + manual + default
+	assert.Len(t, m.Tags, 4)    // template + manual + default + internal
 	assert.Len(t, m.Offsets, 2) // fresh + stale
 	assert.Len(t, m.Images, 3)
 	assert.Equal(t, 37, m.DriftSeconds)

--- a/api/test/e2e/e2e_test.go
+++ b/api/test/e2e/e2e_test.go
@@ -71,11 +71,11 @@ func TestSchemaAppliedAndSeedCounts(t *testing.T) {
 	assert.Equal(t, 3, c.Role.Query().CountX(ctx))
 	assert.Equal(t, 1, c.Project.Query().CountX(ctx))
 	assert.Equal(t, 2, c.Camera.Query().CountX(ctx))
-	assert.Equal(t, 3, c.ImageTag.Query().CountX(ctx))
+	assert.Equal(t, 4, c.ImageTag.Query().CountX(ctx)) // template + manual + default + internal
 	assert.Equal(t, 2, c.TimeOffset.Query().CountX(ctx))
 	assert.Equal(t, 3, c.Image.Query().CountX(ctx))
 	assert.Equal(t, 3, c.ProjectAssignment.Query().CountX(ctx))
-	assert.Equal(t, 3, c.ImageTagAssignment.Query().CountX(ctx))
+	assert.Equal(t, 4, c.ImageTagAssignment.Query().CountX(ctx)) // default on each + internal on the last
 }
 
 // S2 e2e: unique constraints reject dups (must run on Postgres).

--- a/ui/src/components/image/SlideshowOverlay.vue
+++ b/ui/src/components/image/SlideshowOverlay.vue
@@ -1,10 +1,13 @@
 <template>
-  <div class="fixed inset-0 z-50 bg-black" data-testid="slideshow-overlay" @mousemove="showControls" @click="showControls">
+  <!-- overflow-hidden: the Ken Burns transform scales past the viewport, and a
+       slideshow must never grow a scrollbar (the document scroll is locked
+       below for the same reason) -->
+  <div class="fixed inset-0 z-50 overflow-hidden bg-black" data-testid="slideshow-overlay" @mousemove="showControls" @click="showControls">
     <!-- setup phase: configure, then start -->
     <div v-if="phase === 'setup'" class="flex h-full items-center justify-center px-4">
-      <div class="w-full max-w-md rounded-xl border border-primary-800 bg-primary-950 p-6" data-testid="slideshow-setup" @click.stop>
+      <div class="max-h-full w-full max-w-md overflow-y-auto rounded-xl border border-primary-800 bg-primary-950 p-6" data-testid="slideshow-setup" @click.stop>
         <h2 class="display text-xl text-white">Slideshow</h2>
-        <p class="mt-1 text-sm text-primary-400">{{ totalCount.toLocaleString() }} images in the current view</p>
+        <p class="mt-1 text-sm text-primary-400">{{ playableTotal.toLocaleString() }} images in the current view</p>
 
         <div class="mt-5 space-y-4">
           <label class="block">
@@ -109,8 +112,8 @@
         <button type="button" class="text-primary-300 hover:text-white" title="Next" @click="goNext">
           <ForwardIcon class="h-5 w-5" />
         </button>
-        <span class="min-w-0 flex-1 truncate text-center font-data text-sm text-primary-200">{{ images[current]?.computedFileName }}</span>
-        <span class="label-mono-sm shrink-0 text-primary-400" data-testid="slideshow-position">{{ current + 1 }} / {{ totalCount.toLocaleString() }}</span>
+        <span class="min-w-0 flex-1 truncate text-center font-data text-sm text-primary-200">{{ slides[current]?.computedFileName }}</span>
+        <span class="label-mono-sm shrink-0 text-primary-400" data-testid="slideshow-position">{{ current + 1 }} / {{ playableTotal.toLocaleString() }}</span>
         <button type="button" class="shrink-0 text-primary-300 hover:text-white" title="Exit slideshow" data-testid="slideshow-exit" @click="emit('close')">
           <XMarkIcon class="h-6 w-6" />
         </button>
@@ -121,11 +124,20 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue";
-import { useStorage } from "@vueuse/core";
+import { useScrollLock, useStorage } from "@vueuse/core";
 import { PlayIcon, PauseIcon, ForwardIcon, BackwardIcon, XMarkIcon } from "@heroicons/vue/24/outline";
 import { ImageWithTagsType } from "src/types/custom";
 import { devPlaceholder } from "src/util/devPlaceholder";
-import { DEFAULT_SLIDESHOW_CONFIG, SlideshowConfig, kenBurnsVariant, nextSlideIndex, previousSlideIndex, preloadIndices, shouldFetchMore } from "src/util/slideshow";
+import {
+  DEFAULT_SLIDESHOW_CONFIG,
+  SlideshowConfig,
+  isInternalImage,
+  kenBurnsVariant,
+  nextSlideIndex,
+  previousSlideIndex,
+  preloadIndices,
+  shouldFetchMore,
+} from "src/util/slideshow";
 
 const props = defineProps<{
   images: ImageWithTagsType[];
@@ -145,17 +157,26 @@ const current = ref(0);
 const paused = ref(false);
 const waiting = ref(false);
 
+// THE playlist. Internal images are dropped here, once, so no path onto the
+// screen — auto-advance, manual navigation, preload — can reach one. `current`
+// indexes this list, never props.images.
+const slides = computed(() => props.images.filter((image) => !isInternalImage(image)));
+
+// props.totalCount counts the unfiltered view; discount the internal images
+// seen so far. An estimate while paging, exact once everything is loaded.
+const playableTotal = computed(() => Math.max(slides.value.length, props.totalCount - (props.images.length - slides.value.length)));
+
 // Current + previous slide stay mounted so the crossfade has both layers.
 const previous = ref<number | null>(null);
 const visibleSlides = computed(() => {
-  const slides: { index: number; image: ImageWithTagsType }[] = [];
-  if (previous.value !== null && previous.value !== current.value && props.images[previous.value]) {
-    slides.push({ index: previous.value, image: props.images[previous.value] });
+  const layers: { index: number; image: ImageWithTagsType }[] = [];
+  if (previous.value !== null && previous.value !== current.value && slides.value[previous.value]) {
+    layers.push({ index: previous.value, image: slides.value[previous.value] });
   }
-  if (props.images[current.value]) {
-    slides.push({ index: current.value, image: props.images[current.value] });
+  if (slides.value[current.value]) {
+    layers.push({ index: current.value, image: slides.value[current.value] });
   }
-  return slides;
+  return layers;
 });
 
 // Ken Burns runs slightly longer than the slide is on screen so it never halts visibly.
@@ -207,10 +228,10 @@ function preload(image: ImageWithTagsType | undefined): Promise<void> {
 }
 
 function fillPreloadWindow() {
-  for (const index of preloadIndices(current.value, props.images.length)) {
-    void preload(props.images[index]);
+  for (const index of preloadIndices(current.value, slides.value.length)) {
+    void preload(slides.value[index]);
   }
-  if (shouldFetchMore(current.value, props.images.length, props.totalCount)) {
+  if (shouldFetchMore(current.value, slides.value.length, playableTotal.value)) {
     emit("needMore");
   }
 }
@@ -252,7 +273,7 @@ async function goTo(index: number | null) {
     return;
   }
   const token = ++navToken;
-  const target = props.images[index];
+  const target = slides.value[index];
   const src = target ? slideSrc(target) : "";
   if (src && !loaded.has(src)) {
     waiting.value = true;
@@ -263,8 +284,21 @@ async function goTo(index: number | null) {
   show(index);
 }
 
+// A page can be all-internal, so "nothing to advance to" means "the next page
+// has not arrived yet" as long as the server still has images — ending the show
+// there would cut it short. The buffering chip covers the wait; the watch below
+// resumes.
+const stalled = ref(false);
+
 function advance() {
-  void goTo(nextSlideIndex(current.value, props.images.length, config.value.loop));
+  const next = nextSlideIndex(current.value, slides.value.length, config.value.loop);
+  if (next === null && props.images.length < props.totalCount) {
+    stalled.value = true;
+    waiting.value = true;
+    fillPreloadWindow(); // keeps the pages coming
+    return;
+  }
+  void goTo(next);
 }
 
 function show(index: number) {
@@ -287,10 +321,10 @@ async function start() {
   // Best effort: a browser may reject fullscreen without a fresh user gesture.
   document.documentElement.requestFullscreen?.().catch(() => undefined);
   // The first slide is decode-gated like every later one; the buffering chip
-  // covers the wait.
+  // covers the wait — and stays up when the first page held nothing playable.
   waiting.value = true;
-  await preload(props.images[0]);
-  waiting.value = false;
+  await preload(slides.value[0]);
+  waiting.value = slides.value.length === 0;
   fillPreloadWindow();
   scheduleAdvance();
 }
@@ -313,16 +347,24 @@ function goNext() {
 
 function goPrevious() {
   clearTimer();
-  void goTo(previousSlideIndex(current.value, props.images.length, config.value.loop));
+  void goTo(previousSlideIndex(current.value, slides.value.length, config.value.loop));
 }
 
 // more images may have arrived while we were at the end of the loaded list —
 // and the list can also shrink (image deleted from the grid underneath).
+// Watched on the RAW list: an all-internal page leaves the playlist length
+// unchanged, and that is exactly when the next page has to be requested.
 watch(
   () => props.images.length,
-  (length) => {
+  () => {
+    const length = slides.value.length;
     if (current.value >= length && length > 0) current.value = length - 1;
     fillPreloadWindow();
+    if (stalled.value && length > 0) {
+      stalled.value = false;
+      waiting.value = false;
+      scheduleAdvance(); // slides[current] is on screen now; time the next hop
+    }
   },
 );
 
@@ -354,8 +396,14 @@ function onKeydown(event: KeyboardEvent) {
   }
 }
 
+// The overlay is fixed, but the grid underneath still owns the document
+// scrollbar — it would sit there next to the show, and arrow keys would move
+// the page behind it. Locked for as long as the slideshow is up.
+const documentScrollLocked = useScrollLock(document.body);
+
 onMounted(() => {
   window.addEventListener("keydown", onKeydown);
+  documentScrollLocked.value = true;
   showControls();
 });
 
@@ -363,6 +411,7 @@ onBeforeUnmount(() => {
   clearTimer();
   if (controlsTimer) clearTimeout(controlsTimer);
   window.removeEventListener("keydown", onKeydown);
+  documentScrollLocked.value = false;
   if (document.fullscreenElement) document.exitFullscreen?.().catch(() => undefined);
 });
 </script>

--- a/ui/src/components/upload/UploadTimeline.vue
+++ b/ui/src/components/upload/UploadTimeline.vue
@@ -213,10 +213,13 @@ async function loadContext() {
     myItems.value = mine.items;
     allItems.value = all.items;
     projectTags.value = tags.items;
-    seedTracks();
   } catch {
     // The timeline is an enhancement on this page — the upload itself must
     // keep working without it, so context errors stay silent.
+  } finally {
+    // Seed even when the context failed: unlabelled lanes beat no lanes.
+    contextLoaded = true;
+    seedTracks();
   }
 }
 
@@ -227,6 +230,10 @@ const selectedKey = ref<string | null>(null);
 const dirty = ref(false);
 const applying = ref(false);
 let seeded = false;
+// Lane labels are resolved once, at seed time. The image list usually beats
+// loadContext, so seeding before it lands froze every persisted lane on its
+// "Tag"/"Schedule item" placeholder and dropped newly assigned schedule items.
+let contextLoaded = false;
 
 const timedImages = computed<TimedImage[]>(() =>
   props.images.filter((i) => i.id && i.correctedTime).map((i) => ({ id: i.id as string, time: (i.correctedTime as DateTime).toMillis() })),
@@ -249,6 +256,7 @@ const labels = {
 // Seed once: persisted timeline wins; otherwise pre-populate my items when the
 // first timed images exist. Re-seeds when images arrive later (fresh upload).
 function seedTracks() {
+  if (!contextLoaded) return;
   if (seeded && tracks.value.length > 0) return;
   const initial = initialTracks(props.upload.timeline, myItems.value, timedImages.value, labels);
   if (initial.length > 0) {
@@ -331,7 +339,7 @@ function addItemLane(item: ScheduleItem) {
 }
 
 function addTagLane(tag: ImageTag) {
-  tracks.value = addTagTrack(tracks.value, tag.id, tag.name, window_.value);
+  tracks.value = addTagTrack(tracks.value, tag.id, tagLabel(tag), window_.value);
   selectedKey.value = tracks.value[tracks.value.length - 1].key;
   markDirty();
 }

--- a/ui/src/util/slideshow.ts
+++ b/ui/src/util/slideshow.ts
@@ -21,6 +21,18 @@ export const DEFAULT_SLIDESHOW_CONFIG: SlideshowConfig = {
 /** How many upcoming images are kept decoded ahead of the one on screen. */
 export const PRELOAD_HEADROOM = 5;
 
+/** Reserved management tag: these shots never leave the house. */
+export const INTERNAL_TAG = "internal";
+
+/**
+ * Images marked internal are never shown in a slideshow. Combo tags
+ * ("trip|internal") are checked per part, exactly like the EXIF keyword export
+ * (api/internal/exif/inject.go) — the marker cannot be smuggled in as a part.
+ */
+export function isInternalImage(image: { tags?: { tag?: { name?: string } }[] }): boolean {
+  return (image.tags ?? []).some((assignment) => (assignment.tag?.name ?? "").split("|").some((part) => part.trim().toLowerCase() === INTERNAL_TAG));
+}
+
 /** Indices to have preloaded for `current` (the next `headroom` loaded images). */
 export function preloadIndices(current: number, loadedCount: number, headroom: number = PRELOAD_HEADROOM): number[] {
   const indices: number[] = [];

--- a/ui/tests/e2e/global-setup.ts
+++ b/ui/tests/e2e/global-setup.ts
@@ -1,7 +1,8 @@
 import { chromium, FullConfig } from "@playwright/test";
 
 // Reseed the backend to a known fixture before the suite runs, so every spec
-// starts from the deterministic seed state (1 project, 3 tags, 1 upload, 3 images,
+// starts from the deterministic seed state (1 project, 4 tags, 1 upload, 3 images
+// of which the newest is tagged "internal",
 // 2 cameras, 5 personas). See api/internal/seed/seed.go.
 export default async function globalSetup(config: FullConfig) {
   const base = config.projects[0]?.use?.baseURL || "http://localhost:9000";

--- a/ui/tests/e2e/schedule.spec.ts
+++ b/ui/tests/e2e/schedule.spec.ts
@@ -160,7 +160,18 @@ test("upload detail page shows timeline and tile grid", async ({ page }) => {
   await page.getByRole("option", { name: /Podium/ }).click();
   const removeLane = page.getByRole("button", { name: "Remove lane Podium" });
   await expect(removeLane).toBeVisible();
-  await removeLane.click();
+
+  // Applied lanes must come back labelled: the persisted timeline carries only
+  // tag ids, so a reload that seeds before the tag list arrives used to render
+  // every lane as the generic "Tag" placeholder.
+  await page.getByRole("button", { name: "Apply tags" }).click();
+  await expect(page.getByText(/Tags applied/)).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole("button", { name: "Remove lane Podium" })).toBeVisible();
+
+  // Drop the lane again and apply, so the upload is left as seeded.
+  await page.getByRole("button", { name: "Remove lane Podium" }).click();
+  await page.getByRole("button", { name: "Apply tags" }).click();
   await expect(page.getByRole("button", { name: "Remove lane Podium" })).toHaveCount(0);
 
   expect(errors, errors.join("\n")).toHaveLength(0);

--- a/ui/tests/e2e/slideshow.spec.ts
+++ b/ui/tests/e2e/slideshow.spec.ts
@@ -37,6 +37,36 @@ test.describe("slideshow", () => {
     await expect(page.getByTestId("slideshow-overlay")).toHaveCount(0);
   });
 
+  // The seed has 3 images, the last one tagged "internal" — the grid shows all
+  // three, the slideshow only ever counts and plays two.
+  test("skips internal images", async ({ page }) => {
+    await loginAs(page, "admin");
+    await page.goto("/images");
+    await expect(page.locator('[id^="grid-tile-"]')).toHaveCount(3);
+    await page.getByTestId("start-slideshow").click();
+    await expect(page.getByTestId("slideshow-setup")).toContainText("2 images in the current view");
+    await page.getByTestId("slideshow-start").click();
+    await expect(page.getByTestId("slideshow-position")).toContainText("1 / 2");
+  });
+
+  test("never puts a scrollbar on the page", async ({ page }) => {
+    await loginAs(page, "admin");
+    await page.goto("/images");
+    await page.getByTestId("start-slideshow").click();
+    // strong pan & zoom scales the slide past the viewport — the classic way to
+    // grow a scrollbar
+    await page.getByRole("button", { name: "Strong" }).click();
+    await page.getByTestId("slideshow-start").click();
+    await expect(page.getByTestId("slideshow-position")).toBeVisible();
+
+    const viewport = await page.evaluate(() => ({
+      verticalScrollbar: window.innerWidth - document.documentElement.clientWidth,
+      horizontalScrollbar: window.innerHeight - document.documentElement.clientHeight,
+      documentOverflow: getComputedStyle(document.body).overflow,
+    }));
+    expect(viewport).toEqual({ verticalScrollbar: 0, horizontalScrollbar: 0, documentOverflow: "hidden" });
+  });
+
   test("escape closes the slideshow", async ({ page }) => {
     await loginAs(page, "admin");
     await page.goto("/images");

--- a/ui/tests/slideshow.spec.ts
+++ b/ui/tests/slideshow.spec.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from "vitest";
-import { kenBurnsVariant, nextSlideIndex, previousSlideIndex, preloadIndices, shouldFetchMore } from "src/util/slideshow";
+import { isInternalImage, kenBurnsVariant, nextSlideIndex, previousSlideIndex, preloadIndices, shouldFetchMore } from "src/util/slideshow";
+
+describe("isInternalImage (never shown in a slideshow)", () => {
+  const image = (...names: string[]) => ({ tags: names.map((name) => ({ tag: { name } })) });
+
+  it("matches the reserved tag regardless of case", () => {
+    expect(isInternalImage(image("internal"))).toBe(true);
+    expect(isInternalImage(image("podium", "Internal"))).toBe(true);
+  });
+
+  it("matches it as a combo part, like the EXIF export", () => {
+    expect(isInternalImage(image("trip|internal"))).toBe(true);
+    expect(isInternalImage(image("internal | wip"))).toBe(true);
+  });
+
+  it("leaves everything else playable", () => {
+    expect(isInternalImage(image("podium", "autocross|DV"))).toBe(false);
+    expect(isInternalImage(image("internally"))).toBe(false);
+    expect(isInternalImage({})).toBe(false);
+  });
+});
 
 describe("preloadIndices (decode-ahead window)", () => {
   it("returns the next headroom indices", () => {


### PR DESCRIPTION
The slideshow now derives its own playlist from the current view, dropping
every image tagged "internal" — the reserved management tag that is already
kept out of EXIF exports. Every path onto the screen (auto-advance, manual
navigation, decode-ahead) indexes that playlist, so none of them can reach an
internal shot. Combo tags are checked per part ("trip|internal"), mirroring
api/internal/exif/inject.go. The position counter discounts the internal
images seen so far, exact once the view is fully paged.

Falling out of the filter: an all-internal page used to end the show early.
"Nothing to advance to" now means "the next page has not arrived yet" while
the server still has images, and the buffering chip covers the wait.

Slideshow mode also no longer shows a scrollbar on either axis: the overlay
clips the Ken Burns transform that scaled past the viewport, and the document
scroll is locked while it is up — the grid underneath owned that scrollbar,
which sat next to the show and let arrow keys scroll the page behind it.

Also fixes upload timeline lane labels: seeding ran before loadContext
resolved the tag list, freezing persisted lanes on their "Tag" placeholder.

The seed gains the reserved "internal" tag on its newest image so both
guarantees are covered end to end.
