### PR TITLE
feat(review): grid verdict badges and custom tags invisible to AI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,6 @@ yarn-error.log
 
 
 # End of https://www.toptal.com/developers/gitignore/api/vue,vuejs,visualstudiocode,webstorm+all,goland+all,go
+
+# Claude Code worktrees (parked feature branches live here)
+.claude/worktrees/

--- a/api/internal/server/image_response.go
+++ b/api/internal/server/image_response.go
@@ -55,6 +55,15 @@ type namedRef struct {
 	Name string `json:"name"`
 }
 
+// projectRef carries the review flag so the gallery can decide per image —
+// not per active project — whether the reserved verdict tags mean anything
+// (cross-project person search shows images from other projects).
+type projectRef struct {
+	ID                  string `json:"id"`
+	Name                string `json:"name"`
+	UploadReviewEnabled bool   `json:"uploadReviewEnabled"`
+}
+
 type tagRef struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
@@ -94,7 +103,7 @@ type ImageResponse struct {
 	StorageID           string                 `json:"storageId"`
 	User                *userRef               `json:"user"`
 	Camera              *namedRef              `json:"camera"`
-	Project             *namedRef              `json:"project"`
+	Project             *projectRef            `json:"project"`
 	Upload              *uploadRef             `json:"upload"`
 	Tags                []assignmentRef        `json:"tags"`
 	ImageTags           []string               `json:"imageTags"`
@@ -163,7 +172,7 @@ func ToImageResponse(ctx context.Context, img *ent.Image, signer DownloadURLSign
 		resp.Camera = &namedRef{ID: c.ID, Name: c.Name}
 	}
 	if p := img.Edges.Project; p != nil {
-		resp.Project = &namedRef{ID: p.ID, Name: p.Name}
+		resp.Project = &projectRef{ID: p.ID, Name: p.Name, UploadReviewEnabled: p.UploadReviewEnabled}
 	}
 	if up := img.Edges.Upload; up != nil {
 		resp.Upload = &uploadRef{ID: up.ID, Name: up.Name, State: up.State.String()}

--- a/api/internal/server/image_response_test.go
+++ b/api/internal/server/image_response_test.go
@@ -47,7 +47,7 @@ func TestToImageResponseMapShape(t *testing.T) {
 		Edges: ent.ImageEdges{
 			User:    &ent.User{ID: uuid.New(), FirstName: "Ada", LastName: "Lovelace", CopyrightTag: "© Ada"},
 			Camera:  &ent.Camera{ID: "cam1", Name: "Fresh"},
-			Project: &ent.Project{ID: "prj1", Name: "FSG"},
+			Project: &ent.Project{ID: "prj1", Name: "FSG", UploadReviewEnabled: true},
 			Upload:  &ent.Upload{ID: "upl1", Name: "Batch 1"},
 		},
 	}
@@ -60,6 +60,7 @@ func TestToImageResponseMapShape(t *testing.T) {
 	assert.Equal(t, "Ada", resp.User.FirstName)
 	assert.Equal(t, "Fresh", resp.Camera.Name)
 	assert.Equal(t, "FSG", resp.Project.Name)
+	assert.True(t, resp.Project.UploadReviewEnabled, "gallery needs the per-image review flag")
 	assert.Equal(t, "Batch 1", resp.Upload.Name)
 	assert.NotNil(t, resp.ExifData) // empty exif serializes as {} not null
 

--- a/api/internal/service/ai_service.go
+++ b/api/internal/service/ai_service.go
@@ -383,8 +383,11 @@ func (s *AIService) processWith(ctx context.Context, imageID string, inference I
 		if name == "" || name == "none" {
 			continue
 		}
+		// TypeNEQ custom: hard invariant, independent of the vocabulary — even a
+		// misbehaving AI server echoing a custom tag's name must never assign it.
 		tag, err := s.repo.Client.ImageTag.Query().
-			Where(imagetag.ProjectID(project.ID), imagetag.NameEQ(name)).
+			Where(imagetag.ProjectID(project.ID), imagetag.NameEQ(name),
+				imagetag.TypeNEQ(imagetag.TypeCustom)).
 			Only(ctx)
 		if err != nil {
 			// no matching project tag (or lookup error) -> nothing to link.
@@ -425,12 +428,16 @@ func (s *AIService) processWith(ctx context.Context, imageID string, inference I
 }
 
 // AvailableTagNames is the vocabulary sent to the AI server: every aiEnabled
-// project tag except templates (unrendered "$X" patterns are not assignable).
+// project tag except templates (unrendered "$X" patterns are not assignable)
+// and custom tags (personal/unofficial, never exported — AI must never assign
+// them; FSG26 had AI mass-assigning a photographer's custom car_79/car_72).
 // Shared by the per-ingest request and the project prime hook so both stay in
 // sync.
 func AvailableTagNames(ctx context.Context, repo *repository.Repository, projectID string) []string {
 	tags, err := repo.Client.ImageTag.Query().
-		Where(imagetag.ProjectID(projectID), imagetag.TypeNEQ(imagetag.TypeTemplate), imagetag.AiEnabled(true)).
+		Where(imagetag.ProjectID(projectID),
+			imagetag.TypeNotIn(imagetag.TypeTemplate, imagetag.TypeCustom),
+			imagetag.AiEnabled(true)).
 		All(ctx)
 	if err != nil {
 		log.Error().Err(err).Str("project", projectID).Msg("AI: loading project tags failed")

--- a/api/internal/service/ai_service_test.go
+++ b/api/internal/service/ai_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	entimage "github.com/shutterbase/shutterbase/ent/image"
+	"github.com/shutterbase/shutterbase/ent/imagetag"
 	"github.com/shutterbase/shutterbase/ent/imagetagassignment"
 	"github.com/shutterbase/shutterbase/internal/database"
 	"github.com/shutterbase/shutterbase/internal/repository"
@@ -415,6 +416,28 @@ func TestBootRecovery(t *testing.T) {
 	cancel() // dispatcher exits; recovery already ran synchronously
 	assert.Equal(t, "pending", aiStatus(t, svc, stale), "stale processing row must be re-queued")
 	assert.Equal(t, "processing", aiStatus(t, svc, fresh), "fresh processing row must be left to its replica")
+}
+
+// Custom tags are invisible to AI: never in the vocabulary (even with
+// aiEnabled=true), and never assigned even when the AI server returns their
+// exact name (the FSG26 car_79/car_72 incident).
+func TestCustomTagsInvisibleToAI(t *testing.T) {
+	t.Setenv("SESSION_SECRET_KEY", "x")
+	require.NoError(t, util.InitConfig())
+	svc, m := newSvc(t, &StubInference{Tags: []string{"car_99"}})
+	ctx := context.Background()
+	img := m.Images[0]
+
+	custom := svc.repo.Client.ImageTag.Create().
+		SetName("car_99").SetDescription("Custom tag 'car_99'").
+		SetType(imagetag.TypeCustom).SetProjectID(m.Project).
+		SaveX(ctx)
+
+	assert.NotContains(t, AvailableTagNames(ctx, svc.repo, m.Project), "car_99")
+
+	require.NoError(t, svc.process(ctx, img))
+	assert.Equal(t, 0, inferredCount(t, svc, img, custom.ID), "AI must never assign a custom tag")
+	assert.Equal(t, "done", aiStatus(t, svc, img))
 }
 
 // aiEnabled=false removes a tag from the AI vocabulary; everything else stays.

--- a/ui/src/components/image/ImageGridTile.vue
+++ b/ui/src/components/image/ImageGridTile.vue
@@ -20,9 +20,17 @@
       <PhotoIcon class="h-8 w-8 text-primary-300 dark:text-primary-700" />
     </div>
 
-    <!-- selection check -->
-    <div v-if="selected" class="absolute right-2 top-2 rounded-full bg-accent-600 p-1 shadow-sm">
-      <CheckIcon class="h-3.5 w-3.5 text-white" />
+    <!-- review verdicts (rejected / tagging error) and the selection check -->
+    <div class="absolute right-2 top-2 flex items-center gap-1">
+      <div v-if="verdicts.rejected" title="Rejected" class="rounded-full bg-primary-950/70 p-1 shadow-sm">
+        <NoSymbolIcon class="h-4 w-4 text-error-400" />
+      </div>
+      <div v-if="verdicts.error" title="Tagging error" class="rounded-full bg-primary-950/70 p-1 shadow-sm">
+        <ExclamationTriangleIcon class="h-4 w-4 text-warning-400" />
+      </div>
+      <div v-if="selected" class="rounded-full bg-accent-600 p-1 shadow-sm">
+        <CheckIcon class="h-3.5 w-3.5 text-white" />
+      </div>
     </div>
 
     <!-- AI detection status -->
@@ -62,7 +70,8 @@ import { aiBadgeLabel, aiBadgeTitle } from "src/util/aiDetection";
 import { ImageWithTagsType } from "src/types/custom";
 import { devPlaceholder } from "src/util/devPlaceholder";
 import { computed, ref } from "vue";
-import { ArrowPathIcon, CheckIcon, ClockIcon, ExclamationTriangleIcon, PhotoIcon, SparklesIcon } from "@heroicons/vue/24/solid";
+import { reviewVerdicts } from "src/util/uploadReview";
+import { ArrowPathIcon, CheckIcon, ClockIcon, ExclamationTriangleIcon, NoSymbolIcon, PhotoIcon, SparklesIcon } from "@heroicons/vue/24/solid";
 
 type Density = "gallery" | "comfortable" | "dense";
 
@@ -87,6 +96,11 @@ const emit = defineEmits<{
 }>();
 
 const capturedAt = computed(() => dateTimeUtil.dateTimeFromBackend(props.image.capturedAtCorrected));
+
+// per-image, not per-active-project: cross-project person search shows
+// foreign images whose own project decides whether verdict tags mean anything
+const verdicts = computed(() => reviewVerdicts({ reviewEnabled: !!props.image.project?.uploadReviewEnabled, tags: props.image.tags }));
+
 const aiLabel = computed(() => aiBadgeLabel(props.image.aiStatus, props.aiPosition));
 const aiTitle = computed(() => aiBadgeTitle(props.image.aiStatus, props.aiPosition, props.image.aiError));
 

--- a/ui/src/components/project/TagDialog.vue
+++ b/ui/src/components/project/TagDialog.vue
@@ -154,12 +154,18 @@ const createTagFields: CreateField<ImageTagsResponse>[] = [
   { key: "type", label: "Type", type: CreateFieldType.SELECT, options: ["template", "default", "manual", "custom"], optionsDefault: "manual" },
 ];
 
-const editTagFields: EditField<ImageTagsResponse>[] = [
-  { key: "name", label: "Name", type: EditFieldType.TEXT },
-  { key: "displayName", label: "Display name (optional, shown instead of the name)", type: EditFieldType.TEXT },
-  { key: "description", label: "Description", type: EditFieldType.TEXT },
-  { key: "order", label: "Order (lower first, empty = last)", type: EditFieldType.TEXT },
-  { key: "type", label: "Type", type: EditFieldType.SELECT, options: ["template", "default", "manual", "custom"] },
-  { key: "aiEnabled", label: "AI tagging", type: EditFieldType.BOOLEAN, hint: "AI may assign this tag" },
-];
+const editTagFields = computed<EditField<ImageTagsResponse>[]>(() => {
+  const fields: EditField<ImageTagsResponse>[] = [
+    { key: "name", label: "Name", type: EditFieldType.TEXT },
+    { key: "displayName", label: "Display name (optional, shown instead of the name)", type: EditFieldType.TEXT },
+    { key: "description", label: "Description", type: EditFieldType.TEXT },
+    { key: "order", label: "Order (lower first, empty = last)", type: EditFieldType.TEXT },
+    { key: "type", label: "Type", type: EditFieldType.SELECT, options: ["template", "default", "manual", "custom"] },
+  ];
+  // custom tags are never in the AI vocabulary, so the toggle would be a lie
+  if (item.value.type !== "custom") {
+    fields.push({ key: "aiEnabled", label: "AI tagging", type: EditFieldType.BOOLEAN, hint: "AI may assign this tag" });
+  }
+  return fields;
+});
 </script>

--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -200,7 +200,7 @@ import {
   invalidateGridSnapshot,
   resetTransientFilters,
 } from "./imageQueryLogic";
-import { totalImageCount, images, imageIndex, imageIndices, multiselectStart, multiselectEnd, loading, activeProject } from "./imageQueryLogic";
+import { totalImageCount, images, imageIndex, imageIndices, multiselectStart, multiselectEnd, loading } from "./imageQueryLogic";
 import { taggingDialogVisible, addImageTag } from "./imageQueryLogic";
 import { showUnexpectedErrorMessage, unexpectedError } from "./imageQueryLogic";
 import { nextImage, previousImage, previousRow, nextRow, repeatLastTagAssignment, toggleTagByName } from "./imageQueryLogic";

--- a/ui/src/stores/user-store.ts
+++ b/ui/src/stores/user-store.ts
@@ -31,7 +31,7 @@ export const useUserStore = defineStore("user", {
   actions: {
     setProject(project: EmbeddedProject) {
       this.activeProjectId = project.id;
-      this.activeProject = { id: project.id, name: project.name };
+      this.activeProject = { id: project.id, name: project.name, uploadReviewEnabled: project.uploadReviewEnabled };
       this.projectTags = [];
       this.tagStack = [];
       this.loadProjectTags();

--- a/ui/src/util/uploadReview.ts
+++ b/ui/src/util/uploadReview.ts
@@ -20,6 +20,14 @@ export function isReviewerOnlyTag(name: string): boolean {
   return isReviewErrorTag(name) || isReviewRejectedTag(name);
 }
 
+// Grid-view verdict markers: which reserved review tags an image carries. Off
+// entirely without the review flow — a project may own a plain custom tag
+// coincidentally named "error".
+export function reviewVerdicts(input: { reviewEnabled: boolean; tags?: { tag?: { name: string } | null }[] }): { rejected: boolean; error: boolean } {
+  const names = input.reviewEnabled ? (input.tags ?? []).map((a) => a.tag?.name ?? "") : [];
+  return { rejected: names.some(isReviewRejectedTag), error: names.some(isReviewErrorTag) };
+}
+
 export const UPLOAD_STATES: UploadState[] = ["open", "ready", "reviewed"];
 
 export const UPLOAD_STATE_LABEL: Record<UploadState, string> = {

--- a/ui/tests/uploadReview.spec.ts
+++ b/ui/tests/uploadReview.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { canEditTag, canAddImages, allowedTransitions, formatDuration, formatTaggingRate, isReviewErrorTag, isReviewRejectedTag, isReviewerOnlyTag } from "src/util/uploadReview";
+import { canEditTag, canAddImages, allowedTransitions, formatDuration, formatTaggingRate, isReviewErrorTag, isReviewRejectedTag, isReviewerOnlyTag, reviewVerdicts } from "src/util/uploadReview";
 
 // These rules must stay in lockstep with api/internal/authorization — the server
 // is authoritative, so a divergence here means the UI offers 403s.
@@ -73,5 +73,21 @@ describe("metric formatting", () => {
   it("pairs images per second with the readable per-minute rate", () => {
     expect(formatTaggingRate(0)).toBe("–");
     expect(formatTaggingRate(0.0833)).toBe("0.083 img/s (5.0/min)");
+  });
+});
+
+describe("reviewVerdicts", () => {
+  const tags = (...names: string[]) => names.map((name) => ({ tag: { name } }));
+
+  it("flags the reserved verdict tags, case-insensitively", () => {
+    expect(reviewVerdicts({ reviewEnabled: true, tags: tags("Race", "Rejected") })).toEqual({ rejected: true, error: false });
+    expect(reviewVerdicts({ reviewEnabled: true, tags: tags("error") })).toEqual({ rejected: false, error: true });
+    expect(reviewVerdicts({ reviewEnabled: true, tags: tags("error", "rejected") })).toEqual({ rejected: true, error: true });
+  });
+
+  it("stays silent without the review flow, or without tags", () => {
+    expect(reviewVerdicts({ reviewEnabled: false, tags: tags("error", "rejected") })).toEqual({ rejected: false, error: false });
+    expect(reviewVerdicts({ reviewEnabled: true })).toEqual({ rejected: false, error: false });
+    expect(reviewVerdicts({ reviewEnabled: true, tags: [{ tag: null }] })).toEqual({ rejected: false, error: false });
   });
 });


### PR DESCRIPTION
Image grid tiles now show the reserved review verdicts (rejected /
tagging error) as corner badges. The flag comes from the image's own
embedded project — serialized per image — so cross-project person
search judges each image by its own project's review flow, not the
active project's.

Custom tags are now fully invisible to AI: excluded from the
vocabulary sent to the AI server and never assignable even when the
server echoes their exact name (FSG26 had AI mass-assigning a
photographer's custom car_79/car_72). The aiEnabled toggle is hidden
for custom tags since it could never take effect.

Also: setProject() no longer drops uploadReviewEnabled, and
.claude/worktrees/ is gitignored.
