### PR TITLE
feat(images): permalinks with jump-to-context resolution

### DIFF
--- a/api/internal/repository/image.go
+++ b/api/internal/repository/image.go
@@ -158,6 +158,37 @@ func (r *Repository) GetImages(ctx context.Context, parameters *GetImageParamete
 	return items, total, nil
 }
 
+// GetImagePosition returns the zero-based offset of imageID within the gallery
+// query defined by parameters (same predicates and order as GetImages), or -1
+// when the image is not among the first maxScan matches — the deep-link
+// resolver then falls back to a solo detail view. An id-only bounded scan
+// sidesteps null-aware window arithmetic for the nullable sort columns.
+func (r *Repository) GetImagePosition(ctx context.Context, parameters *GetImageParameters, imageID string, maxScan int) (int, error) {
+	predicates, err := buildImagePredicates(parameters)
+	if err != nil {
+		return -1, err
+	}
+	_, _, order, err := parameters.PaginationParameters.build(imageSortFields, "capturedAtCorrected")
+	if err != nil {
+		return -1, err
+	}
+	ids, err := r.Client.Image.Query().
+		Where(image.And(predicates...)).
+		Order(order).
+		Limit(maxScan).
+		IDs(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("error scanning image position")
+		return -1, err
+	}
+	for i, id := range ids {
+		if id == imageID {
+			return i, nil
+		}
+	}
+	return -1, nil
+}
+
 // GetImageTagFacets returns the filter's own match count plus, per project tag,
 // how many of those matches also carry the tag — i.e. the result size if the tag
 // were added as an include filter. Tags matching zero images are omitted.

--- a/api/internal/repository/image_test.go
+++ b/api/internal/repository/image_test.go
@@ -1,0 +1,59 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shutterbase/shutterbase/internal/repository"
+)
+
+func TestGetImagePosition(t *testing.T) {
+	ctx := context.Background()
+	repo, m := seededRepo(t)
+
+	params := func() *repository.GetImageParameters {
+		return &repository.GetImageParameters{
+			ProjectID:            m.Project,
+			PaginationParameters: &repository.PaginationParameters{Sort: "capturedAtCorrected", Order: "desc"},
+		}
+	}
+
+	// the position must match the index the list query itself would yield
+	items, total, err := repo.GetImages(ctx, params())
+	require.NoError(t, err)
+	require.Equal(t, total, len(items), "seed fits in one page")
+	require.GreaterOrEqual(t, len(items), 2, "seed provides multiple images")
+
+	for i, img := range items {
+		pos, err := repo.GetImagePosition(ctx, params(), img.ID, 2000)
+		require.NoError(t, err)
+		assert.Equal(t, i, pos, "image %s", img.ID)
+	}
+
+	// flipping the order flips the position
+	asc := params()
+	asc.PaginationParameters.Order = "asc"
+	pos, err := repo.GetImagePosition(ctx, asc, items[0].ID, 2000)
+	require.NoError(t, err)
+	assert.Equal(t, len(items)-1, pos)
+
+	// unknown id and out-of-scan-window both answer -1
+	pos, err = repo.GetImagePosition(ctx, params(), "no-such-image", 2000)
+	require.NoError(t, err)
+	assert.Equal(t, -1, pos)
+
+	pos, err = repo.GetImagePosition(ctx, params(), items[len(items)-1].ID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, -1, pos)
+
+	// a filter that excludes the image answers -1, not an error
+	filtered := params()
+	otherProject := "no-such-project"
+	filtered.ProjectID = otherProject
+	pos, err = repo.GetImagePosition(ctx, filtered, items[0].ID, 2000)
+	require.NoError(t, err)
+	assert.Equal(t, -1, pos)
+}

--- a/api/internal/repository/repository_test.go
+++ b/api/internal/repository/repository_test.go
@@ -285,7 +285,8 @@ func TestUserCRUDUUID(t *testing.T) {
 }
 
 // PocketBase-hook parity: a new user without an explicit copyright tag gets
