### PR TITLE
feat(images): facet counts in the tag filter, timeline lane selection via label

### DIFF
--- a/api/internal/repository/image.go
+++ b/api/internal/repository/image.go
@@ -63,16 +63,15 @@ type GetImageParameters struct {
 	PaginationParameters *PaginationParameters
 }
 
-// GetImages is the gallery query (SPEC §4.3). projectId is required; tagId AND-match
-// runs over the GIN(jsonb_path_ops) index via a single containment; orientation
-// excludes rows with null width/height. Edges are eager-loaded for serialization.
-func (r *Repository) GetImages(ctx context.Context, parameters *GetImageParameters) ([]*ent.Image, int, error) {
+// buildImagePredicates turns the shared gallery filter (SPEC §4.3) into ent
+// predicates — one source of truth for GetImages and GetImageTagFacets.
+func buildImagePredicates(parameters *GetImageParameters) ([]predicate.Image, error) {
 	var predicates []predicate.Image
 	if len(parameters.ProjectIDs) > 0 {
 		predicates = []predicate.Image{image.ProjectIDIn(parameters.ProjectIDs...)}
 	} else {
 		if parameters.ProjectID == "" {
-			return nil, 0, ErrMissingProject
+			return nil, ErrMissingProject
 		}
 		predicates = []predicate.Image{image.ProjectID(parameters.ProjectID)}
 	}
@@ -122,8 +121,19 @@ func (r *Repository) GetImages(ctx context.Context, parameters *GetImageParamete
 				s.Where(sql.ColumnsGT(s.C(image.FieldWidth), s.C(image.FieldHeight)))
 			})
 		default:
-			return nil, 0, ErrInvalidOrientation
+			return nil, ErrInvalidOrientation
 		}
+	}
+	return predicates, nil
+}
+
+// GetImages is the gallery query (SPEC §4.3). projectId is required; tagId AND-match
+// runs over the GIN(jsonb_path_ops) index via a single containment; orientation
+// excludes rows with null width/height. Edges are eager-loaded for serialization.
+func (r *Repository) GetImages(ctx context.Context, parameters *GetImageParameters) ([]*ent.Image, int, error) {
+	predicates, err := buildImagePredicates(parameters)
+	if err != nil {
+		return nil, 0, err
 	}
 	where := image.And(predicates...)
 
@@ -146,6 +156,47 @@ func (r *Repository) GetImages(ctx context.Context, parameters *GetImageParamete
 		return nil, 0, err
 	}
 	return items, total, nil
+}
+
+// GetImageTagFacets returns the filter's own match count plus, per project tag,
+// how many of those matches also carry the tag — i.e. the result size if the tag
+// were added as an include filter. Tags matching zero images are omitted.
+// ponytail: one count query per tag over the GIN index, same shape as
+// GetProjectTagStatistics — switch both to a single GROUP BY over
+// jsonb_array_elements_text if tag or image counts make this measurably slow.
+func (r *Repository) GetImageTagFacets(ctx context.Context, parameters *GetImageParameters) (int, map[string]int, error) {
+	predicates, err := buildImagePredicates(parameters)
+	if err != nil {
+		return 0, nil, err
+	}
+	where := image.And(predicates...)
+	total, err := r.Client.Image.Query().Where(where).Count(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("error counting images for tag facets")
+		return 0, nil, err
+	}
+	tags, err := r.Client.ImageTag.Query().Where(imagetag.ProjectID(parameters.ProjectID)).All(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("error loading project tags for facets")
+		return 0, nil, err
+	}
+	facets := make(map[string]int, len(tags))
+	for _, t := range tags {
+		tagID := t.ID
+		count, err := r.Client.Image.Query().
+			Where(where, func(s *sql.Selector) {
+				s.Where(sqljson.ValueContains(image.FieldImageTags, []string{tagID}))
+			}).
+			Count(ctx)
+		if err != nil {
+			log.Error().Err(err).Str("tag", tagID).Msg("error counting tag facet")
+			return 0, nil, err
+		}
+		if count > 0 {
+			facets[tagID] = count
+		}
+	}
+	return total, facets, nil
 }
 
 // TagStatistic is one row of GetProjectTagStatistics.

