### PR TITLE
feat(images): include/exclude tag filter, taller tagging dialog, applied-tag hint

### DIFF
--- a/api/internal/repository/image.go
+++ b/api/internal/repository/image.go
@@ -57,6 +57,7 @@ type GetImageParameters struct {
 	UserID               *uuid.UUID
 	Search               *string
 	TagIDs               []string // repeated -> AND-match via a single jsonb @> containment
+	ExcludeTagIDs        []string // repeated -> drop images carrying ANY of these (NOT @> per id)
 	IDs                  []string // restrict to these ids (person filter); nil = no restriction
 	Orientation          *string  // "portrait" (w<h) | "landscape" (w>h); null w/h excluded
 	PaginationParameters *PaginationParameters
@@ -98,6 +99,16 @@ func (r *Repository) GetImages(ctx context.Context, parameters *GetImageParamete
 		tagIDs := parameters.TagIDs
 		predicates = append(predicates, func(s *sql.Selector) {
 			s.Where(sqljson.ValueContains(image.FieldImageTags, tagIDs))
+		})
+	}
+	for _, excludedTagID := range parameters.ExcludeTagIDs {
+		excluded := []string{excludedTagID}
+		predicates = append(predicates, func(s *sql.Selector) {
+			// NULL imageTags must survive: NOT(NULL @> ...) is NULL, which would drop the row.
+			s.Where(sql.Or(
+				sql.IsNull(s.C(image.FieldImageTags)),
+				sql.Not(sqljson.ValueContains(image.FieldImageTags, excluded)),
+			))
 		})
 	}
 	if parameters.Orientation != nil {

--- a/api/internal/server/images_controller.go
+++ b/api/internal/server/images_controller.go
@@ -56,6 +56,9 @@ func (s *Server) listImages(c *gin.Context) {
 	if tags := c.QueryArray("tagId"); len(tags) > 0 {
 		params.TagIDs = tags
 	}
+	if tags := c.QueryArray("excludeTagId"); len(tags) > 0 {
+		params.ExcludeTagIDs = tags
+	}
 	if v := c.Query("orientation"); v != "" {
 		if v != "portrait" && v != "landscape" {
 			apiError(c, http.StatusBadRequest, "invalid_orientation", "orientation must be 'portrait' or 'landscape'")

--- a/api/test/e2e/repository_e2e_test.go
+++ b/api/test/e2e/repository_e2e_test.go
@@ -109,6 +109,43 @@ func TestGetImagesTagAndMatch(t *testing.T) {
 	require.NoError(t, r.DeleteImageTagAssignment(ctx, a.ID))
 }
 
+func TestGetImagesExcludeTags(t *testing.T) {
+	ctx := context.Background()
+	r := repo(t)
+	m := stack.Manifest
+
+	podium := m.Tags["Podium"]
+
+	// Assign Podium to one image, then exclude it -> only the other two remain.
+	_, _, err := r.CreateImageTagAssignment(ctx, &repository.CreateImageTagAssignmentParameters{
+		ImageID: m.Images[0], ImageTagID: podium, Type: imagetagassignment.TypeManual,
+	})
+	require.NoError(t, err)
+
+	items, total, err := r.GetImages(ctx, &repository.GetImageParameters{
+		ProjectID: m.Project, ExcludeTagIDs: []string{podium}, PaginationParameters: defaultPagination(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "NOT imageTags @> '[podium]'")
+	for _, item := range items {
+		assert.NotEqual(t, m.Images[0], item.ID)
+	}
+
+	// include and exclude compose: Default AND NOT Podium.
+	_, total, err = r.GetImages(ctx, &repository.GetImageParameters{
+		ProjectID: m.Project, TagIDs: []string{m.Tags["Default"]}, ExcludeTagIDs: []string{podium},
+		PaginationParameters: defaultPagination(),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+
+	// cleanup: remove the extra assignment so later tests see the seed baseline.
+	a := stack.DB.Client.ImageTagAssignment.Query().
+		Where(imagetagassignment.ImageID(m.Images[0]), imagetagassignment.ImageTagID(podium)).
+		OnlyX(ctx)
+	require.NoError(t, r.DeleteImageTagAssignment(ctx, a.ID))
+}
+
 func TestGetImagesOrientationNullExclusion(t *testing.T) {
 	ctx := context.Background()
 	r := repo(t)

--- a/ui/src/api/images.ts
+++ b/ui/src/api/images.ts
@@ -8,6 +8,7 @@ export interface ImageListParams {
   userId?: string;
   search?: string;
   tagId?: string[]; // repeated, AND-combined server-side
+  excludeTagId?: string[]; // repeated, images carrying ANY of these are dropped
   personRef?: string; // implicit person filter (AI face clustering handle)
   crossProject?: "true"; // person filter only: search every viewable project
   orientation?: "portrait" | "landscape";

--- a/ui/src/components/image/ImagesHeader.vue
+++ b/ui/src/components/image/ImagesHeader.vue
@@ -125,24 +125,53 @@
                 class="h-8 w-full rounded-md border border-primary-200 bg-surface-muted px-2.5 text-sm text-primary-900 placeholder:text-primary-400 focus:border-accent-500 focus:outline-none focus:ring-1 focus:ring-accent-500 dark:border-primary-700 dark:bg-primary-900 dark:text-primary-100"
               />
             </div>
-            <div class="scrollbar-tool max-h-64 overflow-y-auto p-1">
+            <!-- active filters: pinned above the list, immune to the text filter -->
+            <div v-if="selectedTags.length" class="flex flex-wrap gap-1.5 border-b border-primary-100 p-2 dark:border-primary-800">
               <button
+                v-for="entry in selectedTags"
+                :key="entry.tag.id"
+                type="button"
+                :aria-label="`Remove filter ${tagLabel(entry.tag)}`"
+                :title="entry.exclude ? 'Excluded — click to remove' : 'Included — click to remove'"
+                @click="removeTagFilter(entry)"
+                :class="[
+                  'group inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium transition-colors',
+                  entry.exclude
+                    ? 'border-error-400/60 bg-error-500/10 text-error-700 hover:border-error-500 dark:border-error-400/40 dark:text-error-300'
+                    : 'border-success-400/60 bg-success-500/10 text-success-700 hover:border-success-500 dark:border-success-400/40 dark:text-success-300',
+                ]"
+              >
+                <span class="font-semibold">{{ entry.exclude ? "−" : "+" }}</span>
+                <span class="truncate">{{ tagLabel(entry.tag) }}</span>
+                <XMarkIcon class="h-3.5 w-3.5 shrink-0 opacity-60 group-hover:opacity-100" />
+              </button>
+            </div>
+            <div class="scrollbar-tool max-h-64 overflow-y-auto p-1">
+              <div
                 v-for="tag in filteredTags"
                 :key="tag.id"
-                type="button"
-                @click="toggleTag(tag)"
-                class="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm text-primary-700 transition-colors hover:bg-primary-100 dark:text-primary-200 dark:hover:bg-primary-800"
+                class="group flex w-full items-center gap-1 rounded-md px-2.5 py-1.5 text-left text-sm text-primary-700 transition-colors hover:bg-primary-100 dark:text-primary-200 dark:hover:bg-primary-800"
               >
-                <span
-                  :class="[
-                    'flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border',
-                    isSelected(tag) ? 'border-accent-500 bg-accent-500 text-white' : 'border-primary-300 dark:border-primary-600',
-                  ]"
+                <span class="min-w-0 flex-1 truncate">{{ tagLabel(tag) }}</span>
+                <button
+                  type="button"
+                  :aria-label="`Include ${tagLabel(tag)}`"
+                  :title="`Show only images with ${tagLabel(tag)}`"
+                  @click="addTagFilter(tag, false)"
+                  class="rounded p-1 text-primary-400 transition-colors hover:bg-success-500/15 hover:text-success-600 dark:text-primary-500 dark:hover:text-success-300"
                 >
-                  <CheckIcon v-if="isSelected(tag)" class="h-3 w-3" />
-                </span>
-                <span class="truncate">{{ tagLabel(tag) }}</span>
-              </button>
+                  <MagnifyingGlassPlusIcon class="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  :aria-label="`Exclude ${tagLabel(tag)}`"
+                  :title="`Hide images with ${tagLabel(tag)}`"
+                  @click="addTagFilter(tag, true)"
+                  class="rounded p-1 text-primary-400 transition-colors hover:bg-error-500/15 hover:text-error-600 dark:text-primary-500 dark:hover:text-error-300"
+                >
+                  <MagnifyingGlassMinusIcon class="h-4 w-4" />
+                </button>
+              </div>
               <p v-if="!filteredTags.length" class="px-2.5 py-6 text-center text-sm text-primary-400">No tags found</p>
             </div>
             <div v-if="selectedTags.length" class="border-t border-primary-100 p-1 dark:border-primary-800">
@@ -252,6 +281,8 @@
 import {
   PhotoIcon,
   MagnifyingGlassIcon,
+  MagnifyingGlassPlusIcon,
+  MagnifyingGlassMinusIcon,
   QuestionMarkCircleIcon,
   XMarkIcon,
   TagIcon,
@@ -295,7 +326,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   search: [string];
-  filterTags: [ImageTag[]];
+  filterTags: [{ include: ImageTag[]; exclude: ImageTag[] }];
   aspectRatioFilter: [string];
   "update:density": [Density];
   rerunAi: [];
@@ -346,18 +377,31 @@ watch(searchText, () => emit("search", searchText.value));
 const orientation = ref<string>("neutral");
 watch(orientation, () => emit("aspectRatioFilter", orientation.value));
 
-// tags
+// tags — Grafana-style polarity filter: + narrows to images WITH the tag,
+// − drops images WITH the tag. Selected entries pin above the list.
+interface TagFilterEntry {
+  tag: ImageTag;
+  exclude: boolean;
+}
 const tagQuery = ref("");
-const selectedTags = ref<ImageTag[]>([]);
-watch(selectedTags, () => emit("filterTags", selectedTags.value), { deep: true });
+const selectedTags = ref<TagFilterEntry[]>([]);
+watch(selectedTags, () =>
+  emit("filterTags", {
+    include: selectedTags.value.filter((e) => !e.exclude).map((e) => e.tag),
+    exclude: selectedTags.value.filter((e) => e.exclude).map((e) => e.tag),
+  }),
+);
 const selectableTags = computed(() => projectTags.value.filter((t: ImageTag) => t.type !== "template"));
 const filteredTags = computed(() => {
   const q = tagQuery.value.toLowerCase();
-  return selectableTags.value.filter((t: ImageTag) => t.name.toLowerCase().includes(q) || tagLabel(t).toLowerCase().includes(q));
+  return selectableTags.value.filter((t: ImageTag) => !isSelected(t) && (t.name.toLowerCase().includes(q) || tagLabel(t).toLowerCase().includes(q)));
 });
-const isSelected = (tag: ImageTag) => selectedTags.value.some((t) => t.id === tag.id);
-function toggleTag(tag: ImageTag) {
-  selectedTags.value = isSelected(tag) ? selectedTags.value.filter((t) => t.id !== tag.id) : [...selectedTags.value, tag];
+const isSelected = (tag: ImageTag) => selectedTags.value.some((e) => e.tag.id === tag.id);
+function addTagFilter(tag: ImageTag, exclude: boolean) {
+  selectedTags.value = [...selectedTags.value, { tag, exclude }];
+}
+function removeTagFilter(entry: TagFilterEntry) {
+  selectedTags.value = selectedTags.value.filter((e) => e.tag.id !== entry.tag.id);
 }
 function clearTags() {
   selectedTags.value = [];
@@ -388,8 +432,8 @@ function onUploadSelect(id: string | null) {
 }
 
 // kept for Images.vue: re-sync selected tags when toggling grid/detail
-function setFilteredTags(tags: ImageTag[]) {
-  selectedTags.value = tags;
+function setFilteredTags(include: ImageTag[], exclude: ImageTag[]) {
+  selectedTags.value = [...include.map((tag) => ({ tag, exclude: false })), ...exclude.map((tag) => ({ tag, exclude: true }))];
 }
 defineExpose({ setFilteredTags });
 </script>

--- a/ui/src/components/image/TaggingDialog.vue
+++ b/ui/src/components/image/TaggingDialog.vue
@@ -13,7 +13,7 @@
   -->
     <div v-show="shown" class="fixed inset-0 bg-primary-950/60 backdrop-blur-sm transition-opacity"></div>
 
-    <div v-show="shown" class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
+    <div v-show="shown" class="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:px-20 md:py-10">
       <!--
       Command palette, show/hide based on modal state.
 
@@ -50,8 +50,11 @@
           v-if="(filteredTags.length !== 0 && searchText !== '') || (recentTags.length !== 0 && searchText === '')"
           class="flex transform-gpu divide-x divide-primary-200 dark:divide-primary-800"
         >
-          <!-- Preview Visible: "sm:h-96" -->
-          <div class="max-h-96 min-w-0 flex-auto scroll-py-4 overflow-y-auto px-6 py-4 sm:h-96">
+          <!-- ends at ~two thirds of the viewport: taller than the old fixed h-96,
+               but the lower third stays free so the dialog never reads as a
+               takeover; the calc offsets mirror the wrapper padding plus the
+               h-12 input so the panel itself never overflows -->
+          <div class="max-h-[calc(66dvh-5rem)] min-w-0 flex-auto scroll-py-4 overflow-y-auto px-6 py-4 sm:h-[calc(66dvh-5rem)] md:h-[calc(66dvh-6rem)]">
             <!-- Default state, show/hide based on command palette state. -->
             <h2 v-if="filteredTags.length === 0 && searchText === ''" class="label-mono mb-4 mt-2 text-primary-500 dark:text-primary-400">Recent tags</h2>
             <ul v-if="filteredTags.length === 0 && searchText === ''" class="-mx-2 text-sm text-primary-700 dark:text-primary-200" id="options" role="listbox">
@@ -117,9 +120,28 @@
 
         <!-- Empty state, show/hide based on command palette state -->
         <div v-if="filteredTags.length === 0 && searchText !== ''" class="px-6 py-14 text-center text-sm sm:px-14">
-          <TagIcon class="mx-auto h-6 w-6 text-primary-400 dark:text-primary-500" />
-          <p class="mt-4 font-semibold text-primary-900 dark:text-white">No matching tags</p>
-          <p class="mt-2 text-primary-500 dark:text-primary-400">No tag matching your search could be found. Please use a different keyword or create a 'custom' tag</p>
+          <template v-if="appliedMatchingTags.length > 0">
+            <CheckCircleIcon class="mx-auto h-6 w-6 text-success-500 dark:text-success-400" />
+            <p class="mt-4 font-semibold text-primary-900 dark:text-white">Already applied</p>
+            <p class="mt-2 text-primary-500 dark:text-primary-400">
+              The matching {{ appliedMatchingTags.length === 1 ? "tag is" : "tags are" }} already applied to this image
+            </p>
+            <ul class="mt-4 flex flex-wrap justify-center gap-2">
+              <li
+                v-for="tag in appliedMatchingTags"
+                :key="tag.id"
+                class="inline-flex items-center gap-1.5 rounded-full border border-success-400/60 bg-success-500/10 px-3 py-1 text-sm font-medium text-success-700 dark:border-success-400/40 dark:text-success-300"
+              >
+                <CheckIcon class="h-4 w-4" />
+                {{ tagLabel(tag) }}
+              </li>
+            </ul>
+          </template>
+          <template v-else>
+            <TagIcon class="mx-auto h-6 w-6 text-primary-400 dark:text-primary-500" />
+            <p class="mt-4 font-semibold text-primary-900 dark:text-white">No matching tags</p>
+            <p class="mt-2 text-primary-500 dark:text-primary-400">No tag matching your search could be found. Please use a different keyword or create a 'custom' tag</p>
+          </template>
           <p
             @click="createCustomTag"
             @keydown.enter="createCustomTag"
@@ -141,7 +163,7 @@
 import { useUserStore } from "src/stores/user-store";
 import { storeToRefs } from "pinia";
 import { ImageWithTagsType } from "src/types/custom";
-import { TagIcon } from "@heroicons/vue/24/outline";
+import { CheckCircleIcon, CheckIcon, TagIcon } from "@heroicons/vue/24/outline";
 import { Ref, computed, nextTick, onUnmounted, ref, watch } from "vue";
 import { emitter } from "src/boot/mitt";
 import { debug } from "src/util/logger";
@@ -197,6 +219,18 @@ const filteredTags = computed(() => {
     }
     return false;
   });
+});
+
+// matching tags that are already on the image — without this, "No matching
+// tags" reads as "tag missing" when it is in fact already applied
+const appliedMatchingTags = computed(() => {
+  if (!props.image?.tags || searchText.value === "") {
+    return [];
+  }
+  const query = searchText.value.toLowerCase();
+  return props.image.tags
+    .map((assignment) => assignment.tag)
+    .filter((tag) => tag.name.toLowerCase().includes(query) || tagLabel(tag).toLowerCase().includes(query) || tag.description.toLowerCase().includes(query));
 });
 
 const recentTags = computed(() => {

--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -188,6 +188,7 @@ import {
   searchText,
   updateSearchText,
   filterTags,
+  excludeFilterTags,
   updateFilterTags,
   aspectRatioFilter,
   updateAspectRatioFilter,
@@ -303,7 +304,7 @@ async function applyRoute(initial = false) {
     displayMode.value = DisplayMode.GRID;
     nextTick(() => {
       if (imageIndex.value !== -1) scrollToSelectedImage();
-      if (imagesHeader.value) imagesHeader.value.setFilteredTags(filterTags.value);
+      if (imagesHeader.value) imagesHeader.value.setFilteredTags(filterTags.value, excludeFilterTags.value);
     });
   }
 }
@@ -358,7 +359,7 @@ watch(preferredImageSortOrder, () => {
   loadImages(true);
 });
 watch(searchText, reloadDebounced);
-watch(filterTags, reloadDebounced);
+watch([filterTags, excludeFilterTags], reloadDebounced);
 watch(aspectRatioFilter, reloadDebounced);
 
 // Hotkey wiring: the images context and its handlers are only active while

--- a/ui/src/pages/image/imageListParams.ts
+++ b/ui/src/pages/image/imageListParams.ts
@@ -7,6 +7,7 @@ export function buildImageListParams(input: {
   projectId: string;
   search?: string;
   tags?: { id: string }[];
+  excludeTags?: { id: string }[];
   personRef?: string;
   crossProject?: boolean;
   uploadId?: string;
@@ -22,6 +23,9 @@ export function buildImageListParams(input: {
   }
   if (input.tags && input.tags.length > 0) {
     params.tagId = input.tags.map((t) => t.id); // repeated -> AND
+  }
+  if (input.excludeTags && input.excludeTags.length > 0) {
+    params.excludeTagId = input.excludeTags.map((t) => t.id); // repeated -> NOT any
   }
   if (input.personRef) {
     params.personRef = input.personRef;

--- a/ui/src/pages/image/imageQueryLogic.ts
+++ b/ui/src/pages/image/imageQueryLogic.ts
@@ -46,8 +46,15 @@ export function updateSearchText(text: string) {
 }
 
 export const filterTags = ref<ImageTag[]>([]);
-export function updateFilterTags(tags: ImageTag[]) {
-  filterTags.value = tags;
+export const excludeFilterTags = ref<ImageTag[]>([]);
+export function updateFilterTags(filter: { include: ImageTag[]; exclude: ImageTag[] }) {
+  // no-op guard: the header re-emits on setFilteredTags (grid ⇄ detail resync);
+  // swapping in equal-but-new arrays would trigger the reload watcher and
+  // reset a deeply scrolled grid to page 1.
+  const same = (a: ImageTag[], b: ImageTag[]) => a.length === b.length && a.every((tag, i) => tag.id === b[i].id);
+  if (same(filter.include, filterTags.value) && same(filter.exclude, excludeFilterTags.value)) return;
+  filterTags.value = filter.include;
+  excludeFilterTags.value = filter.exclude;
 }
 
 export const aspectRatioFilter = ref("neutral");
@@ -59,10 +66,11 @@ export function updateAspectRatioFilter(aspectRatioState: string) {
 // mount must reset them too — a value surviving here filters the grid
 // invisibly (a sticky portrait filter once shrank a 38-photo person view to 5).
 export function resetTransientFilters() {
-  if (!searchText.value && filterTags.value.length === 0 && aspectRatioFilter.value === "neutral") return;
+  if (!searchText.value && filterTags.value.length === 0 && excludeFilterTags.value.length === 0 && aspectRatioFilter.value === "neutral") return;
   invalidateGridSnapshot(); // the snapshot was taken under the filters being cleared
   searchText.value = "";
   filterTags.value = [];
+  excludeFilterTags.value = [];
   aspectRatioFilter.value = "neutral";
 }
 
@@ -144,12 +152,19 @@ export async function loadImages(reload: boolean) {
   try {
     if (reload) page.value = 1;
 
-    filtered.value = !!searchText.value || filterTags.value.length > 0 || aspectRatioFilter.value !== "neutral" || !!personFilter.value || !!uploadFilter.value;
+    filtered.value =
+      !!searchText.value ||
+      filterTags.value.length > 0 ||
+      excludeFilterTags.value.length > 0 ||
+      aspectRatioFilter.value !== "neutral" ||
+      !!personFilter.value ||
+      !!uploadFilter.value;
 
     const params = buildImageListParams({
       projectId: activeProject.value.id,
       search: searchText.value,
       tags: filterTags.value,
+      excludeTags: excludeFilterTags.value,
       personRef: personFilter.value ?? undefined,
       crossProject: personCrossProject.value,
       uploadId: uploadFilter.value ?? undefined,

--- a/ui/tests/e2e/gallery.spec.ts
+++ b/ui/tests/e2e/gallery.spec.ts
@@ -42,8 +42,34 @@ test.describe("gallery toolbar", () => {
     await expect(page.getByText("Default", { exact: true })).toBeVisible();
     // $DATE is a template tag and must not appear in the filter
     await expect(page.getByText("$DATE")).toHaveCount(0);
-    // toggling a tag surfaces the "Clear N selected" affordance
-    await page.getByRole("button", { name: /Podium/ }).click();
+    // including a tag surfaces the "Clear N selected" affordance
+    await page.getByRole("button", { name: "Include Podium" }).click();
+    await expect(page.getByText(/Clear 1 selected/)).toBeVisible();
+  });
+
+  test("tag filter pins include/exclude chips above the list, immune to the text filter", async ({ page }) => {
+    await page.getByRole("button", { name: "Tags" }).click();
+    await page.getByRole("button", { name: "Exclude Podium" }).click();
+    await page.getByRole("button", { name: "Include Default" }).click();
+
+    // both chips pinned; a selected tag leaves the pick list below
+    const podiumChip = page.getByRole("button", { name: "Remove filter Podium" });
+    const defaultChip = page.getByRole("button", { name: "Remove filter Default" });
+    await expect(podiumChip).toBeVisible();
+    await expect(defaultChip).toBeVisible();
+    await expect(page.getByRole("button", { name: "Include Podium" })).toHaveCount(0);
+
+    // the text filter narrows the pick list but never the pinned chips
+    await page.getByPlaceholder("Filter tags…").fill("zzz-no-such-tag");
+    await expect(page.getByText("No tags found")).toBeVisible();
+    await expect(podiumChip).toBeVisible();
+    await expect(defaultChip).toBeVisible();
+
+    // chip click removes a single filter; the tag returns to the pick list
+    await page.getByPlaceholder("Filter tags…").fill("");
+    await podiumChip.click();
+    await expect(podiumChip).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Include Podium" })).toBeVisible();
     await expect(page.getByText(/Clear 1 selected/)).toBeVisible();
   });
 

--- a/ui/tests/e2e/zen-tagging.spec.ts
+++ b/ui/tests/e2e/zen-tagging.spec.ts
@@ -56,6 +56,21 @@ test.describe("detail view keyboard flow", () => {
     await page.keyboard.press("Escape");
   });
 
+  test("searching for an already-applied tag shows the green applied state", async ({ page }) => {
+    // seeded images carry the Default tag; applied tags leave the result list,
+    // so this search must land in the "Already applied" state, not "No matching tags"
+    await page.keyboard.press("t");
+    const search = page.getByPlaceholder("Search tag...");
+    await expect(search).toBeVisible();
+    await search.fill("Default");
+    await expect(page.getByText("Already applied", { exact: true })).toBeVisible();
+    await expect(page.locator('li:has-text("Default")')).toBeVisible();
+    await expect(page.getByText("No matching tags")).toHaveCount(0);
+    // creating a same-named custom tag stays available
+    await expect(page.getByRole("button", { name: /Create custom tag/ })).toBeVisible();
+    await page.keyboard.press("Escape");
+  });
+
   test("z toggles zen over either view, g stays grid/detail only", async ({ page }) => {
     const zen = page.getByTestId("zen-overlay");
     const first = imageParam(page);

--- a/ui/tests/e2e/zen-tagging.spec.ts
+++ b/ui/tests/e2e/zen-tagging.spec.ts
@@ -57,16 +57,24 @@ test.describe("detail view keyboard flow", () => {
   });
 
   test("searching for an already-applied tag shows the green applied state", async ({ page }) => {
-    // seeded images carry the Default tag; applied tags leave the result list,
-    // so this search must land in the "Already applied" state, not "No matching tags"
+    // a fresh unique custom tag: earlier suite runs leave tags behind (e.g. the
+    // date tag description 'default tag "…"'), so only a Date.now() name is
+    // guaranteed to match nothing but itself
+    const uniq = `e2e-applied-${Date.now()}`;
     await page.keyboard.press("t");
     const search = page.getByPlaceholder("Search tag...");
     await expect(search).toBeVisible();
-    await search.fill("Default");
+    await search.fill(uniq);
+    await page.getByRole("button", { name: /Create custom tag/ }).click();
+    await expect(visibleBadge(page, uniq)).toHaveCount(1); // created AND applied
+
+    // the dialog stays open with a cleared search box; searching the now-applied
+    // tag must land in the green "Already applied" state, not "No matching tags"
+    await search.fill(uniq);
     await expect(page.getByText("Already applied", { exact: true })).toBeVisible();
-    await expect(page.locator('li:has-text("Default")')).toBeVisible();
+    await expect(page.locator(`li:has-text("${uniq}")`)).toBeVisible();
     await expect(page.getByText("No matching tags")).toHaveCount(0);
-    // creating a same-named custom tag stays available
+    // creating another same-named custom tag stays available
     await expect(page.getByRole("button", { name: /Create custom tag/ })).toBeVisible();
     await page.keyboard.press("Escape");
   });

--- a/ui/tests/imageListParams.spec.ts
+++ b/ui/tests/imageListParams.spec.ts
@@ -34,10 +34,18 @@ describe("buildImageListParams (UI state -> §4.3 list params)", () => {
   });
 
   it("drops the neutral orientation and empty search", () => {
-    const params = buildImageListParams({ projectId: "p1", search: "", tags: [], orientation: "neutral" });
+    const params = buildImageListParams({ projectId: "p1", search: "", tags: [], excludeTags: [], orientation: "neutral" });
     expect(params.orientation).toBeUndefined();
     expect(params.search).toBeUndefined();
     expect(params.tagId).toBeUndefined();
+    expect(params.excludeTagId).toBeUndefined();
+  });
+
+  it("maps exclude-tags independently of include-tags", () => {
+    const params = buildImageListParams({ projectId: "p1", tags: [{ id: "t1" }], excludeTags: [{ id: "t2" }, { id: "t3" }] });
+    expect(params.tagId).toEqual(["t1"]);
+    expect(params.excludeTagId).toEqual(["t2", "t3"]);
+    expect(buildImageListParams({ projectId: "p1", excludeTags: [{ id: "t2" }] }).tagId).toBeUndefined();
   });
 
   it("maps the implicit person filter and drops it when unset", () => {


### PR DESCRIPTION
- Gallery tag filter reworked Grafana-style: per-tag +/- magnifier buttons
  add a tag as a positive or negative filter; selected tags pin as green/red
  chips above the pick list, immune to the text search, click to remove.
  New repeated excludeTagId list param -> ExcludeTagIDs NOT-containment
  predicates (NULL-safe) in the gallery query.
- Tagging dialog result list grows to ~two thirds of the viewport (was a
  fixed 24rem), lower third stays free; no overflow at any breakpoint.
- Searching for a tag that is already applied now shows a green 'Already
  applied' state instead of a misleading 'No matching tags'.