-// their last name as the default; an explicit tag always wins.
+// their last name as the default; an explicit tag always wins. Both paths run
+// through NormalizeCopyrightTag (lowercase, separators → underscore).
 func TestCreateUserDefaultsCopyrightTagToLastName(t *testing.T) {
 	ctx := context.Background()
 	repo := testRepo(t)
@@ -294,21 +295,21 @@ func TestCreateUserDefaultsCopyrightTagToLastName(t *testing.T) {
 		Username: "trinity", FirstName: "Trinity", LastName: "Moss",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "Moss", defaulted.CopyrightTag)
+	assert.Equal(t, "moss", defaulted.CopyrightTag)
 
 	emptied, err := repo.CreateUser(ctx, &repository.CreateUserParameters{
 		Username: "smith", FirstName: "Agent", LastName: "Smith",
 		CopyrightTag: util.StringPointer(""),
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "Smith", emptied.CopyrightTag)
+	assert.Equal(t, "smith", emptied.CopyrightTag)
 
 	explicit, err := repo.CreateUser(ctx, &repository.CreateUserParameters{
 		Username: "oracle", FirstName: "The", LastName: "Oracle",
 		CopyrightTag: util.StringPointer("ORCL"),
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "ORCL", explicit.CopyrightTag)
+	assert.Equal(t, "orcl", explicit.CopyrightTag)
 }
 
 // GetUploadMetrics runs a hand-built join through the ent SQL builder — the one

--- a/api/internal/repository/user.go
+++ b/api/internal/repository/user.go
@@ -3,6 +3,8 @@ package repository
 import (
 	"context"
 	"reflect"
+	"regexp"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -95,6 +97,18 @@ func (r *Repository) GetUsers(ctx context.Context, parameters *GetUserParameters
 	return items, total, nil
 }
 
+// The copyright tag ends up in EXIF fields and computed filenames:
+// lowercase, umlauts transliterated (ä→ae, ö→oe, ü→ue, ß→ss), and any run
+// of non-letter/digit/underscore characters (whitespace, dashes, dots, …)
+// collapsed to a single underscore.
+// Mirrored in ui/src/util/copyrightTag.ts.
+var copyrightTagSeparators = regexp.MustCompile(`[^\p{L}\p{N}_]+`)
+var copyrightTagUmlauts = strings.NewReplacer("ä", "ae", "ö", "oe", "ü", "ue", "ß", "ss")
+
+func NormalizeCopyrightTag(tag string) string {
+	return copyrightTagSeparators.ReplaceAllString(copyrightTagUmlauts.Replace(strings.ToLower(tag)), "_")
+}
+
 type CreateUserParameters struct {
 	Username            string
 	PasswordHash        *string
@@ -122,11 +136,11 @@ func (r *Repository) CreateUser(ctx context.Context, parameters *CreateUserParam
 		create = create.SetPasswordHash(*parameters.PasswordHash)
 	}
 	if parameters.CopyrightTag != nil && *parameters.CopyrightTag != "" {
-		create = create.SetCopyrightTag(*parameters.CopyrightTag)
+		create = create.SetCopyrightTag(NormalizeCopyrightTag(*parameters.CopyrightTag))
 	} else {
 		// PocketBase-hook parity: a new user's copyright tag defaults to their
 		// last name, so photographers can upload without touching their profile.
-		create = create.SetCopyrightTag(parameters.LastName)
+		create = create.SetCopyrightTag(NormalizeCopyrightTag(parameters.LastName))
 	}
 	if parameters.Email != nil {
 		create = create.SetEmail(*parameters.Email)
@@ -217,9 +231,12 @@ func (r *Repository) UpdateUser(ctx context.Context, id uuid.UUID, parameters *U
 		update.SetLastName(*parameters.LastName)
 		st.SetFieldChanged(user.FieldLastName, item.LastName, *parameters.LastName)
 	}
-	if parameters.CopyrightTag != nil && item.CopyrightTag != *parameters.CopyrightTag {
-		update.SetCopyrightTag(*parameters.CopyrightTag)
-		st.SetFieldChanged(user.FieldCopyrightTag, item.CopyrightTag, *parameters.CopyrightTag)
+	if parameters.CopyrightTag != nil {
+		tag := NormalizeCopyrightTag(*parameters.CopyrightTag)
+		if item.CopyrightTag != tag {
+			update.SetCopyrightTag(tag)
+			st.SetFieldChanged(user.FieldCopyrightTag, item.CopyrightTag, tag)
+		}
 	}
 	if parameters.Email != nil && item.Email != *parameters.Email {
 		update.SetEmail(*parameters.Email)

--- a/api/internal/repository/user_test.go
+++ b/api/internal/repository/user_test.go
@@ -1,0 +1,21 @@
+package repository
+
+import "testing"
+
+func TestNormalizeCopyrightTag(t *testing.T) {
+	cases := map[string]string{
+		"mm":             "mm",
+		"MM":             "mm",
+		"Max Mustermann": "max_mustermann",
+		"max-mustermann": "max_mustermann",
+		"max.muster - x": "max_muster_x",
+		"Möller":         "moeller",
+		"Äöü ß":          "aeoeue_ss",
+		"":               "",
+	}
+	for in, want := range cases {
+		if got := NormalizeCopyrightTag(in); got != want {
+			t.Errorf("NormalizeCopyrightTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/api/internal/server/images_controller.go
+++ b/api/internal/server/images_controller.go
@@ -17,6 +17,7 @@ import (
 func (s *Server) registerImageRoutes(api *gin.RouterGroup) {
 	api.GET("/images", s.listImages)
 	api.GET("/images/tag-facets", s.listImageTagFacets)
+	api.GET("/images/position", s.getImagePosition)
 	api.GET("/images/:id", s.getImage)
 	api.POST("/images", s.createImage)
 	api.PUT("/images/:id", s.updateImage)
@@ -121,6 +122,40 @@ func (s *Server) listImages(c *gin.Context) {
 		out = append(out, ToImageResponse(c.Request.Context(), img, s.s3Client, s.thumbnailSizes))
 	}
 	c.JSON(http.StatusOK, ListResponse[*ImageResponse]{Limit: pagination.Limit, Offset: pagination.Offset, Total: total, Items: out})
+}
+
+// imagePositionMaxScan bounds the deep-link "jump to context" scan; images
+// deeper in the collection fall back to the SPA's solo detail view.
+const imagePositionMaxScan = 2000
+
+// getImagePosition answers where one image sits under the same filter+sort the
+// gallery list uses, so a permalink recipient's SPA knows how far to load.
+// position -1 = not within the first imagePositionMaxScan matches, or the
+// current filter excludes the image entirely.
+func (s *Server) getImagePosition(c *gin.Context) {
+	imageID := c.Query("imageId")
+	if imageID == "" {
+		apiError(c, http.StatusBadRequest, "missing_image", "imageId is required")
+		return
+	}
+	pagination, ok := getPagination(c)
+	if !ok {
+		return
+	}
+	params, emptyResult, ok := s.parseImageFilterParams(c)
+	if !ok {
+		return
+	}
+	position := -1
+	if !emptyResult {
+		params.PaginationParameters = pagination
+		var err error
+		position, err = s.Repository.GetImagePosition(c.Request.Context(), params, imageID, imagePositionMaxScan)
+		if abortRepoListError(c, err) {
+			return
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"position": position})
 }
 
 // TagFacetsResponse backs the tag filter popover: facets[tagId] = images the

--- a/ui/src/api/images.ts
+++ b/ui/src/api/images.ts
@@ -57,6 +57,14 @@ export async function tagFacets(params: ImageListParams): Promise<TagFacetsRespo
   return data;
 }
 
+// Zero-based offset of one image under the same filter+sort `list` uses, or -1
+// when the filter excludes it / it sits beyond the server's scan bound — the
+// deep-link resolver decides jump-to-context vs. solo detail on this.
+export async function position(params: ImageListParams & { imageId: string }): Promise<number> {
+  const { data } = await http.get<{ position: number }>("/images/position", { params, paramsSerializer: { indexes: null } });
+  return data.position;
+}
+
 export async function get(id: string): Promise<Image> {
   const { data } = await http.get<Image>(`/images/${id}`);
   return data;

--- a/ui/src/boot/axios.ts
+++ b/ui/src/boot/axios.ts
@@ -9,14 +9,17 @@ export const http: AxiosInstance = axios.create({
   withCredentials: true,
 });
 
-// 401 -> bounce to /login (except while already there, to avoid a redirect loop).
+// 401 -> bounce to /login (except while already there, to avoid a redirect
+// loop), carrying the current page as ?redirect= so a deep link (e.g. a shared
+// image permalink) or an expired mid-session view survives the round trip.
 http.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error?.response?.status === 401) {
       const path = window.location.pathname;
       if (!path.startsWith("/login")) {
-        window.location.assign("/login");
+        const target = path + window.location.search;
+        window.location.assign(target === "/" ? "/login" : `/login?redirect=${encodeURIComponent(target)}`);
       }
     }
     return Promise.reject(error);

--- a/ui/src/components/DetailEditGroup.vue
+++ b/ui/src/components/DetailEditGroup.vue
@@ -122,6 +122,17 @@ const props = withDefaults(defineProps<Props>(), {
 const editData: UnwrapNestedRefs<EditData<T>> = reactive({} as EditData<T>);
 const hasEdits = computed(() => checkEdits());
 
+// Field transforms apply live while typing (e.g. copyright tag normalization);
+// re-triggering the watch with an already-transformed value is a no-op.
+watch(editData, () => {
+  for (const field of props.fields) {
+    const value = editData[field.key];
+    if (!field.transform || typeof value !== "string") continue;
+    const transformed = field.transform(value);
+    if (transformed !== value) editData[field.key] = transformed;
+  }
+});
+
 const emit = defineEmits<{
   editAbort: [];
   editSave: [EditData<T>];
@@ -185,6 +196,7 @@ export type Field<T> = {
   type: FieldType;
   options?: string[];
   hint?: string;
+  transform?: (value: string) => string;
 };
 
 export enum FieldType {

--- a/ui/src/components/image/Sidebar.vue
+++ b/ui/src/components/image/Sidebar.vue
@@ -67,9 +67,12 @@
             delete
           </p>
         </template>
-        <p @click="showAllDetails = !showAllDetails" class="text-sm font-medium text-accent-600 hover:text-accent-500 dark:text-accent-400 underline cursor-pointer">
-          {{ showAllDetails ? "less" : "more" }}
-        </p>
+        <div class="flex gap-4">
+          <p @click="showAllDetails = !showAllDetails" class="text-sm font-medium text-accent-600 hover:text-accent-500 dark:text-accent-400 underline cursor-pointer">
+            {{ showAllDetails ? "less" : "more" }}
+          </p>
+          <p @click="copyPermalink" class="text-sm font-medium text-accent-600 hover:text-accent-500 dark:text-accent-400 underline cursor-pointer">copy link</p>
+        </div>
       </div>
 
       <div class="border-b border-primary-200 dark:border-primary-800 pb-4">
@@ -238,6 +241,8 @@ import { appliedTimeOffset } from "src/util/dateTimeUtil";
 import { canRemoveTagAssignment, removeTagAssignment } from "src/util/imageTags";
 import { groupTagAssignments } from "src/util/tagOrder";
 import { aiPositions, aiQueueTotal } from "src/pages/image/imageQueryLogic";
+import { useRouter } from "vue-router";
+import { copyToClipboard } from "src/util/clipboard";
 
 const userStore = useUserStore();
 
@@ -254,6 +259,16 @@ const props = withDefaults(defineProps<Props>(), {});
 
 // details collapse to name + corrected capture time; "more" reveals the rest
 const showAllDetails = ref(false);
+
+// permalink: the canonical minimal deep link — no filter/sort context, so the
+// recipient's resolver (jumpToImage) decides how to present it
+const router = useRouter();
+function copyPermalink() {
+  if (!props.item) return;
+  const href = router.resolve({ name: "images", query: { image: props.item.id } }).href;
+  copyToClipboard(`${window.location.origin}${href}`);
+  showNotificationToast({ headline: "Link copied", type: "success" });
+}
 
 // Auto-shrink the name to a single line: compare the hidden measurer's width
 // (full name at base 14px) against the row minus the clipboard icon, scale the

--- a/ui/src/components/image/ZoomableImage.vue
+++ b/ui/src/components/image/ZoomableImage.vue
@@ -6,7 +6,7 @@
   <div
     ref="container"
     class="overflow-hidden"
-    :class="[stageActive ? expandClass : 'relative w-fit max-w-full', zoomed ? (panning ? 'cursor-grabbing touch-none' : 'cursor-grab touch-none') : '']"
+    :class="[stageActive ? expandClass : 'relative w-fit max-w-full', zoomed ? (panning ? 'cursor-grabbing touch-none select-none' : 'cursor-grab touch-none select-none') : '']"
     @wheel.prevent="onWheel"
     @dblclick="onDblClick"
     @pointerdown="onPointerDown"

--- a/ui/src/pages/ChangePassword.vue
+++ b/ui/src/pages/ChangePassword.vue
@@ -60,12 +60,14 @@
 </template>
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
+import { sanitizeRedirect } from "src/util/loginRedirect";
 import { useUserStore } from "src/stores/user-store";
 import { showNotificationToast } from "src/boot/mitt";
 import PasswordRequirements from "src/components/PasswordRequirements.vue";
 
 const router = useRouter();
+const route = useRoute();
 const userStore = useUserStore();
 
 const currentPassword = ref("");
@@ -95,7 +97,7 @@ async function submit() {
       newPasswordConfirm: newPasswordConfirm.value,
     });
     showNotificationToast({ headline: "Password changed", type: "success" });
-    router.push("/");
+    router.push(sanitizeRedirect(route.query.redirect));
   } catch (error: any) {
     const code = error.response?.data?.code;
     errorMessage.value = (code && CODE_MESSAGES[code]) || error.response?.data?.message || error.response?.data?.error || "Failed to change password";

--- a/ui/src/pages/Login.vue
+++ b/ui/src/pages/Login.vue
@@ -111,14 +111,20 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useUserStore } from "src/stores/user-store";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
+import { sanitizeRedirect } from "src/util/loginRedirect";
 import * as EmailValidator from "email-validator";
 import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
 import CornerMarks from "src/components/CornerMarks.vue";
 import { ClockIcon, TagIcon, MagnifyingGlassIcon } from "@heroicons/vue/24/outline";
 
 const router = useRouter();
+const route = useRoute();
 const userStore = useUserStore();
+
+// a guard-bounced deep link (e.g. a shared image permalink) rides along as
+// ?redirect= and is honored after authentication
+const redirectTarget = () => sanitizeRedirect(route.query.redirect);
 
 const year = new Date().getFullYear();
 const features = [
@@ -154,7 +160,7 @@ async function devQuickLogin(role: string) {
     const dev = await import("src/api/dev");
     await dev.login({ role });
     await userStore.load();
-    router.push("/"); // router guard redirects to change-password if the seed user still needs it
+    router.push(redirectTarget()); // router guard redirects to change-password if the seed user still needs it
   } catch (error: any) {
     unexpectedErrorHeadline.value = "Dev login failed";
     unexpectedErrorMessage.value = error.response?.data?.message || error.message || "";
@@ -195,10 +201,10 @@ async function login() {
   try {
     const user = await userStore.login(email.value, password.value);
     if (user.forcePasswordChange) {
-      router.push({ name: "change-password" });
+      router.push({ name: "change-password", query: route.query.redirect ? { redirect: redirectTarget() } : {} });
       return;
     }
-    router.push("/");
+    router.push(redirectTarget());
   } catch (error: any) {
     const status = error.response?.status;
     if (status === 400 || status === 401) {

--- a/ui/src/pages/image/Images.vue
+++ b/ui/src/pages/image/Images.vue
@@ -189,7 +189,7 @@ import { faceBoxStyle } from "src/util/aiDetection";
 import { useUserStore } from "src/stores/user-store";
 import * as websocket from "src/util/websocket";
 
-import { DisplayMode, loadImages, triggerInfiniteScroll } from "./imageQueryLogic";
+import { DisplayMode, loadImages, triggerInfiniteScroll, jumpToImage, soloImage } from "./imageQueryLogic";
 import {
   preferredImageSortOrder,
   searchText,
@@ -296,11 +296,27 @@ async function applyRoute(initial = false) {
   }
 
   if (imageId) {
-    const index = images.value.findIndex((image) => image.id === imageId);
+    let index = images.value.findIndex((image) => image.id === imageId);
     if (index === -1) {
-      // deep link beyond the loaded pages (or a deleted image) — stay in the grid
-      displayMode.value = DisplayMode.GRID;
-      return;
+      // permalink beyond the loaded pages, into another project, or dead —
+      // resolve it: jump-to-context, solo detail, or an explanatory toast
+      const jump = await jumpToImage(imageId);
+      if (jump.projectSwitched || jump.status === "solo") {
+        // person/upload context params belonged to the previous view — a
+        // no-op for applyRoute since the matching refs were cleared with them
+        pushQuery((q) => {
+          delete q.person;
+          delete q.personScope;
+          delete q.upload;
+        }, true);
+      }
+      if (jump.status === "unavailable") {
+        displayMode.value = DisplayMode.GRID;
+        pushQuery((q) => delete q.image, true);
+        return;
+      }
+      index = images.value.findIndex((image) => image.id === imageId);
+      if (index === -1) return; // superseded by a newer navigation mid-flight
     }
     imageIndex.value = index;
     if (displayMode.value !== DisplayMode.DETAIL) {
@@ -309,12 +325,19 @@ async function applyRoute(initial = false) {
       imageIndices.value = [];
       displayMode.value = DisplayMode.DETAIL;
     }
-  } else if (displayMode.value !== DisplayMode.GRID) {
-    displayMode.value = DisplayMode.GRID;
-    nextTick(() => {
-      if (imageIndex.value !== -1) scrollToSelectedImage();
-      if (imagesHeader.value) imagesHeader.value.setFilteredTags(filterTags.value, excludeFilterTags.value);
-    });
+  } else {
+    if (soloImage.value) {
+      // leaving a solo detail: the one-image array is no grid — load a real one
+      imageIndex.value = -1;
+      await loadImages(true);
+    }
+    if (displayMode.value !== DisplayMode.GRID) {
+      displayMode.value = DisplayMode.GRID;
+      nextTick(() => {
+        if (imageIndex.value !== -1) scrollToSelectedImage();
+        if (imagesHeader.value) imagesHeader.value.setFilteredTags(filterTags.value, excludeFilterTags.value);
+      });
+    }
   }
 }
 

--- a/ui/src/pages/image/imageQueryLogic.ts
+++ b/ui/src/pages/image/imageQueryLogic.ts
@@ -144,14 +144,36 @@ export async function triggerInfiniteScroll() {
 // dropped and a stale in-flight response is discarded.
 let requestId = 0;
 
+// shared filter/sort state → buildImageListParams input; one source of truth
+// for the list, the facets and the deep-link position queries
+function currentFilterInput() {
+  return {
+    projectId: activeProject.value.id,
+    search: searchText.value,
+    tags: filterTags.value,
+    excludeTags: excludeFilterTags.value,
+    personRef: personFilter.value ?? undefined,
+    crossProject: personCrossProject.value,
+    uploadId: uploadFilter.value ?? undefined,
+    orientation: aspectRatioFilter.value,
+    sortOrder: preferredImageSortOrder.value,
+  };
+}
+
 export async function loadImages(reload: boolean) {
+  // no active project (fresh account following a permalink) — the query is
+  // meaningless and would 400; jumpToImage switches the project first
+  if (!activeProject.value?.id) return;
   // pagination guard only: don't stack "load more" requests, but a reload
   // (new filter/search/sort) must always issue a fresh query.
   if (!reload && loading.value) return;
   const myRequestId = ++requestId;
   loading.value = true;
   try {
-    if (reload) page.value = 1;
+    if (reload) {
+      page.value = 1;
+      soloImage.value = false;
+    }
 
     filtered.value =
       !!searchText.value ||
@@ -162,15 +184,7 @@ export async function loadImages(reload: boolean) {
       !!uploadFilter.value;
 
     const params = buildImageListParams({
-      projectId: activeProject.value.id,
-      search: searchText.value,
-      tags: filterTags.value,
-      excludeTags: excludeFilterTags.value,
-      personRef: personFilter.value ?? undefined,
-      crossProject: personCrossProject.value,
-      uploadId: uploadFilter.value ?? undefined,
-      orientation: aspectRatioFilter.value,
-      sortOrder: preferredImageSortOrder.value,
+      ...currentFilterInput(),
       limit: PAGE_SIZE,
       offset: (page.value - 1) * PAGE_SIZE,
     });
@@ -193,6 +207,101 @@ export async function loadImages(reload: boolean) {
   }
 }
 
+// --- deep link / permalink resolution ------------------------------------------
+// A shared /images?image=<id> URL must open for a recipient whose loaded pages,
+// active project or filters don't contain the image. jumpToImage resolves it:
+// fetch the image (403/404 → toast), switch the active project if the link
+// points into another of the viewer's projects, ask the API where the image
+// sits under the current sort, and extend the loaded window up to it. When the
+// position is unknown (filtered out, or deeper than the server's scan bound)
+// the detail opens solo: the image alone, without grid context.
+// ponytail: solo beyond 2000 — add backward pagination if deep links into old
+// archives ever matter.
+
+const JUMP_CONTEXT_MAX = 2000;
+const LIST_MAX_LIMIT = 500; // server-side limit clamp
+
+// solo = the images array holds only the deep-linked image; leaving the detail
+// view (or any reload) restores a real grid.
+export const soloImage = ref(false);
+
+export type JumpResult = { status: "jumped" | "solo" | "unavailable"; projectSwitched: boolean };
+
+export async function jumpToImage(imageId: string): Promise<JumpResult> {
+  let img: ImageWithTagsType;
+  try {
+    img = await api.images.get(imageId);
+  } catch (error: any) {
+    showNotificationToast({
+      headline: error?.response?.status === 403 ? "You don't have access to this image's project" : "This image no longer exists",
+      type: "warning",
+    });
+    return { status: "unavailable", projectSwitched: false };
+  }
+
+  let projectSwitched = false;
+  if (img.project && img.project.id !== activeProject.value?.id) {
+    // the link points into another of the viewer's projects (non-members got
+    // the 403 above) — switch, dropping filters that belonged to the old one
+    useUserStore().setProject(img.project);
+    personFilter.value = null;
+    personCrossProject.value = false;
+    uploadFilter.value = null;
+    resetTransientFilters();
+    projectSwitched = true;
+    await loadImages(true);
+    if (images.value.some((i) => i.id === imageId)) return { status: "jumped", projectSwitched };
+  }
+
+  let position = -1;
+  try {
+    position = await api.images.position({ ...buildImageListParams(currentFilterInput()), imageId });
+  } catch {
+    // fall through to solo
+  }
+  if (position >= 0 && position < JUMP_CONTEXT_MAX) {
+    await loadImagesUntil(position + 1);
+    if (images.value.some((i) => i.id === imageId)) return { status: "jumped", projectSwitched };
+  }
+
+  images.value = [img];
+  totalImageCount.value = 1;
+  page.value = 1;
+  soloImage.value = true;
+  return { status: "solo", projectSwitched };
+}
+
+// loadImagesUntil extends the loaded window to at least count images (server
+// pages cap at LIST_MAX_LIMIT per request) so a deep-linked image gets its real
+// grid context around it. Leaves the page counter consistent for infinite scroll.
+async function loadImagesUntil(count: number) {
+  const target = Math.min(Math.ceil(count / PAGE_SIZE) * PAGE_SIZE, JUMP_CONTEXT_MAX);
+  if (images.value.length >= target) return;
+  const myRequestId = ++requestId;
+  loading.value = true;
+  try {
+    while (images.value.length < target) {
+      const params = buildImageListParams({
+        ...currentFilterInput(),
+        limit: Math.min(target - images.value.length, LIST_MAX_LIMIT),
+        offset: images.value.length,
+      });
+      const result = await api.images.list(params);
+      if (myRequestId !== requestId) return;
+      totalImageCount.value = result.total;
+      images.value.push(...result.items);
+      if (result.items.length === 0) break;
+    }
+    page.value = Math.floor(images.value.length / PAGE_SIZE) + 1;
+  } catch (error: any) {
+    if (myRequestId !== requestId) return;
+    unexpectedError.value = error;
+    showUnexpectedErrorMessage.value = true;
+  } finally {
+    if (myRequestId === requestId) loading.value = false;
+  }
+}
+
 // --- tag facets ---------------------------------------------------------------
 // Per-tag counts under the CURRENT filter, feeding the tag popover: hide tags
 // that would empty the view, show what each +/− filter would leave. Fetched on
@@ -203,16 +312,7 @@ export const tagFacets = ref<TagFacetsResponse | null>(null);
 let lastFacetsKey = "";
 
 export async function loadTagFacets(force = false) {
-  const params = buildImageListParams({
-    projectId: activeProject.value.id,
-    search: searchText.value,
-    tags: filterTags.value,
-    excludeTags: excludeFilterTags.value,
-    personRef: personFilter.value ?? undefined,
-    crossProject: personCrossProject.value,
-    uploadId: uploadFilter.value ?? undefined,
-    orientation: aspectRatioFilter.value,
-  });
+  const params = buildImageListParams(currentFilterInput());
   const key = JSON.stringify(params);
   if (!force && key === lastFacetsKey && tagFacets.value) return;
   lastFacetsKey = key;

--- a/ui/src/pages/user/UserCreate.vue
+++ b/ui/src/pages/user/UserCreate.vue
@@ -48,12 +48,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive, ref } from "vue";
+import { computed, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { api } from "src/api";
 import PasswordRequirements from "src/components/PasswordRequirements.vue";
 import UnexpectedErrorMessage from "src/components/UnexpectedErrorMessage.vue";
 import { showNotificationToast } from "src/boot/mitt";
+import { normalizeCopyrightTag } from "src/util/copyrightTag";
 
 const router = useRouter();
 
@@ -79,6 +80,14 @@ const textFields: { key: FormKey; label: string; type?: string; autocomplete?: s
   { key: "copyrightTag", label: "Copyright tag" },
   { key: "password", label: "Initial password", type: "password", autocomplete: "new-password" },
 ];
+
+watch(
+  () => form.copyrightTag,
+  (value) => {
+    const normalized = normalizeCopyrightTag(value);
+    if (normalized !== value) form.copyrightTag = normalized;
+  },
+);
 
 const pwReqs = ref<any>(null);
 const errorMessage = ref("");

--- a/ui/src/pages/user/UserGeneral.vue
+++ b/ui/src/pages/user/UserGeneral.vue
@@ -180,6 +180,7 @@ import { UsersResponse } from "src/types/pocketbase";
 import { api } from "src/api";
 import { showNotificationToast } from "src/boot/mitt";
 import { useUserStore } from "src/stores/user-store";
+import { normalizeCopyrightTag } from "src/util/copyrightTag";
 import { CheckCircleIcon, KeyIcon, LockClosedIcon, NoSymbolIcon, ShieldCheckIcon, UserIcon } from "@heroicons/vue/24/outline";
 
 const route = useRoute();
@@ -217,7 +218,7 @@ const informationFields: Field<ITEM_TYPE>[] = [
   { key: "lastName", label: "Last name", type: FieldType.TEXT },
   { key: "username", label: "Username", type: FieldType.TEXT },
   { key: "email", label: "Email", type: FieldType.TEXT },
-  { key: "copyrightTag", label: "Copyright Tag", type: FieldType.TEXT },
+  { key: "copyrightTag", label: "Copyright Tag", type: FieldType.TEXT, transform: normalizeCopyrightTag },
 ];
 
 async function loadItem() {

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -48,14 +48,15 @@ export default route(function (/* { store, ssrContext } */) {
       }
     }
     if (!userStore.isAuthenticated) {
-      return { name: "login" };
+      // carry the target (e.g. a shared image permalink) through the login flow
+      return { name: "login", query: to.fullPath === "/" ? {} : { redirect: to.fullPath } };
     }
     // Enforce password rotation on every navigation, not just post-login
     // (Login.vue). A refresh/deep-link/restored session with forcePasswordChange
     // still set otherwise sails past this guard and 403s every API call the page
     // fires. Mirrors the backend forcePasswordChangeMiddleware.
     if (userStore.user?.forcePasswordChange && toName !== "change-password") {
-      return { name: "change-password" };
+      return { name: "change-password", query: to.fullPath === "/" ? {} : { redirect: to.fullPath } };
     }
   });
 

--- a/ui/src/util/copyrightTag.ts
+++ b/ui/src/util/copyrightTag.ts
@@ -1,0 +1,13 @@
+// The copyright tag ends up in EXIF fields and computed filenames:
+// lowercase, umlauts transliterated (ä→ae, ö→oe, ü→ue, ß→ss), and any run
+// of non-letter/digit/underscore characters (whitespace, dashes, dots, …)
+// collapsed to a single underscore.
+// Mirrored in api/internal/repository/user.go (NormalizeCopyrightTag).
+const UMLAUTS: Record<string, string> = { ä: "ae", ö: "oe", ü: "ue", ß: "ss" };
+
+export function normalizeCopyrightTag(tag: string): string {
+  return tag
+    .toLowerCase()
+    .replace(/[äöüß]/g, (c) => UMLAUTS[c] ?? c)
+    .replace(/[^\p{L}\p{N}_]+/gu, "_");
+}

--- a/ui/src/util/loginRedirect.ts
+++ b/ui/src/util/loginRedirect.ts
@@ -1,7 +1,8 @@
 // Post-login target from the ?redirect= query. Only same-app absolute paths
-// survive — full URLs and protocol-relative "//host" are open-redirect vectors
-// and fall back to the start page.
+// survive — full URLs and protocol-relative "//host" are open-redirect vectors,
+// and /logout would sign the user straight out again; all fall back to the
+// start page.
 export function sanitizeRedirect(value: unknown): string {
-  if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) return "/";
+  if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//") || value.startsWith("/logout")) return "/";
   return value;
 }

--- a/ui/src/util/loginRedirect.ts
+++ b/ui/src/util/loginRedirect.ts
@@ -1,0 +1,7 @@
+// Post-login target from the ?redirect= query. Only same-app absolute paths
+// survive — full URLs and protocol-relative "//host" are open-redirect vectors
+// and fall back to the start page.
+export function sanitizeRedirect(value: unknown): string {
+  if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) return "/";
+  return value;
+}

--- a/ui/tests/axiosInterceptor.spec.ts
+++ b/ui/tests/axiosInterceptor.spec.ts
@@ -9,15 +9,21 @@ function rejectedHandler() {
   return (http.interceptors.response as any).handlers[0].rejected as (e: any) => Promise<any>;
 }
 
-function stubLocation(pathname: string) {
+function stubLocation(pathname: string, search = "") {
   const assign = vi.fn();
-  Object.defineProperty(window, "location", { value: { pathname, assign }, writable: true });
+  Object.defineProperty(window, "location", { value: { pathname, search, assign }, writable: true });
   return assign;
 }
 
 describe("axios 401 interceptor", () => {
-  it("redirects to /login on a 401 when not already on the login page", async () => {
-    const assign = stubLocation("/images");
+  it("redirects to /login with the current page as ?redirect= on a 401", async () => {
+    const assign = stubLocation("/images", "?image=abc");
+    await expect(rejectedHandler()({ response: { status: 401 } })).rejects.toBeDefined();
+    expect(assign).toHaveBeenCalledWith(`/login?redirect=${encodeURIComponent("/images?image=abc")}`);
+  });
+
+  it("redirects to bare /login from the start page", async () => {
+    const assign = stubLocation("/");
     await expect(rejectedHandler()({ response: { status: 401 } })).rejects.toBeDefined();
     expect(assign).toHaveBeenCalledWith("/login");
   });

--- a/ui/tests/copyrightTag.spec.ts
+++ b/ui/tests/copyrightTag.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCopyrightTag } from "src/util/copyrightTag";
+
+describe("normalizeCopyrightTag", () => {
+  it("lowercases and replaces separators with underscores", () => {
+    expect(normalizeCopyrightTag("mm")).toBe("mm");
+    expect(normalizeCopyrightTag("MM")).toBe("mm");
+    expect(normalizeCopyrightTag("Max Mustermann")).toBe("max_mustermann");
+    expect(normalizeCopyrightTag("max-mustermann")).toBe("max_mustermann");
+    expect(normalizeCopyrightTag("max.muster - x")).toBe("max_muster_x");
+    expect(normalizeCopyrightTag("Möller")).toBe("moeller");
+    expect(normalizeCopyrightTag("Äöü ß")).toBe("aeoeue_ss");
+    expect(normalizeCopyrightTag("")).toBe("");
+  });
+});

--- a/ui/tests/e2e/auth.spec.ts
+++ b/ui/tests/e2e/auth.spec.ts
@@ -5,7 +5,9 @@ test.describe("authentication", () => {
   test("unauthenticated access to a protected route redirects to login", async ({ page }) => {
     await page.context().clearCookies();
     await page.goto("/images");
-    await expect(page).toHaveURL(/\/login$/);
+    // the target rides along as ?redirect= and is honored after signing in
+    await expect(page).toHaveURL(/\/login\?redirect=/);
+    expect(new URL(page.url()).searchParams.get("redirect")).toBe("/images");
     await expect(page.getByRole("button", { name: /^Sign in$/ })).toBeVisible();
   });
 

--- a/ui/tests/e2e/permalink.spec.ts
+++ b/ui/tests/e2e/permalink.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, Page } from "@playwright/test";
+import { loginAs, collectJsErrors } from "./helpers";
+
+// Permalinks: a shared /images?image=<id> URL must open the detail view for the
+// recipient (jump-to-context / solo resolution in imageQueryLogic.jumpToImage),
+// degrade with a toast for dead links, and survive the login redirect.
+
+const imageParam = (page: Page) => new URL(page.url()).searchParams.get("image");
+
+async function anyImageId(page: Page, projectId: string): Promise<string> {
+  return page.evaluate(async (pid) => {
+    const r = await fetch(`/api/v1/images?projectId=${pid}&limit=1`, { credentials: "include" });
+    const b = await r.json();
+    return b.items[0].id as string;
+  }, projectId);
+}
+
+test.describe("image permalinks", () => {
+  let errors: string[];
+  test.beforeEach(async ({ page }) => {
+    errors = collectJsErrors(page);
+  });
+  test.afterEach(() => {
+    expect(errors, errors.join("\n")).toHaveLength(0);
+  });
+
+  test("deep link opens the detail view directly", async ({ page }) => {
+    const project = await loginAs(page, "admin");
+    const id = await anyImageId(page, project!.id);
+    await page.goto(`/images?image=${id}`);
+    await expect(page.getByText("Image Tags")).toBeVisible();
+    expect(imageParam(page)).toBe(id);
+  });
+
+  test("copy link puts the canonical permalink on the clipboard", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const project = await loginAs(page, "admin");
+    const id = await anyImageId(page, project!.id);
+    await page.goto(`/images?image=${id}`);
+    await page.getByText("copy link", { exact: true }).click();
+    await expect(page.getByText("Link copied")).toBeVisible();
+    const copied = await page.evaluate(() => navigator.clipboard.readText());
+    expect(copied).toContain(`/images?image=${id}`);
+  });
+
+  test("dead link falls back to the grid with a toast", async ({ page }) => {
+    await loginAs(page, "admin");
+    await page.goto("/images?image=no-such-image");
+    await expect(page.getByText("This image no longer exists")).toBeVisible();
+    await expect.poll(() => imageParam(page)).toBeNull(); // ?image stripped from the URL
+  });
+
+  test("unauthenticated deep link is carried through the login redirect", async ({ page }) => {
+    await page.goto("/images?image=some-id");
+    await expect(page).toHaveURL(/\/login\?redirect=/);
+    expect(new URL(page.url()).searchParams.get("redirect")).toBe("/images?image=some-id");
+  });
+});

--- a/ui/tests/imageNavigationPrefetch.spec.ts
+++ b/ui/tests/imageNavigationPrefetch.spec.ts
@@ -12,7 +12,10 @@ vi.mock("src/api", () => ({
 
 // imageQueryLogic touches the user store at import time, so pinia must be live first
 setActivePinia(createPinia());
-const { images, imageIndex, totalImageCount, nextImage, nextRow } = await import("src/pages/image/imageQueryLogic");
+const { images, imageIndex, totalImageCount, nextImage, nextRow, activeProject } = await import("src/pages/image/imageQueryLogic");
+
+// loadImages refuses to query without an active project (permalink guard)
+activeProject.value = { id: "project-1", name: "Test", uploadReviewEnabled: false };
 
 function fakeImages(count: number, offset = 0): ImageWithTagsType[] {
   return Array.from({ length: count }, (_, i) => ({ id: `img-${offset + i}`, tags: [] }) as unknown as ImageWithTagsType);

--- a/ui/tests/loginRedirect.spec.ts
+++ b/ui/tests/loginRedirect.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeRedirect } from "src/util/loginRedirect";
+
+describe("sanitizeRedirect", () => {
+  it("keeps same-app absolute paths", () => {
+    expect(sanitizeRedirect("/images?image=abc123")).toBe("/images?image=abc123");
+    expect(sanitizeRedirect("/projects")).toBe("/projects");
+  });
+
+  it("rejects everything else", () => {
+    expect(sanitizeRedirect(undefined)).toBe("/");
+    expect(sanitizeRedirect(null)).toBe("/");
+    expect(sanitizeRedirect("")).toBe("/");
+    expect(sanitizeRedirect("https://evil.example/phish")).toBe("/");
+    expect(sanitizeRedirect("//evil.example/phish")).toBe("/");
+    expect(sanitizeRedirect(["/a", "/b"])).toBe("/");
+  });
+});

--- a/ui/tests/loginRedirect.spec.ts
+++ b/ui/tests/loginRedirect.spec.ts
@@ -14,5 +14,6 @@ describe("sanitizeRedirect", () => {
     expect(sanitizeRedirect("https://evil.example/phish")).toBe("/");
     expect(sanitizeRedirect("//evil.example/phish")).toBe("/");
     expect(sanitizeRedirect(["/a", "/b"])).toBe("/");
+    expect(sanitizeRedirect("/logout")).toBe("/"); // would sign the user straight out again
   });
 });


### PR DESCRIPTION
- copy-link action in the detail sidebar; /images?image=<id> now resolves
  for any recipient: GET /api/images/position locates the image under the
  viewer's filter+sort and the SPA loads the grid up to it (solo detail
  fallback beyond the scan bound), switching the active project when the
  link points into another of the viewer's projects
- login and force-password-change guards carry the deep link through
  ?redirect= (sanitized against open redirects)
- copyright tags normalize to lowercase with underscores and umlaut
  transliteration on user create/edit, live in the UI and enforced in the
  repository layer
- zoomed image panning no longer selects surrounding content (select-none)