--- a/api/internal/server/images_controller.go
+++ b/api/internal/server/images_controller.go
@@ -15,27 +15,29 @@ import (
 
 func (s *Server) registerImageRoutes(api *gin.RouterGroup) {
 	api.GET("/images", s.listImages)
+	api.GET("/images/tag-facets", s.listImageTagFacets)
 	api.GET("/images/:id", s.getImage)
 	api.POST("/images", s.createImage)
 	api.PUT("/images/:id", s.updateImage)
 	api.DELETE("/images/:id", s.deleteImage)
 }
 
-func (s *Server) listImages(c *gin.Context) {
+// parseImageFilterParams parses the shared gallery filter params (§4.3, minus
+// pagination) including the person-filter resolution — one source of truth for
+// the list and the tag-facets endpoints. emptyResult=true means the person
+// filter matched nothing and the caller should answer with an empty payload.
+// On ok=false the HTTP error has already been written.
+func (s *Server) parseImageFilterParams(c *gin.Context) (params *repository.GetImageParameters, emptyResult bool, ok bool) {
 	// authz (S8): caller must be admin or assigned to projectId, else 403.
-	pagination, ok := getPagination(c)
-	if !ok {
-		return
-	}
 	projectID := c.Query("projectId")
 	if projectID == "" {
 		apiError(c, http.StatusBadRequest, "missing_project", "projectId is required")
-		return
+		return nil, false, false
 	}
 	if !allow(c, authorization.CanViewProject(authUser(c), projectID)) {
-		return
+		return nil, false, false
 	}
-	params := &repository.GetImageParameters{ProjectID: projectID, PaginationParameters: pagination}
+	params = &repository.GetImageParameters{ProjectID: projectID}
 	if v := c.Query("uploadId"); v != "" {
 		params.UploadID = &v
 	}
@@ -46,7 +48,7 @@ func (s *Server) listImages(c *gin.Context) {
 		uid, err := uuid.Parse(v)
 		if err != nil {
 			apiError(c, http.StatusBadRequest, "invalid_user_id", "invalid userId")
-			return
+			return nil, false, false
 		}
 		params.UserID = &uid
 	}
@@ -62,14 +64,14 @@ func (s *Server) listImages(c *gin.Context) {
 	if v := c.Query("orientation"); v != "" {
 		if v != "portrait" && v != "landscape" {
 			apiError(c, http.StatusBadRequest, "invalid_orientation", "orientation must be 'portrait' or 'landscape'")
-			return
+			return nil, false, false
 		}
 		params.Orientation = &v
 	}
 	if v := c.Query("personRef"); v != "" {
-		ids, ok := s.personImageIDs(c, projectID, v)
-		if !ok {
-			return
+		ids, idsOk := s.personImageIDs(c, projectID, v)
+		if !idsOk {
+			return nil, false, false
 		}
 		// The ONE exception to the hard project filter: cross-project person
 		// search widens to every project the user may view. The requested
@@ -87,10 +89,26 @@ func (s *Server) listImages(c *gin.Context) {
 			params.ProjectIDs = append([]string{projectID}, others...)
 		}
 		if len(ids) == 0 {
-			c.JSON(http.StatusOK, ListResponse[*ImageResponse]{Limit: pagination.Limit, Offset: pagination.Offset, Total: 0, Items: []*ImageResponse{}})
-			return
+			return params, true, true
 		}
 		params.IDs = ids
+	}
+	return params, false, true
+}
+
+func (s *Server) listImages(c *gin.Context) {
+	pagination, ok := getPagination(c)
+	if !ok {
+		return
+	}
+	params, emptyResult, ok := s.parseImageFilterParams(c)
+	if !ok {
+		return
+	}
+	params.PaginationParameters = pagination
+	if emptyResult {
+		c.JSON(http.StatusOK, ListResponse[*ImageResponse]{Limit: pagination.Limit, Offset: pagination.Offset, Total: 0, Items: []*ImageResponse{}})
+		return
 	}
 
 	items, total, err := s.Repository.GetImages(c.Request.Context(), params)
@@ -102,6 +120,30 @@ func (s *Server) listImages(c *gin.Context) {
 		out = append(out, ToImageResponse(c.Request.Context(), img, s.s3Client, s.thumbnailSizes))
 	}
 	c.JSON(http.StatusOK, ListResponse[*ImageResponse]{Limit: pagination.Limit, Offset: pagination.Offset, Total: total, Items: out})
+}
+
+// TagFacetsResponse backs the tag filter popover: facets[tagId] = images the
+// current filter would still match with tagId added as an include filter
+// (zero-count tags omitted); total = matches of the filter itself.
+type TagFacetsResponse struct {
+	Total  int            `json:"total"`
+	Facets map[string]int `json:"facets"`
+}
+
+func (s *Server) listImageTagFacets(c *gin.Context) {
+	params, emptyResult, ok := s.parseImageFilterParams(c)
+	if !ok {
+		return
+	}
+	if emptyResult {
+		c.JSON(http.StatusOK, TagFacetsResponse{Facets: map[string]int{}})
+		return
+	}
+	total, facets, err := s.Repository.GetImageTagFacets(c.Request.Context(), params)
+	if abortRepoListError(c, err) {
+		return
+	}
+	c.JSON(http.StatusOK, TagFacetsResponse{Total: total, Facets: facets})
 }
 
 func (s *Server) getImage(c *gin.Context) {

--- a/api/test/e2e/repository_e2e_test.go
+++ b/api/test/e2e/repository_e2e_test.go
@@ -146,6 +146,51 @@ func TestGetImagesExcludeTags(t *testing.T) {
 	require.NoError(t, r.DeleteImageTagAssignment(ctx, a.ID))
 }
 
+func TestGetImageTagFacets(t *testing.T) {
+	ctx := context.Background()
+	r := repo(t)
+	m := stack.Manifest
+
+	podium := m.Tags["Podium"]
+	defaultTag := m.Tags["Default"]
+
+	// Baseline: 3 seed images, all carrying Default, none carrying Podium.
+	total, facets, err := r.GetImageTagFacets(ctx, &repository.GetImageParameters{ProjectID: m.Project})
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	assert.Equal(t, 3, facets[defaultTag])
+	assert.NotContains(t, facets, podium, "zero-count tags are omitted")
+
+	// Podium on one image: an exclude filter drops it from total and facets.
+	_, _, err = r.CreateImageTagAssignment(ctx, &repository.CreateImageTagAssignmentParameters{
+		ImageID: m.Images[0], ImageTagID: podium, Type: imagetagassignment.TypeManual,
+	})
+	require.NoError(t, err)
+
+	total, facets, err = r.GetImageTagFacets(ctx, &repository.GetImageParameters{
+		ProjectID: m.Project, ExcludeTagIDs: []string{podium},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Equal(t, 2, facets[defaultTag])
+	assert.NotContains(t, facets, podium)
+
+	// Facets under an include filter count within the narrowed set.
+	total, facets, err = r.GetImageTagFacets(ctx, &repository.GetImageParameters{
+		ProjectID: m.Project, TagIDs: []string{podium},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Equal(t, 1, facets[defaultTag])
+	assert.Equal(t, 1, facets[podium])
+
+	// cleanup: remove the extra assignment so later tests see the seed baseline.
+	a := stack.DB.Client.ImageTagAssignment.Query().
+		Where(imagetagassignment.ImageID(m.Images[0]), imagetagassignment.ImageTagID(podium)).
+		OnlyX(ctx)
+	require.NoError(t, r.DeleteImageTagAssignment(ctx, a.ID))
+}
+
 func TestGetImagesOrientationNullExclusion(t *testing.T) {
 	ctx := context.Background()
 	r := repo(t)

--- a/ui/src/api/images.ts
+++ b/ui/src/api/images.ts
@@ -45,6 +45,18 @@ export async function list(params: ImageListParams): Promise<ListResponse<Image>
   return data;
 }
 
+// facets[tagId] = images the filter would still match with tagId added as an
+// include filter (zero-count tags omitted); total = matches of the filter itself.
+export interface TagFacetsResponse {
+  total: number;
+  facets: Record<string, number>;
+}
+
+export async function tagFacets(params: ImageListParams): Promise<TagFacetsResponse> {
+  const { data } = await http.get<TagFacetsResponse>("/images/tag-facets", { params, paramsSerializer: { indexes: null } });
+  return data;
+}
+
 export async function get(id: string): Promise<Image> {
   const { data } = await http.get<Image>(`/images/${id}`);
   return data;

--- a/ui/src/components/image/ImagesHeader.vue
+++ b/ui/src/components/image/ImagesHeader.vue
@@ -94,8 +94,8 @@
       </div>
 
       <!-- tags filter -->
-      <Popover class="relative">
-        <PopoverButton :class="[triggerBase, selectedTags.length ? triggerActive : triggerIdle]">
+      <Popover class="relative" v-slot="{ open }">
+        <PopoverButton :class="[triggerBase, selectedTags.length ? triggerActive : triggerIdle]" @click="!open && emit('facetsNeeded', true)">
           <TagIcon class="h-[18px] w-[18px]" />
           <span>Tags</span>
           <span
@@ -115,7 +115,7 @@
           leave-to-class="opacity-0 translate-y-1"
         >
           <PopoverPanel
-            class="absolute right-0 z-30 mt-2 w-[calc(100vw-2rem)] max-w-72 origin-top-right overflow-hidden rounded-lg border border-primary-200 bg-surface shadow-xl dark:border-primary-700 dark:bg-surface-dark"
+            class="absolute right-0 z-30 mt-2 w-[calc(100vw-2rem)] max-w-80 origin-top-right overflow-hidden rounded-lg border border-primary-200 bg-surface shadow-xl dark:border-primary-700 dark:bg-surface-dark"
           >
             <div class="border-b border-primary-100 p-2 dark:border-primary-800">
               <input
@@ -148,7 +148,7 @@
             </div>
             <div class="scrollbar-tool max-h-64 overflow-y-auto p-1">
               <div
-                v-for="tag in filteredTags"
+                v-for="tag in visibleTags"
                 :key="tag.id"
                 class="group flex w-full items-center gap-1 rounded-md px-2.5 py-1.5 text-left text-sm text-primary-700 transition-colors hover:bg-primary-100 dark:text-primary-200 dark:hover:bg-primary-800"
               >
@@ -157,22 +157,26 @@
                   type="button"
                   :aria-label="`Include ${tagLabel(tag)}`"
                   :title="`Show only images with ${tagLabel(tag)}`"
+                  :disabled="includeCount(tag) === 0"
                   @click="addTagFilter(tag, false)"
-                  class="rounded p-1 text-primary-400 transition-colors hover:bg-success-500/15 hover:text-success-600 dark:text-primary-500 dark:hover:text-success-300"
+                  class="flex items-center gap-0.5 rounded p-1 text-primary-400 transition-colors hover:bg-success-500/15 hover:text-success-600 disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-primary-400 dark:text-primary-500 dark:hover:text-success-300"
                 >
                   <MagnifyingGlassPlusIcon class="h-4 w-4" />
+                  <span v-if="includeCount(tag) !== null" class="font-data text-[10px] tabular-nums">{{ includeCount(tag) }}</span>
                 </button>
                 <button
                   type="button"
                   :aria-label="`Exclude ${tagLabel(tag)}`"
                   :title="`Hide images with ${tagLabel(tag)}`"
+                  :disabled="excludeCount(tag) === 0"
                   @click="addTagFilter(tag, true)"
-                  class="rounded p-1 text-primary-400 transition-colors hover:bg-error-500/15 hover:text-error-600 dark:text-primary-500 dark:hover:text-error-300"
+                  class="flex items-center gap-0.5 rounded p-1 text-primary-400 transition-colors hover:bg-error-500/15 hover:text-error-600 disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-primary-400 dark:text-primary-500 dark:hover:text-error-300"
                 >
                   <MagnifyingGlassMinusIcon class="h-4 w-4" />
+                  <span v-if="excludeCount(tag) !== null" class="font-data text-[10px] tabular-nums">{{ excludeCount(tag) }}</span>
                 </button>
               </div>
-              <p v-if="!filteredTags.length" class="px-2.5 py-6 text-center text-sm text-primary-400">No tags found</p>
+              <p v-if="!visibleTags.length" class="px-2.5 py-6 text-center text-sm text-primary-400">No tags found</p>
             </div>
             <div v-if="selectedTags.length" class="border-t border-primary-100 p-1 dark:border-primary-800">
               <button
@@ -303,6 +307,7 @@ import { useUserStore } from "src/stores/user-store";
 import { emitter } from "src/boot/mitt";
 import { computed, h, ref, watch } from "vue";
 import { ImageTag, Upload } from "src/types/api";
+import type { TagFacetsResponse } from "src/api/images";
 import { tagLabel } from "src/util/tagOrder";
 import { api } from "src/api";
 
@@ -316,12 +321,15 @@ interface Props {
   selectionCount?: number;
   // active upload-batch filter — route-driven, Images.vue owns the query sync
   uploadFilter?: string | null;
+  // per-tag counts under the current filter — Images.vue fetches on facetsNeeded
+  tagFacets?: TagFacetsResponse | null;
 }
 const props = withDefaults(defineProps<Props>(), {
   totalImageCount: 0,
   density: "comfortable",
   selectionCount: 0,
   uploadFilter: null,
+  tagFacets: null,
 });
 
 const emit = defineEmits<{
@@ -332,6 +340,8 @@ const emit = defineEmits<{
   rerunAi: [];
   uploadFilter: [string | null];
   slideshow: [];
+  // true = force a refresh (popover open), false = only if the filter changed
+  facetsNeeded: [boolean];
 }>();
 
 const { activeProject, preferredImageSortOrder, projectTags } = storeToRefs(useUserStore());
@@ -385,17 +395,31 @@ interface TagFilterEntry {
 }
 const tagQuery = ref("");
 const selectedTags = ref<TagFilterEntry[]>([]);
-watch(selectedTags, () =>
+watch(selectedTags, () => {
   emit("filterTags", {
     include: selectedTags.value.filter((e) => !e.exclude).map((e) => e.tag),
     exclude: selectedTags.value.filter((e) => e.exclude).map((e) => e.tag),
-  }),
-);
+  });
+  // after filterTags, so the facet fetch reads the already-updated filter state
+  emit("facetsNeeded", false);
+});
 const selectableTags = computed(() => projectTags.value.filter((t: ImageTag) => t.type !== "template"));
 const filteredTags = computed(() => {
   const q = tagQuery.value.toLowerCase();
   return selectableTags.value.filter((t: ImageTag) => !isSelected(t) && (t.name.toLowerCase().includes(q) || tagLabel(t).toLowerCase().includes(q)));
 });
+// under an active filter, tags that would produce an empty result set disappear;
+// with no filter every tag stays offered (zero-count tags are normal pre-event)
+const visibleTags = computed(() => {
+  if (selectedTags.value.length === 0 || !props.tagFacets) return filteredTags.value;
+  return filteredTags.value.filter((t: ImageTag) => (props.tagFacets!.facets[t.id] ?? 0) > 0);
+});
+// images left when adding the tag as +/− filter; null while facets are loading
+const includeCount = (tag: ImageTag): number | null => (props.tagFacets ? (props.tagFacets.facets[tag.id] ?? 0) : null);
+const excludeCount = (tag: ImageTag): number | null => {
+  const inc = includeCount(tag);
+  return inc === null ? null : props.tagFacets!.total - inc;
+};
 const isSelected = (tag: ImageTag) => selectedTags.value.some((e) => e.tag.id === tag.id);
 function addTagFilter(tag: ImageTag, exclude: boolean) {
   selectedTags.value = [...selectedTags.value, { tag, exclude }];

--- a/ui/src/components/upload/UploadTimeline.vue
+++ b/ui/src/components/upload/UploadTimeline.vue
@@ -53,7 +53,7 @@
       </div>
 
       <!-- lanes -->
-      <div v-for="tr in tracks" :key="tr.key" class="flex items-center gap-2 py-1.5" @click="selectedKey = tr.key">
+      <div v-for="tr in tracks" :key="tr.key" class="flex cursor-pointer items-center gap-2 py-1.5" @click="selectTrack(tr)">
         <div class="flex w-34 flex-shrink-0 items-center gap-1.5 overflow-hidden" style="width: 8.5rem">
           <component :is="tr.scheduleItemId ? CalendarDaysIcon : TagIcon" class="h-3.5 w-3.5 flex-shrink-0 text-primary-400" />
           <span class="min-w-0 flex-1 truncate text-xs font-medium text-primary-700 dark:text-primary-200" :title="tr.label">{{ tr.label }}</span>
@@ -85,7 +85,7 @@
             :style="barStyle(tr)"
             tabindex="0"
             @keydown="onKeydown(tr, $event)"
-            @click.stop="selectedKey = tr.key"
+            @click.stop="selectTrack(tr)"
           >
             <span class="pointer-events-none absolute inset-x-2 top-1/2 -translate-y-1/2 truncate font-medium">
               {{ formatTime(tr.start) }}–{{ formatTime(tr.end) }} · {{ coveredCount(tr) }} photos
@@ -374,6 +374,14 @@ const laneEls = new Map<string, HTMLElement>();
 function registerLane(key: string, el: HTMLElement | null) {
   if (el) laneEls.set(key, el);
   else laneEls.delete(key);
+}
+
+// Keyboard in/out nudging listens on the FOCUSED bar, so selecting must also
+// focus it: the bar can be too narrow to hit, and Safari never focuses a
+// tabindex div on click anyway — the row/label click is the reliable target.
+function selectTrack(track: EditorTrack) {
+  selectedKey.value = track.key;
+  laneEls.get(track.key)?.querySelector<HTMLElement>("[tabindex]")?.focus({ preventScroll: true });
 }
 
 function startDrag(track: EditorTrack, edge: "start" | "end", event: PointerEvent) {

--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -8,8 +8,10 @@
         :show-filter="displayMode === DisplayMode.GRID"
         :selection-count="imageIndices.length"
         :upload-filter="uploadFilter"
+        :tag-facets="tagFacets"
         @search="updateSearchText"
         @filter-tags="updateFilterTags"
+        @facets-needed="loadTagFacets"
         @aspect-ratio-filter="updateAspectRatioFilter"
         @rerun-ai="rerunSelection"
         @upload-filter="setUploadFilter"
@@ -200,6 +202,8 @@ import {
   restoreGridSnapshot,
   invalidateGridSnapshot,
   resetTransientFilters,
+  tagFacets,
+  loadTagFacets,
 } from "./imageQueryLogic";
 import { totalImageCount, images, imageIndex, imageIndices, multiselectStart, multiselectEnd, loading } from "./imageQueryLogic";
 import { taggingDialogVisible, addImageTag } from "./imageQueryLogic";

--- a/ui/src/pages/image/imageQueryLogic.ts
+++ b/ui/src/pages/image/imageQueryLogic.ts
@@ -2,6 +2,7 @@ import { useUserStore } from "src/stores/user-store";
 import { storeToRefs } from "pinia";
 import { ref } from "vue";
 import { api } from "src/api";
+import type { TagFacetsResponse } from "src/api/images";
 import { ImageTag } from "src/types/api";
 import { ImageWithTagsType } from "src/types/custom";
 import { buildImageListParams } from "src/pages/image/imageListParams";
@@ -189,6 +190,38 @@ export async function loadImages(reload: boolean) {
     showUnexpectedErrorMessage.value = true;
   } finally {
     if (myRequestId === requestId) loading.value = false;
+  }
+}
+
+// --- tag facets ---------------------------------------------------------------
+// Per-tag counts under the CURRENT filter, feeding the tag popover: hide tags
+// that would empty the view, show what each +/− filter would leave. Fetched on
+// popover open (force) and on selection changes; the key memo skips refetches
+// when nothing filter-relevant changed (e.g. grid ⇄ detail resync re-emits).
+
+export const tagFacets = ref<TagFacetsResponse | null>(null);
+let lastFacetsKey = "";
+
+export async function loadTagFacets(force = false) {
+  const params = buildImageListParams({
+    projectId: activeProject.value.id,
+    search: searchText.value,
+    tags: filterTags.value,
+    excludeTags: excludeFilterTags.value,
+    personRef: personFilter.value ?? undefined,
+    crossProject: personCrossProject.value,
+    uploadId: uploadFilter.value ?? undefined,
+    orientation: aspectRatioFilter.value,
+  });
+  const key = JSON.stringify(params);
+  if (!force && key === lastFacetsKey && tagFacets.value) return;
+  lastFacetsKey = key;
+  try {
+    tagFacets.value = await api.images.tagFacets(params);
+  } catch {
+    // facets are decoration — the popover degrades to the plain tag list
+    tagFacets.value = null;
+    lastFacetsKey = "";
   }
 }
 

--- a/ui/tests/e2e/gallery.spec.ts
+++ b/ui/tests/e2e/gallery.spec.ts
@@ -42,9 +42,18 @@ test.describe("gallery toolbar", () => {
     await expect(page.getByText("Default", { exact: true })).toBeVisible();
     // $DATE is a template tag and must not appear in the filter
     await expect(page.getByText("$DATE")).toHaveCount(0);
-    // including a tag surfaces the "Clear N selected" affordance
-    await page.getByRole("button", { name: "Include Podium" }).click();
+
+    // facet counts: all 3 seed images carry Default, none carries Podium
+    const includeDefault = page.getByRole("button", { name: "Include Default" });
+    await expect(includeDefault).toContainText("3");
+    await expect(page.getByRole("button", { name: "Include Podium" })).toBeDisabled(); // would show 0 images
+    await expect(page.getByRole("button", { name: "Exclude Default" })).toBeDisabled(); // would empty the view
+
+    // including a tag surfaces the "Clear N selected" affordance…
+    await includeDefault.click();
     await expect(page.getByText(/Clear 1 selected/)).toBeVisible();
+    // …and under the active filter, tags that would empty the result disappear
+    await expect(page.getByRole("button", { name: "Include Podium" })).toHaveCount(0);
   });
 
   test("tag filter pins include/exclude chips above the list, immune to the text filter", async ({ page }) => {
@@ -66,10 +75,12 @@ test.describe("gallery toolbar", () => {
     await expect(defaultChip).toBeVisible();
 
     // chip click removes a single filter; the tag returns to the pick list
+    // (Default, not Podium: under the remaining [+Default] filter a removed
+    // Podium stays facet-hidden — 0 of the matching images carry it)
     await page.getByPlaceholder("Filter tags…").fill("");
-    await podiumChip.click();
-    await expect(podiumChip).toHaveCount(0);
-    await expect(page.getByRole("button", { name: "Include Podium" })).toBeVisible();
+    await defaultChip.click();
+    await expect(defaultChip).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Include Default" })).toBeVisible();
     await expect(page.getByText(/Clear 1 selected/)).toBeVisible();
   });
 


### PR DESCRIPTION
- New GET /images/tag-facets endpoint: same filter params as the image list,
  returns per-tag counts of the images the current filter would still match
  with that tag added as an include filter (zero-count tags omitted) plus the
  filter's own total. Gallery predicates extracted to one shared builder so
  list and facets cannot diverge.
- Tag filter popover shows the remaining-image count next to each +/- filter
  button; under an active filter, tags that would produce an empty result set
  are hidden; buttons that would show 0 images are disabled.
- Upload timeline: clicking a lane's name (or anywhere in its row) now selects
  AND focuses the bar, so keyboard in/out nudging works even when the bar is
  too narrow to click. Also fixes Safari, which never focuses a tabindex div
  on click.
